### PR TITLE
Run the playwright tests in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 
 # Tooling effluent
 /.coverage
+
+# browser install location in docker
+.playwright-browsers/

--- a/.test.env
+++ b/.test.env
@@ -6,5 +6,6 @@ DJANGO_ALLOWED_HOSTS="*"
 AIRLOCK_WORK_DIR=workdir/
 
 # For Playwright:
-# Stop the playwright install from creating .cache directory
-PLAYWRIGHT_BROWSERS_PATH=0
+# Ensure playwright browser binaries are installed to a path in the
+# mounted volume that the non-root docker user has access to
+PLAYWRIGHT_BROWSERS_PATH=/app/.playwright-browsers/

--- a/.test.env
+++ b/.test.env
@@ -4,3 +4,7 @@ DJANGO_SECRET_KEY="INSECURE-if-you-use-this-in-prod-you-will-have-a-bad-day"
 DJANGO_ALLOWED_HOSTS="*"
 
 AIRLOCK_WORK_DIR=workdir/
+
+# For Playwright:
+# Stop the playwright install from creating .cache directory
+PLAYWRIGHT_BROWSERS_PATH=0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,6 +171,10 @@ COPY requirements.dev.txt /tmp/requirements.dev.txt
 RUN --mount=type=cache,target=/root/.cache \
     python -m pip install --require-hashes --requirement /tmp/requirements.dev.txt
 
+# Install playwright chromium dependencies. This needs to be done AFTER 
+# playwright is pip-installed
+RUN playwright install-deps chromium
+
 # Override ENTRYPOINT rather than CMD so we can pass arbitrary commands to the entrypoint script
 ENTRYPOINT ["/app/docker/entrypoints/dev.sh"]
 

--- a/docker/justfile
+++ b/docker/justfile
@@ -31,7 +31,7 @@ build env="dev": _dotenv
 test *pytest_args="": _dotenv build
     #!/bin/bash
     # Note, we do *not* run coverage in docker, as we want to use xdist, and coverage does not seem to work reliably.
-    docker compose run --rm test pytest -k "not functional" {{ pytest_args }}
+    docker compose run --rm test pytest {{ pytest_args }}
 
 
 # run server in dev|prod container

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -18,8 +18,10 @@ def playwright_install(request):
     # subsequently a silent no-op) we disable output capturing so that progress gets
     # displayed to the user
     capmanager = request.config.pluginmanager.getplugin("capturemanager")
-    command = [sys.executable, "-m", "playwright", "install"]
-    if os.environ.get("CI"):  # pragma: no cover
-        command.extend(["--with-deps", "chromium"])
+    command = [sys.executable, "-m", "playwright", "install", "chromium"]
+    # Install with dependencies in CI (but not in docker, as they've already
+    # been installed in the image)
+    if os.environ.get("CI") and not os.environ.get("DOCKER"):  # pragma: no cover
+        command.extend(["--with-deps"])
     with capmanager.global_and_fixture_disabled():
         subprocess.run(command, check=True)


### PR DESCRIPTION
Fixes #40 

I'm not entirely sure I'm happy about installing the chromium dependencies in the image, and at the dev step.  But I don't want to install them in the prod steps, and they need `pip install playwright` to have run first (unless we listed out all the separate dependencies, which is a possibility).