### PR TITLE
fix: create a workdir in the prod image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -153,6 +153,13 @@ LABEL org.opencontainers.image.revision=$GITREF
 # 10000 corresponds to jobrunner user in backend-server
 ARG USERID=10000
 ARG GROUPID=10000
+
+# create workdir with permissions that the jobrunner user can access
+# this can be used for prod-like tests, but persistent storage should be 
+# mounted for actual production
+RUN mkdir /workdir \
+ && chown ${USERID}:${GROUPID} /workdir
+
 USER ${USERID}:${GROUPID}
 
 ##################################################

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,8 +27,6 @@ services:
     extends:
       service: base
     volumes:
-      # use the default dev workdir
-      - ../workdir:/workdir
       - ../workspaces:/workspaces
     # this compose file is only used for production-like testing - so we 
     # don't worry about potentially leaking dummy env vars into actual prod


### PR DESCRIPTION
* use the jobrunner uid so that our smoke tests can pass
* remove the docker-compose mount that was causing tests to unintentionally pass in CI