### PR TITLE
Add a very basic file browser app

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -51,6 +51,17 @@ You can run all the tests with:
 just test
 ```
 
+To load some initial data for playing with the app locally use:
+```
+just load-example-data
+```
+
+To start the app use:
+```
+just run
+```
+
+
 ### Running commands without using `just`
 
 `just` automatically takes care of a few things:

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -159,8 +159,10 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 
-ASSETS_DIST = Path(os.environ.get("ASSETS_DIST", BASE_DIR / "assets/dist"))
-STATICFILES_DIRS = [str(ASSETS_DIST)]
+ASSETS_DIST = BASE_DIR / "assets/dist"
+STATICFILES_DIRS = [
+    ASSETS_DIST,
+]
 
 # Serve files from static dirs directly. This removes the need to run collectstatic
 # https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_USE_FINDERS
@@ -169,7 +171,7 @@ WHITENOISE_USE_FINDERS = True
 DJANGO_VITE = {
     "default": {
         # vite assumes collectstatic, so tell it where the manifest is directly
-        "manifest_path": "assets/dist/.vite/manifest.json",
+        "manifest_path": ASSETS_DIST / ".vite/manifest.json",
     },
 }
 

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -180,3 +180,7 @@ DJANGO_VITE = {
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# In production we'd expect AIRLOCK_WORKSPACE_DIR to be an absolute path pointing
+# somewhere outside of WORK_DIR
+WORKSPACE_DIR = WORK_DIR / get_env_var("AIRLOCK_WORKSPACE_DIR")

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -1,0 +1,67 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+{% #article_header title="File Browser" %}
+{% /article_header %}
+
+<div class="flex flex-row">
+
+  <div style="flex-basis: 25%">
+
+    {% #card %}
+      {% #list_group %}
+        {% if not path_item.parent %}
+          {% list_group_empty icon=True title="Workspace Root" %}
+        {% else %}
+          {% #list_group_item href=path_item.parent.url %}
+            ↰ ..
+          {% /list_group_item %}
+          {% for entry in path_item.siblings %}
+            {% #list_group_item href=entry.url %}
+              {{ entry.name}}
+              {% if entry.is_directory %}
+                {% icon_folder_outline class="h-6 w-6 text-slate-600 inline" %}
+              {% endif %}
+            {% /list_group_item %}
+          {% endfor %}
+        {% endif %}
+      {% /list_group %}
+    {% /card %}
+
+  </div>
+
+  <div style="flex-basis: 75%">
+
+    {% if path_item.is_directory %}
+
+      {% #card title=path_item.name %}
+        {% #list_group %}
+          {% if not path_item.children %}
+            {% list_group_empty icon=True title="Empty Directory" %}
+          {% else %}
+            {% for entry in path_item.children %}
+              {% #list_group_item href=entry.url %}
+                {{ entry.name}}
+                {% if entry.is_directory %}
+                  {% icon_folder_outline class="h-6 w-6 text-slate-600 inline" %}
+                {% endif %}
+              {% /list_group_item %}
+            {% endfor %}
+          {% endif %}
+        {% /list_group %}
+      {% /card %}
+
+    {% else %}
+
+      {% #card title=path_item.name %}
+        <pre><code>{{ path_item.contents }}</code></pre>
+      {% /card %}
+
+    {% endif %}
+
+  </div>
+
+</div>
+
+{% endblock content %}

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -17,10 +17,12 @@ Including another URLconf
 from django.urls import path
 
 import airlock.views
-from assets.views import components
+import assets.views
 
 
 urlpatterns = [
     path("", airlock.views.index, name="home"),
-    path("ui-components/", components),
+    path("ui-components/", assets.views.components),
+    path("file-browser/", airlock.views.file_browser, name="file_browser_home"),
+    path("file-browser/<path:path>", airlock.views.file_browser, name="file_browser"),
 ]

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -1,5 +1,24 @@
+from django.http import Http404
+from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+
+from airlock.workspace_api import PathItem
 
 
 def index(request):
     return TemplateResponse(request, "index.html")
+
+
+def file_browser(request, path: str = ""):
+    path_item = PathItem.from_relative_path(path)
+
+    if not path_item.exists():
+        raise Http404()
+
+    is_directory_url = path.endswith("/") or path == ""
+    if path_item.is_directory() != is_directory_url:
+        return redirect(path_item.url())
+
+    return TemplateResponse(
+        request, "file_browser/index.html", {"path_item": path_item}
+    )

--- a/airlock/workspace_api.py
+++ b/airlock/workspace_api.py
@@ -1,0 +1,65 @@
+import dataclasses
+import pathlib
+
+from django.conf import settings
+from django.urls import reverse
+
+
+@dataclasses.dataclass(frozen=True)
+class PathItem:
+    """
+    This provides a thin abstraction over `pathlib.Path` objects with two goals:
+
+        1. Paths should be enforced as being relative to a certain "container" directory
+           and it should not be possible to traverse outside of this directory or to
+           construct one which points outside this directory (using the designated
+           constructor classmethods).
+
+        2. The abstraction should permit us, in future, to switch the implementation to
+           something which is not tied to concrete filesystem paths.
+    """
+
+    relpath: pathlib.Path
+
+    @classmethod
+    def from_relative_path(cls, path: str | pathlib.Path):
+        return cls._from_absolute_path(settings.WORKSPACE_DIR / path)
+
+    @classmethod
+    def _from_absolute_path(cls, path: pathlib.Path):
+        return cls(path.resolve().relative_to(settings.WORKSPACE_DIR))
+
+    def _absolute_path(self):
+        return settings.WORKSPACE_DIR / self.relpath
+
+    def exists(self):
+        return self._absolute_path().exists()
+
+    def is_directory(self):
+        return self._absolute_path().is_dir()
+
+    def name(self):
+        return self.relpath.name
+
+    def url(self):
+        suffix = "/" if self.is_directory() else ""
+        return reverse("file_browser", kwargs={"path": f"{self.relpath}{suffix}"})
+
+    def parent(self):
+        if self.relpath.parents:
+            return PathItem(self.relpath.parent)
+
+    def children(self):
+        return [
+            PathItem._from_absolute_path(child)
+            for child in self._absolute_path().iterdir()
+        ]
+
+    def siblings(self):
+        if not self.relpath.parents:
+            return []
+        else:
+            return self.parent().children()
+
+    def contents(self):
+        return self._absolute_path().read_text()

--- a/assets/views.py
+++ b/assets/views.py
@@ -3,7 +3,7 @@ from datetime import UTC, datetime
 from django.template.response import TemplateResponse
 
 
-def components(request):
+def components(request):  # pragma: no cover
     example_date = datetime.fromtimestamp(1667317153, tz=UTC)
     example_form_email = {
         "auto_id": "id_email",

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -5,3 +5,4 @@ DJANGO_SECRET_KEY="INSECURE-if-you-use-this-in-prod-you-will-have-a-bad-day"
 DJANGO_ALLOWED_HOSTS="*"
 
 AIRLOCK_WORK_DIR=workdir/
+AIRLOCK_WORKSPACE_DIR=workspaces/

--- a/justfile
+++ b/justfile
@@ -137,3 +137,29 @@ test *ARGS: devenv
       --cov=tests \
       --cov-report=html \
       --cov-report=term-missing:skip-covered
+
+
+# load example data so there's something to look at in development
+load-example-data: devenv
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [[ "$DJANGO_DEBUG" != "True" ]]; then
+      echo "DJANGO_DEBUG env var is not set to 'True'."
+      echo "Exiting in case this is a production environment."
+      exit 1
+    fi
+
+    # This is where we'd set up the database, load fixtures etc. if we had any
+
+    # Use a loop to create a bunch of workspace files. In future we'll probably
+    # bundle a more sensible set of example files which we can copy over.
+    workspace="${AIRLOCK_WORK_DIR%/}/${AIRLOCK_WORKSPACE_DIR%/}/example-workspace"
+    for i in {1..2}; do
+      subdir="$workspace/sub_dir_$i"
+      mkdir -p "$subdir"
+      for j in {1..5}; do
+        echo "I am file $i$j" > "$subdir/file_$i$j.txt"
+      done
+    done
+    mkdir -p "$workspace/sub_dir_empty"

--- a/justfile
+++ b/justfile
@@ -133,6 +133,7 @@ test *ARGS: devenv
 
     $BIN/python -m pytest \
       --cov=airlock \
+      --cov=assets \
       --cov=tests \
       --cov-report=html \
       --cov-report=term-missing:skip-covered

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -1,3 +1,50 @@
+import pytest
+
+
 def test_index(client):
     response = client.get("/")
     assert "Hello World" in response.rendered_content
+
+
+@pytest.fixture
+def tmp_workspace(tmp_path, settings):
+    settings.WORKSPACE_DIR = tmp_path
+    return tmp_path
+
+
+def test_file_browser_index(client, tmp_workspace):
+    (tmp_workspace / "file.txt").touch()
+    response = client.get("/file-browser/")
+    assert "file.txt" in response.rendered_content
+
+
+def test_file_browser_with_directory(client, tmp_workspace):
+    (tmp_workspace / "some_dir").mkdir()
+    (tmp_workspace / "some_dir/file.txt").touch()
+    response = client.get("/file-browser/some_dir/")
+    assert "file.txt" in response.rendered_content
+
+
+def test_file_browser_with_file(client, tmp_workspace):
+    (tmp_workspace / "file.txt").write_text("foobar")
+    response = client.get("/file-browser/file.txt")
+    assert "foobar" in response.rendered_content
+
+
+def test_file_browser_with_404(client, tmp_workspace):
+    response = client.get("/file-browser/no_such_file.txt")
+    assert response.status_code == 404
+
+
+def test_file_browser_redirects_to_directory(client, tmp_workspace):
+    (tmp_workspace / "some_dir").mkdir()
+    response = client.get("/file-browser/some_dir")
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/file-browser/some_dir/"
+
+
+def test_file_browser_redirects_to_file(client, tmp_workspace):
+    (tmp_workspace / "file.txt").touch()
+    response = client.get("/file-browser/file.txt/")
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/file-browser/file.txt"

--- a/tests/unit/test_workspace_api.py
+++ b/tests/unit/test_workspace_api.py
@@ -1,0 +1,134 @@
+import pytest
+
+from airlock.workspace_api import PathItem
+
+
+@pytest.fixture(scope="module")
+def tmp_files(tmp_path_factory):
+    tmp_files = tmp_path_factory.mktemp(__name__)
+    (tmp_files / "empty_dir").mkdir()
+    (tmp_files / "some_dir").mkdir()
+    (tmp_files / "some_dir/file_a.txt").write_text("file_a")
+    (tmp_files / "some_dir/file_b.txt").write_text("file_b")
+    return tmp_files
+
+
+@pytest.fixture
+def workspace_files(tmp_files, settings):
+    settings.WORKSPACE_DIR = tmp_files
+
+
+@pytest.mark.parametrize(
+    "path,exists",
+    [
+        ("some_dir", True),
+        ("some_dir/file_a.txt", True),
+        ("not_a_dir", False),
+        ("empty_dir/not_a_file.txt", False),
+    ],
+)
+def test_exists(workspace_files, path, exists):
+    assert PathItem.from_relative_path(path).exists() == exists
+
+
+@pytest.mark.parametrize(
+    "path,is_directory",
+    [
+        ("some_dir", True),
+        ("some_dir/file_a.txt", False),
+    ],
+)
+def test_is_directory(workspace_files, path, is_directory):
+    assert PathItem.from_relative_path(path).is_directory() == is_directory
+
+
+def test_name(workspace_files):
+    assert PathItem.from_relative_path("some_dir/file_a.txt").name() == "file_a.txt"
+
+
+@pytest.mark.parametrize(
+    "path,url",
+    [
+        ("some_dir", "/some_dir/"),
+        ("some_dir/file_a.txt", "/some_dir/file_a.txt"),
+    ],
+)
+def test_url(workspace_files, path, url):
+    assert PathItem.from_relative_path(path).url().endswith(url)
+
+
+@pytest.mark.parametrize(
+    "path,parent_path",
+    [
+        ("", None),
+        ("some_dir", ""),
+        ("some_dir/file_a.txt", "some_dir"),
+    ],
+)
+def test_parent(workspace_files, path, parent_path):
+    parent = PathItem.from_relative_path(path).parent()
+    if parent_path is None:
+        assert parent is None
+    else:
+        assert parent == PathItem.from_relative_path(parent_path)
+
+
+@pytest.mark.parametrize(
+    "path,child_paths",
+    [
+        (
+            "",
+            ["some_dir", "empty_dir"],
+        ),
+        (
+            "empty_dir",
+            [],
+        ),
+        (
+            "some_dir",
+            ["some_dir/file_a.txt", "some_dir/file_b.txt"],
+        ),
+    ],
+)
+def test_children(workspace_files, path, child_paths):
+    children = PathItem.from_relative_path(path).children()
+    assert set(children) == {
+        PathItem.from_relative_path(child) for child in child_paths
+    }
+
+
+@pytest.mark.parametrize(
+    "path,sibling_paths",
+    [
+        ("", []),
+        ("empty_dir", ["empty_dir", "some_dir"]),
+    ],
+)
+def test_siblings(workspace_files, path, sibling_paths):
+    siblings = PathItem.from_relative_path(path).siblings()
+    assert set(siblings) == {
+        PathItem.from_relative_path(sibling) for sibling in sibling_paths
+    }
+
+
+@pytest.mark.parametrize(
+    "path,contents",
+    [
+        ("some_dir/file_a.txt", "file_a"),
+        ("some_dir/file_b.txt", "file_b"),
+    ],
+)
+def test_contents(workspace_files, path, contents):
+    assert PathItem.from_relative_path(path).contents() == contents
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../../relative_path",
+        "/tmp/absolute/path",
+    ],
+)
+def test_from_relative_path_rejects_path_escape(path):
+    with pytest.raises(ValueError, match="is not in the subpath"):
+        PathItem.from_relative_path(path)


### PR DESCRIPTION
Most of this should be pretty obvious. A few high-level notes:

 * You'll see I've used type annotations in a few places, but not consistently. This is a practice we developed in ehrQL where we abandoned the attempt at full type checking (either it wasn't ready for something like ehrQL, or we weren't ready for it), but still found ourselves wanting to mention types in comments where they weren't immediately clear. So we ended up using type annotations as a form of terse, standardised comment. And possibly this will inch us towards a world where we do end up using types for real.

 * My "unit" tests touch the filesystem, which will cause the purists to retch in horror. I'm taking the ehrQL stance that "unit test" just means "fast and focused" and not worrying too much about the precise semantics.

 * I've resorted to inline styles in a couple of places. It turns out that the way Tailwind works is quite different from other CSS frameworks, and the only classes we have defined in our CSS are the ones Job Server happens to use. (Note, this is not dead code elimination: the classes are constructed dynamically when they're referenced so it's not like there's some "full Tailwind" stylesheet we can include.) There's a broader question we'll need to tackle about this, but for now I've added things inline.