### PR TITLE
Add a logout view

### DIFF
--- a/airlock/middleware.py
+++ b/airlock/middleware.py
@@ -1,0 +1,12 @@
+from airlock.users import User
+
+
+def user_middleware(get_response):
+    """Add the session user to the request"""
+
+    def middleware(request):
+        request.user = User.from_session(request.session)
+        response = get_response(request)
+        return response
+
+    return middleware

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -86,6 +86,7 @@ MIDDLEWARE = [
     # "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "airlock.middleware.user_middleware",
 ]
 
 ROOT_URLCONF = "airlock.urls"

--- a/airlock/templates/base.html
+++ b/airlock/templates/base.html
@@ -43,13 +43,15 @@
         <nav class="relative container xl:max-w-screen-xl flex justify-center items-center flex-wrap py-3 gap-y-2">
             <p class="relative z-30 flex-shrink-0 flex items-center mr-4 text-xl font-extrabold tracking-tight leading-none text-stone-700">
             {% url 'home' as url %}
+            {% url 'login' as login_url %}
+            {% url 'logout' as logout_url %}
             <a
                 class="
                 group relative p-2 -ml-2 bg-transparent rounded overflow-hidden focus:text-bn-strawberry-600 focus:outline-none focus:ring-2 focus:ring-oxford-500
                 after:absolute after:bottom-1 after:h-[2px] after:left-2 after:bg-bn-strawberry-300 after:w-1 after:transition-all after:opacity-0
                 after:hover:w-11/12 after:hover:opacity-100
                 "
-                href="{% url 'home' %}"
+                href="{{ url }}"
             >
                 <span class="transition-colors ease-in duration-150 text-oxford group-hover:text-bn-strawberry-700 group-focus:text-bn-strawberry-700">
                 OpenSAFELY
@@ -79,7 +81,7 @@
                 </a>
             </li>
             {% endfor %}
-            {% if not user.is_authenticated %}
+            {% if not request.user.is_authenticated %}
             <li>
                 <a
                 class="
@@ -123,6 +125,19 @@
                 </details>
                 </details-utils>
             </li>
+            <li>
+              <a
+              class="
+                  relative inline-flex self-start p-2 rounded whitespace-nowrap text-oxford duration-200 bg-bn-strawberry-200 border border-bn-strawberry-300 px-4 mx-0 leading-none transition-all
+                  hover:text-bn-strawberry-700 hover:bg-bn-strawberry-100 hover:border-bn-strawberry-400 hover:shadow-lg
+                  focus:bg-bn-strawberry-100 focus:text-bn-strawberry-700 focus:border-bn-strawberry-400 focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-oxford-500
+              "
+              href="{{ logout_url }}"
+              rel="nofollow"
+              >
+              Logout
+              </a>
+          </li>
             {% endif %}
             </ul>
         </nav>

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -23,6 +23,7 @@ import assets.views
 urlpatterns = [
     path("", airlock.views.index, name="home"),
     path("login/", airlock.views.login, name="login"),
+    path("logout/", airlock.views.logout, name="logout"),
     path("ui-components/", assets.views.components),
     path(
         "workspaces/<str:workspace_name>/",

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -22,6 +22,7 @@ import assets.views
 
 urlpatterns = [
     path("", airlock.views.index, name="home"),
+    path("login/", airlock.views.login, name="login"),
     path("ui-components/", assets.views.components),
     path(
         "workspaces/<str:workspace_name>/",

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -11,6 +11,7 @@ class User:
     """
 
     id: int
+    username: str
     workspaces: Tuple = dataclasses.field(default_factory=tuple)
     is_output_checker: bool = dataclasses.field(default=False)
 
@@ -21,10 +22,13 @@ class User:
             return
         workspaces = tuple(user.get("workspaces", tuple()))
         is_output_checker = user.get("is_output_checker", False)
-        return cls(user["id"], workspaces, is_output_checker)
+        return cls(user["id"], user["username"], workspaces, is_output_checker)
 
     def has_permission(self, workspace_name):
         return (
             # Output checkers can view all workspaces
             self.is_output_checker or workspace_name in self.workspaces
         )
+
+    def is_authenticated(self):
+        return True

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -3,7 +3,6 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 
-from airlock.users import User
 from airlock.workspace_api import ReleaseRequest, Workspace, WorkspacesRoot
 
 
@@ -13,10 +12,9 @@ def index(request):
 
 def validate_user(request):
     """Ensure we have a valid user."""
-    user = User.from_session(request.session)
-    if user is None:
+    if request.user is None:
         raise PermissionDenied()
-    return user
+    return request.user
 
 
 def validate_workspace(user, workspace_name):

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -6,6 +6,19 @@ from django.template.response import TemplateResponse
 from airlock.workspace_api import ReleaseRequest, Workspace, WorkspacesRoot
 
 
+def login(request):
+    """
+    Temporary login view that pretends the current user is an
+    output-checker
+    """
+    request.session["user"] = {
+        "id": 1,
+        "username": "temp_output_checker",
+        "is_output_checker": True,
+    }
+    return redirect("workspace_index")
+
+
 def index(request):
     return TemplateResponse(request, "index.html")
 

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -2,6 +2,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse
 
 from airlock.workspace_api import ReleaseRequest, Workspace, WorkspacesRoot
 
@@ -16,7 +17,16 @@ def login(request):
         "username": "temp_output_checker",
         "is_output_checker": True,
     }
-    return redirect("workspace_index")
+    return redirect(reverse("workspace_index"))
+
+
+def logout(request):
+    """
+    User information is held in the session. On logout, remove
+    session data and redirect to the home page.
+    """
+    request.session.flush()
+    return redirect(reverse("home"))
 
 
 def index(request):

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_login(client):
+    assert "user" not in client.session
+    response = client.get("/login/")
+    assert client.session["user"]["username"] == "temp_output_checker"
+    assert response.url == "/workspaces/"

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -9,3 +9,14 @@ def test_login(client):
     response = client.get("/login/")
     assert client.session["user"]["username"] == "temp_output_checker"
     assert response.url == "/workspaces/"
+
+
+def test_logout(client):
+    session_user = {"id": 1, "username": "test"}
+    session = client.session
+    session["user"] = session_user
+    session.save()
+
+    response = client.get("/logout/")
+    assert response.url == "/"
+    assert "user" not in client.session

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -14,7 +14,8 @@ def test_index(client):
 
 @pytest.fixture
 def client_with_user(client):
-    def _client(session_user=None):
+    def _client(session_user):
+        session_user = {"id": 1, "username": "test", **session_user}
         session = client.session
         session["user"] = session_user
         session.save()
@@ -25,7 +26,7 @@ def client_with_user(client):
 
 @pytest.fixture
 def client_with_permission(client_with_user):
-    output_checker = {"id": 1, "is_output_checker": True}
+    output_checker = {"is_output_checker": True}
     yield client_with_user(output_checker)
 
 
@@ -100,14 +101,14 @@ def test_workspace_view_with_directory_no_user(client, tmp_workspace):
 
 
 def test_workspace_view_index_no_permission(client_with_user, tmp_workspace):
-    forbidden_client = client_with_user({"id": 1, "workspaces": ["another-workspace"]})
+    forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
     response = forbidden_client.get(f"/workspaces/{tmp_workspace.name}/")
     assert response.status_code == 403
 
 
 def test_workspace_view_with_directory_no_permission(client_with_user, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
-    forbidden_client = client_with_user({"id": 1, "workspaces": ["another-workspace"]})
+    forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
     response = forbidden_client.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
     assert response.status_code == 403
 
@@ -129,7 +130,7 @@ def test_workspaces_index_shows_workspace_dirs_only(
 
 
 def test_workspaces_index_user_permitted_workspaces(client_with_user, tmp_workspace):
-    permitted_client = client_with_user({"id": 1, "workspaces": ["test1"]})
+    permitted_client = client_with_user({"workspaces": ["test1"]})
     WorkspaceFactory("test1")
     WorkspaceFactory("test2")
     response = permitted_client.get("/workspaces/")

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -7,6 +7,7 @@ def test_session_user_from_session():
     mock_session = {
         "user": {
             "id": 1,
+            "username": "test",
             "workspaces": ["test-workspace-1", "test_workspace2"],
             "is_output_checker": True,
         }
@@ -17,7 +18,12 @@ def test_session_user_from_session():
 
 
 def test_session_user_with_defaults():
-    mock_session = {"user": {"id": 1}}
+    mock_session = {
+        "user": {
+            "id": 1,
+            "username": "test",
+        }
+    }
     user = User.from_session(mock_session)
     assert user.workspaces == ()
     assert not user.is_output_checker
@@ -42,6 +48,7 @@ def test_session_user_has_permission(is_output_checker, workspaces, has_permissi
     mock_session = {
         "user": {
             "id": 1,
+            "username": "test",
             "workspaces": workspaces,
             "is_output_checker": is_output_checker,
         }

--- a/tests/unit/test_workspace_api.py
+++ b/tests/unit/test_workspace_api.py
@@ -185,7 +185,12 @@ def test_from_relative_path_rejects_path_escape(container, path):
 def test_root_container(is_output_checker, expected_workspaces):
     (settings.WORKSPACE_DIR / "allowed").mkdir()
     (settings.WORKSPACE_DIR / "not-allowed").mkdir()
-    user = User(id=1, workspaces=["allowed"], is_output_checker=is_output_checker)
+    user = User(
+        id=1,
+        username="test",
+        workspaces=["allowed"],
+        is_output_checker=is_output_checker,
+    )
     workspace_root = WorkspacesRoot(user=user)
     assert {ws.name for ws in workspace_root.workspaces} == expected_workspaces
 


### PR DESCRIPTION
Fixes #20 
- Adds a tiny middleware to add user to the request
- Adds username and is_authenticated to User for use in templates
- A minimal temporary login url/view so that we can login as an output-checker, in absence of actual login flow
- Logout view, with associated template buttons