### PR TITLE
Configure WAL journal mode for SQLite database

### DIFF
--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -1,0 +1,19 @@
+import pytest
+from django.db import ConnectionHandler
+
+
+@pytest.mark.django_db
+def test_connection_init_queries(settings, tmp_path):
+    # We want to test that we have correctly configured WAL mode, but we can't do this
+    # against the standard test database because that runs in memory. So we construct a
+    # temporary database using the same configuration as the default and check that.
+    connections = ConnectionHandler(
+        {
+            "default": settings.DATABASES["default"]
+            | {
+                "NAME": tmp_path / "test.db",
+            },
+        }
+    )
+    results = connections["default"].cursor().execute("PRAGMA journal_mode")
+    assert results.fetchone()[0] == "wal"


### PR DESCRIPTION
This is needed to support a reasonable level of concurrent writes, which isn't an issue now but is best to address before it becomes an issue.

This also gives us a framework for changing other SQLite configuration options like `PRAGMA synchronous = normal` if we choose to do so.

Attaching a signal handler during the settings import is a _bit_ non-standard (normally you'd do it within an app's `ready()` method). But this is a system-wide setting so there's not an obvious app to attach it to and it more naturally belongs with the database config. I can't thing of any specific problems having it here would cause us.