### PR TITLE
Allow users to view and access their own workspaces only

### DIFF
--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -66,7 +66,7 @@ INSTALLED_APPS = [
     "airlock",
     # "django.contrib.auth",
     # "django.contrib.contenttypes",
-    # "django.contrib.sessions",
+    "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -11,8 +11,15 @@
 
     {% #card %}
       {% #list_group %}
-        {% if not path_item.parent %}
-          {% list_group_empty icon=True title="Workspace Root" %}
+        {% if not path_item %}
+          {% list_group_empty icon=True title="Workspace Root" %}   
+        
+        {% elif not path_item.parent %}
+          {% list_group_empty title=path_item.container.name %}   
+          {% #list_group_item href=path_item.container.index_url %}
+            ↰ ..
+          {% /list_group_item %}
+
         {% else %}
           {% #list_group_item href=path_item.parent.url %}
             ↰ ..
@@ -32,8 +39,20 @@
   </div>
 
   <div style="flex-basis: 75%">
+    {% if not path_item %}
 
-    {% if path_item.is_directory %}
+      {% #card title="/" %}
+        {% #list_group %}
+            {% for workspace in container.workspaces %}
+              {% #list_group_item href=workspace.url %}
+                {{ workspace.name}}
+                {% icon_folder_outline class="h-6 w-6 text-slate-600 inline" %}
+              {% /list_group_item %}
+            {% endfor %}
+        {% /list_group %}
+      {% /card %}
+
+    {% elif path_item.is_directory %}
 
       {% #card title=path_item.name %}
         {% #list_group %}

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -24,13 +24,18 @@ urlpatterns = [
     path("", airlock.views.index, name="home"),
     path("ui-components/", assets.views.components),
     path(
-        "workspace/<str:workspace_name>/",
+        "workspaces/<str:workspace_name>/",
         airlock.views.workspace_view,
         name="workspace_home",
     ),
     path(
-        "workspace/<str:workspace_name>/<path:path>",
+        "workspaces/<str:workspace_name>/<path:path>",
         airlock.views.workspace_view,
         name="workspace_view",
+    ),
+    path(
+        "workspaces/",
+        airlock.views.workspace_index_view,
+        name="workspace_index",
     ),
 ]

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -22,3 +22,9 @@ class User:
         workspaces = tuple(user.get("workspaces", tuple()))
         is_output_checker = user.get("is_output_checker", False)
         return cls(user["id"], workspaces, is_output_checker)
+
+    def has_permission(self, workspace_name):
+        return (
+            # Output checkers can view all workspaces
+            self.is_output_checker or workspace_name in self.workspaces
+        )

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -1,0 +1,24 @@
+import dataclasses
+from typing import Tuple
+
+
+@dataclasses.dataclass(frozen=True)
+class User:
+    """
+    A datastructure to manage users.
+    Information about a user is stored on the session. This
+    is a convenience for passing that information around.
+    """
+
+    id: int
+    workspaces: Tuple = dataclasses.field(default_factory=tuple)
+    is_output_checker: bool = dataclasses.field(default=False)
+
+    @classmethod
+    def from_session(cls, session_data):
+        user = session_data.get("user")
+        if user is None:
+            return
+        workspaces = tuple(user.get("workspaces", tuple()))
+        is_output_checker = user.get("is_output_checker", False)
+        return cls(user["id"], workspaces, is_output_checker)

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -1,7 +1,9 @@
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 
+from airlock.users import User
 from airlock.workspace_api import Workspace
 
 
@@ -10,10 +12,12 @@ def index(request):
 
 
 def workspace_view(request, workspace_name: str, path: str = ""):
+    user = User.from_session(request.session)
     workspace = Workspace(workspace_name)
-    # TODO workspace authorization
     if not workspace.exists():
         raise Http404()
+    if not workspace.has_permission(user):
+        raise PermissionDenied()
 
     path_item = workspace.get_path(path)
 

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -4,11 +4,22 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 
 from airlock.users import User
-from airlock.workspace_api import Workspace
+from airlock.workspace_api import Workspace, WorkspacesRoot
 
 
 def index(request):
     return TemplateResponse(request, "index.html")
+
+
+def workspace_index_view(request):
+    user = User.from_session(request.session)
+    return TemplateResponse(
+        request,
+        "file_browser/index.html",
+        {
+            "container": WorkspacesRoot(user=user),
+        },
+    )
 
 
 def workspace_view(request, workspace_name: str, path: str = ""):

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -27,7 +27,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     workspace = Workspace(workspace_name)
     if not workspace.exists():
         raise Http404()
-    if not workspace.has_permission(user):
+    if user is None or not user.has_permission(workspace_name):
         raise PermissionDenied()
 
     path_item = workspace.get_path(path)

--- a/airlock/workspace_api.py
+++ b/airlock/workspace_api.py
@@ -25,6 +25,24 @@ class Container:
 
 
 @dataclasses.dataclass(frozen=True)
+class WorkspacesRoot(Container):
+    """This container represents settings.WORKSPACE_DIR"""
+
+    user: User
+
+    def root(self):
+        return settings.WORKSPACE_DIR
+
+    @property
+    def workspaces(self):
+        for child in self.get_path("").children():
+            if child.is_directory():
+                workspace = Workspace(child.name())
+                if workspace.has_permission(self.user):
+                    yield workspace
+
+
+@dataclasses.dataclass(frozen=True)
 class Workspace(Container):
     """These are containers that must live under the settings.WORKSPACE_DIR"""
 
@@ -38,6 +56,12 @@ class Workspace(Container):
 
     def root(self):
         return settings.WORKSPACE_DIR / self.name
+
+    def index_url(self):
+        return reverse("workspace_index")
+
+    def url(self):
+        return reverse("workspace_home", kwargs={"workspace_name": self.name})
 
     def get_url(self, relpath):
         return reverse(

--- a/airlock/workspace_api.py
+++ b/airlock/workspace_api.py
@@ -35,11 +35,11 @@ class WorkspacesRoot(Container):
 
     @property
     def workspaces(self):
+        if self.user is None:
+            return []
         for child in self.get_path("").children():
-            if child.is_directory():
-                workspace = Workspace(child.name())
-                if workspace.has_permission(self.user):
-                    yield workspace
+            if child.is_directory() and self.user.has_permission(child.name()):
+                yield Workspace(child.name())
 
 
 @dataclasses.dataclass(frozen=True)
@@ -47,12 +47,6 @@ class Workspace(Container):
     """These are containers that must live under the settings.WORKSPACE_DIR"""
 
     name: str
-
-    def has_permission(self, user: User = None):
-        return user is not None and (
-            # Output checkers can view all workspaces
-            user.is_output_checker or self.name in user.workspaces
-        )
 
     def root(self):
         return settings.WORKSPACE_DIR / self.name

--- a/airlock/workspace_api.py
+++ b/airlock/workspace_api.py
@@ -4,6 +4,8 @@ import pathlib
 from django.conf import settings
 from django.urls import reverse
 
+from airlock.users import User
+
 
 class Container:
     def root(self):
@@ -24,9 +26,15 @@ class Container:
 
 @dataclasses.dataclass(frozen=True)
 class Workspace(Container):
-    """These are container that must live under the settings.WORKSPACE_DIR"""
+    """These are containers that must live under the settings.WORKSPACE_DIR"""
 
     name: str
+
+    def has_permission(self, user: User = None):
+        return user is not None and (
+            # Output checkers can view all workspaces
+            user.is_output_checker or self.name in user.workspaces
+        )
 
     def root(self):
         return settings.WORKSPACE_DIR / self.name

--- a/justfile
+++ b/justfile
@@ -162,15 +162,17 @@ load-example-data: devenv
     # bundle a more sensible set of example files which we can copy over.
     workspace="${AIRLOCK_WORK_DIR%/}/${AIRLOCK_WORKSPACE_DIR%/}/example-workspace"
     for i in {1..2}; do
-      subdir="$workspace/sub_dir_$i"
-      mkdir -p "$subdir"
-      for j in {1..5}; do
-        echo "I am file $i$j" > "$subdir/file_$i$j.txt"
+      workspace_dir="${workspace}_$i"
+      for j in {1..2}; do
+        subdir="$workspace_dir/sub_dir_$j"
+        mkdir -p "$subdir"
+        for k in {1..5}; do
+          echo "I am file $j$k" > "$subdir/file_$j$k.txt"
+        done
       done
+      mkdir -p "$workspace_dir/sub_dir_empty"
+      tmp=$(mktemp)
+      # grab published database outputs for example csv and html data
+      curl -s https://jobs.opensafely.org/opensafely-internal/tpp-database-schema/outputs/85/download/ --output "$tmp"
+      unzip "$tmp" -d "$workspace"
     done
-    mkdir -p "$workspace/sub_dir_empty"
-
-    tmp=$(mktemp)
-    # grab published database outputs for example csv and html data
-    curl -s https://jobs.opensafely.org/opensafely-internal/tpp-database-schema/outputs/85/download/ --output "$tmp"
-    unzip "$tmp" -d "$workspace"

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -1,9 +1,29 @@
 import pytest
 
 
+pytestmark = pytest.mark.django_db
+
+
 def test_index(client):
     response = client.get("/")
     assert "Hello World" in response.rendered_content
+
+
+@pytest.fixture
+def client_with_user(client):
+    def _client(session_user=None):
+        session = client.session
+        session["user"] = session_user
+        session.save()
+        return client
+
+    return _client
+
+
+@pytest.fixture
+def client_with_permission(client_with_user):
+    output_checker = {"id": 1, "is_output_checker": True}
+    yield client_with_user(output_checker)
 
 
 workspace_name = "test"
@@ -17,44 +37,70 @@ def tmp_workspace(tmp_path, settings):
     return workspace_dir
 
 
-def test_workspace_view_index(client, tmp_workspace):
+def test_workspace_view_index(client_with_permission, tmp_workspace):
     (tmp_workspace / "file.txt").touch()
-    response = client.get(f"/workspace/{workspace_name}/")
+    response = client_with_permission.get(f"/workspace/{workspace_name}/")
     assert "file.txt" in response.rendered_content
 
 
-def test_workspace_does_not_exist(client):
-    response = client.get("/workspace/bad/")
+def test_workspace_does_not_exist(client_with_permission):
+    response = client_with_permission.get("/workspace/bad/")
     assert response.status_code == 404
 
 
-def test_workspace_view_with_directory(client, tmp_workspace):
+def test_workspace_view_with_directory(client_with_permission, tmp_workspace):
     (tmp_workspace / "some_dir").mkdir()
     (tmp_workspace / "some_dir/file.txt").touch()
-    response = client.get(f"/workspace/{workspace_name}/some_dir/")
+    response = client_with_permission.get(f"/workspace/{workspace_name}/some_dir/")
     assert "file.txt" in response.rendered_content
 
 
-def test_workspace_view_with_file(client, tmp_workspace):
+def test_workspace_view_with_file(client_with_permission, tmp_workspace):
     (tmp_workspace / "file.txt").write_text("foobar")
-    response = client.get(f"/workspace/{workspace_name}/file.txt")
+    response = client_with_permission.get(f"/workspace/{workspace_name}/file.txt")
     assert "foobar" in response.rendered_content
 
 
-def test_workspace_view_with_404(client, tmp_workspace):
-    response = client.get(f"/workspace/{workspace_name}/no_such_file.txt")
+def test_workspace_view_with_404(client_with_permission, tmp_workspace):
+    response = client_with_permission.get(
+        f"/workspace/{workspace_name}/no_such_file.txt"
+    )
     assert response.status_code == 404
 
 
-def test_workspace_view_redirects_to_directory(client, tmp_workspace):
+def test_workspace_view_redirects_to_directory(client_with_permission, tmp_workspace):
     (tmp_workspace / "some_dir").mkdir()
-    response = client.get(f"/workspace/{workspace_name}/some_dir")
+    response = client_with_permission.get(f"/workspace/{workspace_name}/some_dir")
     assert response.status_code == 302
     assert response.headers["Location"] == f"/workspace/{workspace_name}/some_dir/"
 
 
-def test_workspace_view_redirects_to_file(client, tmp_workspace):
+def test_workspace_view_redirects_to_file(client_with_permission, tmp_workspace):
     (tmp_workspace / "file.txt").touch()
-    response = client.get(f"/workspace/{workspace_name}/file.txt/")
+    response = client_with_permission.get(f"/workspace/{workspace_name}/file.txt/")
     assert response.status_code == 302
     assert response.headers["Location"] == f"/workspace/{workspace_name}/file.txt"
+
+
+def test_workspace_view_index_no_user(client, tmp_workspace):
+    response = client.get(f"/workspace/{workspace_name}/")
+    assert response.status_code == 403
+
+
+def test_workspace_view_with_directory_no_user(client, tmp_workspace):
+    (tmp_workspace / "some_dir").mkdir()
+    response = client.get(f"/workspace/{workspace_name}/some_dir/")
+    assert response.status_code == 403
+
+
+def test_workspace_view_index_no_permission(client_with_user, tmp_workspace):
+    forbidden_client = client_with_user({"id": 1, "workspaces": ["another-workspace"]})
+    response = forbidden_client.get(f"/workspace/{workspace_name}/")
+    assert response.status_code == 403
+
+
+def test_workspace_view_with_directory_no_permission(client_with_user, tmp_workspace):
+    (tmp_workspace / "some_dir").mkdir()
+    forbidden_client = client_with_user({"id": 1, "workspaces": ["another-workspace"]})
+    response = forbidden_client.get(f"/workspace/{workspace_name}/some_dir/")
+    assert response.status_code == 403

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -39,68 +39,68 @@ def tmp_workspace(tmp_path, settings):
 
 def test_workspace_view_index(client_with_permission, tmp_workspace):
     (tmp_workspace / "file.txt").touch()
-    response = client_with_permission.get(f"/workspace/{workspace_name}/")
+    response = client_with_permission.get(f"/workspaces/{workspace_name}/")
     assert "file.txt" in response.rendered_content
 
 
 def test_workspace_does_not_exist(client_with_permission):
-    response = client_with_permission.get("/workspace/bad/")
+    response = client_with_permission.get("/workspaces/bad/")
     assert response.status_code == 404
 
 
 def test_workspace_view_with_directory(client_with_permission, tmp_workspace):
     (tmp_workspace / "some_dir").mkdir()
     (tmp_workspace / "some_dir/file.txt").touch()
-    response = client_with_permission.get(f"/workspace/{workspace_name}/some_dir/")
+    response = client_with_permission.get(f"/workspaces/{workspace_name}/some_dir/")
     assert "file.txt" in response.rendered_content
 
 
 def test_workspace_view_with_file(client_with_permission, tmp_workspace):
     (tmp_workspace / "file.txt").write_text("foobar")
-    response = client_with_permission.get(f"/workspace/{workspace_name}/file.txt")
+    response = client_with_permission.get(f"/workspaces/{workspace_name}/file.txt")
     assert "foobar" in response.rendered_content
 
 
 def test_workspace_view_with_404(client_with_permission, tmp_workspace):
     response = client_with_permission.get(
-        f"/workspace/{workspace_name}/no_such_file.txt"
+        f"/workspaces/{workspace_name}/no_such_file.txt"
     )
     assert response.status_code == 404
 
 
 def test_workspace_view_redirects_to_directory(client_with_permission, tmp_workspace):
     (tmp_workspace / "some_dir").mkdir()
-    response = client_with_permission.get(f"/workspace/{workspace_name}/some_dir")
+    response = client_with_permission.get(f"/workspaces/{workspace_name}/some_dir")
     assert response.status_code == 302
-    assert response.headers["Location"] == f"/workspace/{workspace_name}/some_dir/"
+    assert response.headers["Location"] == f"/workspaces/{workspace_name}/some_dir/"
 
 
 def test_workspace_view_redirects_to_file(client_with_permission, tmp_workspace):
     (tmp_workspace / "file.txt").touch()
-    response = client_with_permission.get(f"/workspace/{workspace_name}/file.txt/")
+    response = client_with_permission.get(f"/workspaces/{workspace_name}/file.txt/")
     assert response.status_code == 302
-    assert response.headers["Location"] == f"/workspace/{workspace_name}/file.txt"
+    assert response.headers["Location"] == f"/workspaces/{workspace_name}/file.txt"
 
 
 def test_workspace_view_index_no_user(client, tmp_workspace):
-    response = client.get(f"/workspace/{workspace_name}/")
+    response = client.get(f"/workspaces/{workspace_name}/")
     assert response.status_code == 403
 
 
 def test_workspace_view_with_directory_no_user(client, tmp_workspace):
     (tmp_workspace / "some_dir").mkdir()
-    response = client.get(f"/workspace/{workspace_name}/some_dir/")
+    response = client.get(f"/workspaces/{workspace_name}/some_dir/")
     assert response.status_code == 403
 
 
 def test_workspace_view_index_no_permission(client_with_user, tmp_workspace):
     forbidden_client = client_with_user({"id": 1, "workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspace/{workspace_name}/")
+    response = forbidden_client.get(f"/workspaces/{workspace_name}/")
     assert response.status_code == 403
 
 
 def test_workspace_view_with_directory_no_permission(client_with_user, tmp_workspace):
     (tmp_workspace / "some_dir").mkdir()
     forbidden_client = client_with_user({"id": 1, "workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspace/{workspace_name}/some_dir/")
+    response = forbidden_client.get(f"/workspaces/{workspace_name}/some_dir/")
     assert response.status_code == 403

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1,0 +1,27 @@
+from airlock.users import User
+
+
+def test_session_user_from_session():
+    mock_session = {
+        "user": {
+            "id": 1,
+            "workspaces": ["test-workspace-1", "test_workspace2"],
+            "is_output_checker": True,
+        }
+    }
+    user = User.from_session(mock_session)
+    assert user.workspaces == ("test-workspace-1", "test_workspace2")
+    assert user.is_output_checker
+
+
+def test_session_user_with_defaults():
+    mock_session = {"user": {"id": 1}}
+    user = User.from_session(mock_session)
+    assert user.workspaces == ()
+    assert not user.is_output_checker
+
+
+def test_session_user_no_user_set():
+    mock_session = {}
+    user = User.from_session(mock_session)
+    assert user is None

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1,3 +1,5 @@
+import pytest
+
 from airlock.users import User
 
 
@@ -25,3 +27,24 @@ def test_session_user_no_user_set():
     mock_session = {}
     user = User.from_session(mock_session)
     assert user is None
+
+
+@pytest.mark.parametrize(
+    "is_output_checker,workspaces,has_permission",
+    [
+        (True, [], True),
+        (True, ["other", "other1"], True),
+        (False, ["test", "other", "other1"], True),
+        (False, ["other", "other1"], False),
+    ],
+)
+def test_session_user_has_permission(is_output_checker, workspaces, has_permission):
+    mock_session = {
+        "user": {
+            "id": 1,
+            "workspaces": workspaces,
+            "is_output_checker": is_output_checker,
+        }
+    }
+    user = User.from_session(mock_session)
+    assert user.has_permission("test") == has_permission


### PR DESCRIPTION
Fixes #21 and #22 

This limits the workspaces shown to only those available to that user, unless the user is an output checker, in which case they can see everything.

The file-browser view currently checks the path it's given, and redirects to the root workspace if the user doesn't have permission for it. All users, including non-logged in users, have access to the root workspace, although it won't show any files to non-logged in users. We probably to redirect non-logged in users to a login view when one is available.

Each child/sibling directory and file checks to ensure user has permission.

Note this makes some assumption about what the user info in the session looks like, so it might need some reworking based on #19. 