### PR TITLE
Universal login_requires, with exemptions.

### DIFF
--- a/airlock/middleware.py
+++ b/airlock/middleware.py
@@ -1,12 +1,27 @@
+from urllib.parse import urlencode
+
+from django.shortcuts import redirect, reverse
+
 from airlock.users import User
 
 
-def user_middleware(get_response):
-    """Add the session user to the request"""
+class UserMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.login_url = reverse("login")
 
-    def middleware(request):
+    def __call__(self, request):
+        """Add the session user to the request"""
         request.user = User.from_session(request.session)
-        response = get_response(request)
+        response = self.get_response(request)
         return response
 
-    return middleware
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if getattr(view_func, "login_exempt", False):
+            return
+
+        if request.user is not None:
+            return
+
+        qs = urlencode({"next": request.get_full_path()}, safe="/")
+        return redirect(self.login_url + f"?{qs}")

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -89,7 +89,7 @@ MIDDLEWARE = [
     # "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "airlock.middleware.user_middleware",
+    "airlock.middleware.UserMiddleware",
 ]
 
 ROOT_URLCONF = "airlock.urls"

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -90,13 +90,13 @@ def test_workspace_view_redirects_to_file(client_with_permission, tmp_workspace)
 def test_workspace_view_index_no_user(client, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
     response = client.get(f"/workspaces/{tmp_workspace.name}/")
-    assert response.status_code == 403
+    assert response.status_code == 302
 
 
 def test_workspace_view_with_directory_no_user(client, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
     response = client.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
-    assert response.status_code == 403
+    assert response.status_code == 302
 
 
 def test_workspace_view_index_no_permission(client_with_user, tmp_workspace):
@@ -114,7 +114,7 @@ def test_workspace_view_with_directory_no_permission(client_with_user, tmp_works
 
 def test_workspaces_index_no_user(client):
     response = client.get("/workspaces/")
-    assert response.status_code == 403
+    assert response.status_code == 302
 
 
 def test_workspaces_index_user_permitted_workspaces(client_with_user, tmp_workspace):
@@ -131,7 +131,7 @@ def test_request_view_index_no_user(client, tmp_request):
     response = client.get(
         f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/"
     )
-    assert response.status_code == 403
+    assert response.status_code == 302
 
 
 def test_request_view_index(client_with_permission, tmp_request):


### PR DESCRIPTION
Now, all views will redirect if the user is not logged in, except for
login and index (at least for now)

We are not using django auth currently, so this is a DIY version, but
it's pretty simple.

it removes the risk of us forgetting to protect a view.
