### PR TITLE
Use non-deprecated Ruff configuration

### DIFF
--- a/justfile
+++ b/justfile
@@ -101,7 +101,7 @@ check: devenv
     }
 
     check "$BIN/ruff format --diff --quiet ."
-    check "$BIN/ruff check --show-source ."
+    check "$BIN/ruff check --output-format=full ."
     check "docker run --rm -i ghcr.io/hadolint/hadolint:v2.12.0-alpine < docker/Dockerfile"
 
     if [[ $failed > 0 ]]; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-[tool.ruff]
+[tool.ruff.lint]
 # See: https://docs.astral.sh/ruff/rules/
 extend-select = [
   "A", # prevent shadowing builtins
@@ -11,9 +11,7 @@ extend-select = [
 extend-ignore = [
   "E501", # ignore line length
 ]
-
-[tool.ruff.isort]
-lines-after-imports = 2
+isort.lines-after-imports = 2
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "airlock.settings"


### PR DESCRIPTION
This silences the following warnings:
```
warning: The `--show-source` argument is deprecated. Use `--output-format=full` instead.
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'extend-ignore' -> 'lint.extend-ignore'
  - 'extend-select' -> 'lint.extend-select'
  - 'isort' -> 'lint.isort'
```