### PR TITLE
Further `justfile` improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
         with:
           python-version: "3.11"
           install-just: true
-      - name: Set default environment variables
-        run: cp dotenv-sample .env
+      - name: Set up development environment
+        run: just devenv
       - name: Check formatting and linting rules
         run: just check
 
@@ -28,8 +28,8 @@ jobs:
         with:
           python-version: "3.11"
           install-just: true
-      - name: Set default environment variables
-        run: cp dotenv-sample .env
+      - name: Set up development environment
+        run: just devenv
       - name: Run tests
         run: |
           just test-all

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -41,11 +41,6 @@ Set up a local development environment with:
 just devenv
 ```
 
-You'll probably find you need to run this twice. The first time it will
-complain that you don't have a `.env` environment file and will create
-one for you. Then you'll need to run the command again with the `.env`
-file in place.
-
 Check that Django is configured correctly with:
 ```
 just manage check

--- a/justfile
+++ b/justfile
@@ -15,25 +15,8 @@ default:
     @{{ just_executable() }} --list
 
 
-# ensure that a '.env` file exists
-ensure-env:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if [[ ! -f .env ]]; then
-      echo "No '.env' file found; creating a default '.env' from 'dotenv-sample'"
-      cp dotenv-sample .env
-      # Unfortunately if the '.env' file didn't exist at the start of the run I
-      # don't see a way to get the variables loaded into the environment; so we
-      # have to fail the task and force the user to run it again. This is
-      # annoying but should only happen once.
-      echo "If you re-attempt the previous command it should now pick up the default environment variables"
-      exit 1
-    fi
-
-
 # ensure valid virtualenv
-virtualenv: ensure-env
+virtualenv:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -64,6 +47,11 @@ pip-compile *args: devenv
 devenv: virtualenv
     #!/usr/bin/env bash
     set -euo pipefail
+
+    if [[ ! -f .env ]]; then
+      echo "No '.env' file found; creating a default '.env' from 'dotenv-sample'"
+      cp dotenv-sample .env
+    fi
 
     for req_file in requirements.dev.txt requirements.prod.txt; do
       # If we've installed this file before and the original hasn't been

--- a/justfile
+++ b/justfile
@@ -25,13 +25,8 @@ virtualenv:
 
     # create venv and upgrade pip
     if [[ ! -d $VIRTUAL_ENV ]]; then
-      # Collapse output when running in Github Actions
-      [[ -v CI ]] && echo "::group::Setting up venv (click to view)" || true
-
       $PYTHON_VERSION -m venv $VIRTUAL_ENV
       $PIP install --upgrade pip
-
-      [[ -v CI ]]  && echo "::endgroup::" || true
     fi
 
 
@@ -68,13 +63,10 @@ devenv: virtualenv
       else
         # Otherwise actually install the requirements
 
-        # Collapse output when running in Github Actions
-        [[ -v CI ]] && echo "::group::Install $req_file (click to view)" || true
         # --no-deps is recommended when using hashes, and also works around a
         # bug with constraints and hashes. See:
         # https://pip.pypa.io/en/stable/topics/secure-installs/#do-not-use-setuptools-directly
         $PIP install --no-deps -r "$req_file"
-        [[ -v CI ]]  && echo "::endgroup::" || true
 
         # Make a record of what we just installed
         cp "$req_file" "$record_file"

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 set dotenv-load := true
+set positional-arguments
 
 
 export VIRTUAL_ENV  := env_var_or_default("VIRTUAL_ENV", ".venv")
@@ -132,17 +133,17 @@ fix: devenv
 
 
 run *ARGS: devenv
-    $BIN/python manage.py runserver {{ ARGS }}
-    
+    $BIN/python manage.py runserver "$@"
+
 
 # run Django's manage.py entrypoint
 manage *ARGS: devenv
-    $BIN/python manage.py {{ ARGS }}
+    $BIN/python manage.py "$@"
 
 
 # run tests
 test *ARGS: devenv
-    $BIN/python -m pytest {{ ARGS }}
+    $BIN/python -m pytest "$@"
 
 
 # run tests as they will be in run CI (checking code coverage etc)


### PR DESCRIPTION
The major change here is to use positional arguments for argument forwarding so that arguments with spaces are now handled correctly e.g

    just test -k 'not functional'

We also slightly tweak the approach to the initial creation of the `.env` file. Rather than always throwing an error on the first run we now assume that `just devenv` will be run as a standalone initial step (both by developers and in CI) and do the necessary set up there without throwing an error.

This allows us to simplify both the Getting Started process and the CI config.