### PR TITLE
Add some starting docs on test structure to DEVELOPERS.md

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -79,3 +79,22 @@ activating a virtual environment and running something like:
 ```bash
 set -a; source .env; set +a
 ```
+
+## Testing
+
+### Test categories
+
+Tests are divided into the following categories.
+
+<dl>
+   <dt>unit</dt><dd>fast tests of small code units</dd>
+   <dt>integration</dt><dd>tests of components working together (e.g. views)</dd>
+   <dt>functional</dt><dd>end-to-end [Playwright](https://playwright.dev/docs/intro) tests</dd>
+</dl>
+
+Each category lives in its own directory (for example `tests/unit`) and can be run with
+`just test -k <category>` (for example `just test -k unit`).
+
+Additional arguments passed to `just test` are passed on to pytest. For example, to
+run all the tests _except_ the functional tests, run `just test -k 'not functional'`,
+or to run a single test, run e.g. `just test tests/unit/test_urls.py::test_urls`.


### PR DESCRIPTION
Fixes #11 which says it's about docs for functional tests, but there isn't really much to document yet. This just describes the structure of the tests, along the same lines as we did for ehrQL, with the intention that we keep our developer docs update as we add to the tests and test structure.  Airlock's test might not get to be as complex as ehrQL's, but I found an overview of the test structure a useful thing.