### PR TITLE
Fail test run if any warnings present

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+# Fail the test run if we see any warnings
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    if terminalreporter.stats.get("warnings"):  # pragma: no cover
+        print("\nWARNINGS DETECTED: Exiting with error")
+        if terminalreporter._session.exitstatus == 0:
+            terminalreporter._session.exitstatus = 13


### PR DESCRIPTION
Tiny pytest plugin borrowed from ehrQL. This forces us to either deal with or explicitly silence any warnings.