### PR TITLE
Refactor PathItem to have plugable root directory.

### DIFF
--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -23,6 +23,14 @@ import assets.views
 urlpatterns = [
     path("", airlock.views.index, name="home"),
     path("ui-components/", assets.views.components),
-    path("file-browser/", airlock.views.file_browser, name="file_browser_home"),
-    path("file-browser/<path:path>", airlock.views.file_browser, name="file_browser"),
+    path(
+        "workspace/<str:workspace_name>/",
+        airlock.views.workspace_view,
+        name="workspace_home",
+    ),
+    path(
+        "workspace/<str:workspace_name>/<path:path>",
+        airlock.views.workspace_view,
+        name="workspace_view",
+    ),
 ]

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -2,15 +2,20 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 
-from airlock.workspace_api import PathItem
+from airlock.workspace_api import Workspace
 
 
 def index(request):
     return TemplateResponse(request, "index.html")
 
 
-def file_browser(request, path: str = ""):
-    path_item = PathItem.from_relative_path(path)
+def workspace_view(request, workspace_name: str, path: str = ""):
+    workspace = Workspace(workspace_name)
+    # TODO workspace authorization
+    if not workspace.exists():
+        raise Http404()
+
+    path_item = workspace.get_path(path)
 
     if not path_item.exists():
         raise Http404()
@@ -20,5 +25,10 @@ def file_browser(request, path: str = ""):
         return redirect(path_item.url())
 
     return TemplateResponse(
-        request, "file_browser/index.html", {"path_item": path_item}
+        request,
+        "file_browser/index.html",
+        {
+            "container": workspace,
+            "path_item": path_item,
+        },
     )

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -6,45 +6,55 @@ def test_index(client):
     assert "Hello World" in response.rendered_content
 
 
+workspace_name = "test"
+
+
 @pytest.fixture
 def tmp_workspace(tmp_path, settings):
     settings.WORKSPACE_DIR = tmp_path
-    return tmp_path
+    workspace_dir = tmp_path / workspace_name
+    workspace_dir.mkdir()
+    return workspace_dir
 
 
-def test_file_browser_index(client, tmp_workspace):
+def test_workspace_view_index(client, tmp_workspace):
     (tmp_workspace / "file.txt").touch()
-    response = client.get("/file-browser/")
+    response = client.get(f"/workspace/{workspace_name}/")
     assert "file.txt" in response.rendered_content
 
 
-def test_file_browser_with_directory(client, tmp_workspace):
-    (tmp_workspace / "some_dir").mkdir()
-    (tmp_workspace / "some_dir/file.txt").touch()
-    response = client.get("/file-browser/some_dir/")
-    assert "file.txt" in response.rendered_content
-
-
-def test_file_browser_with_file(client, tmp_workspace):
-    (tmp_workspace / "file.txt").write_text("foobar")
-    response = client.get("/file-browser/file.txt")
-    assert "foobar" in response.rendered_content
-
-
-def test_file_browser_with_404(client, tmp_workspace):
-    response = client.get("/file-browser/no_such_file.txt")
+def test_workspace_does_not_exist(client):
+    response = client.get("/workspace/bad/")
     assert response.status_code == 404
 
 
-def test_file_browser_redirects_to_directory(client, tmp_workspace):
+def test_workspace_view_with_directory(client, tmp_workspace):
     (tmp_workspace / "some_dir").mkdir()
-    response = client.get("/file-browser/some_dir")
+    (tmp_workspace / "some_dir/file.txt").touch()
+    response = client.get(f"/workspace/{workspace_name}/some_dir/")
+    assert "file.txt" in response.rendered_content
+
+
+def test_workspace_view_with_file(client, tmp_workspace):
+    (tmp_workspace / "file.txt").write_text("foobar")
+    response = client.get(f"/workspace/{workspace_name}/file.txt")
+    assert "foobar" in response.rendered_content
+
+
+def test_workspace_view_with_404(client, tmp_workspace):
+    response = client.get(f"/workspace/{workspace_name}/no_such_file.txt")
+    assert response.status_code == 404
+
+
+def test_workspace_view_redirects_to_directory(client, tmp_workspace):
+    (tmp_workspace / "some_dir").mkdir()
+    response = client.get(f"/workspace/{workspace_name}/some_dir")
     assert response.status_code == 302
-    assert response.headers["Location"] == "/file-browser/some_dir/"
+    assert response.headers["Location"] == f"/workspace/{workspace_name}/some_dir/"
 
 
-def test_file_browser_redirects_to_file(client, tmp_workspace):
+def test_workspace_view_redirects_to_file(client, tmp_workspace):
     (tmp_workspace / "file.txt").touch()
-    response = client.get("/file-browser/file.txt/")
+    response = client.get(f"/workspace/{workspace_name}/file.txt/")
     assert response.status_code == 302
-    assert response.headers["Location"] == "/file-browser/file.txt"
+    assert response.headers["Location"] == f"/workspace/{workspace_name}/file.txt"


### PR DESCRIPTION
This way, it can be used for viewing both workspaces and output
requests. A PathItem now takes a reference to container object, which
must have a root path, and a way to generate urls.

Added a top level Workspace object, as the first implementation of such
a Container, will add one for an OutputRequest later.

A workspace is now explict, rather than embedded in that path. As such,
I took the opportunity to explicitly add it as url parameter. The
PathItem.relpath is now always relative to the workspace directory, not
WORKSPACE_DIR.

In anticipation of adding a request file browser view, I renamed the
urls/views to be "workspace".
