### PR TITLE
url refactor

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -81,7 +81,7 @@
 
       {% fragment as add_button %}
         {% if context == "workspace" %}
-          <form action="{{ add_file_url }}" method="POST">
+          <form action="{{ request_file_url }}" method="POST">
             {% csrf_token %}
             <input type=hidden name="path" value="{{ path_item.relpath }}"/>
             {% #button type="submit" tooltip="Add this file to the current output request, starting a new one if needed" variant="success" %}Add File to Output Request{% /button %}

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -7,7 +7,7 @@
     <form action="" method="POST">
     {% csrf_token %}
     <input type=hidden name="workspace" value="{{ workspace.name }}"/>
-    <input type=hidden name="output_request" value="{{ output_request.request_id }}"/>
+    <input type=hidden name="release_request" value="{{ release_request.request_id }}"/>
     {% #button type="submit" tooltip="This output request is ready to be reviewed" variant="success" %}Submit Output Request For Review{% /button %}
     </form>
   {% elif is_output_checker %}
@@ -91,7 +91,7 @@
             {% csrf_token %}
             <input type=hidden name="file" value="{{ path_item.relpath }}"/>
             <input type=hidden name="workspace" value="{{ workspace.name }}"/>
-            <input type=hidden name="output_request" value="{{ output_request.request_id }}"/>
+            <input type=hidden name="release_request" value="{{ release_request.request_id }}"/>
             {% #button type="submit" tooltip="Remove this file from this output request" variant="warning" %}Remove File from Output Request{% /button %}
           </form>
  

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -28,42 +28,42 @@ urlpatterns = [
     # workspaces
     path(
         "workspaces/",
-        airlock.views.workspace_index_view,
+        airlock.views.workspace_index,
         name="workspace_index",
     ),
     path(
-        "workspaces/<str:workspace_name>/",
+        "workspaces/view/<str:workspace_name>/",
         airlock.views.workspace_view,
         name="workspace_home",
     ),
     path(
-        "workspaces/<str:workspace_name>/<path:path>",
+        "workspaces/view/<str:workspace_name>/<path:path>",
         airlock.views.workspace_view,
         name="workspace_view",
+    ),
+    path(
+        "workspaces/request-file/<str:workspace_name>",
+        airlock.views.workspace_request_file,
+        name="workspace_request_file",
     ),
     # requests
     path(
         "requests/",
-        airlock.views.request_index_view,
+        airlock.views.request_index,
         name="request_index",
     ),
     path(
-        "requests/<str:workspace_name>/<str:request_id>/",
+        "requests/view/<str:workspace_name>/<str:request_id>/",
         airlock.views.request_view,
         name="request_home",
     ),
     path(
-        "requests/<str:workspace_name>/<str:request_id>/<path:path>",
+        "requests/view/<str:workspace_name>/<str:request_id>/<path:path>",
         airlock.views.request_view,
         name="request_view",
     ),
     path(
-        "requests/<str:workspace_name>/add",
-        airlock.views.request_add_file,
-        name="request_add_file",
-    ),
-    path(
-        "release/<str:workspace_name>/<str:request_id>",
+        "requests/release/<str:workspace_name>/<str:request_id>",
         airlock.views.request_release_files,
         name="request_release_files",
     ),

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -53,17 +53,17 @@ urlpatterns = [
         name="request_index",
     ),
     path(
-        "requests/view/<str:workspace_name>/<str:request_id>/",
+        "requests/view/<str:request_id>/",
         airlock.views.request_view,
         name="request_home",
     ),
     path(
-        "requests/view/<str:workspace_name>/<str:request_id>/<path:path>",
+        "requests/view/<str:request_id>/<path:path>",
         airlock.views.request_view,
         name="request_view",
     ),
     path(
-        "requests/release/<str:workspace_name>/<str:request_id>",
+        "requests/release/<str:request_id>",
         airlock.views.request_release_files,
         name="request_release_files",
     ),

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -94,14 +94,14 @@ def validate_workspace(user, workspace_name):
     return workspace
 
 
-def validate_output_request(user, workspace, request_id):
+def validate_release_request(user, workspace, request_id):
     """Ensure the release request exists for this workspace."""
-    output_request = ReleaseRequest(workspace, request_id)
+    release_request = ReleaseRequest(workspace, request_id)
     # TODO output request authorization?
-    if not output_request.exists():
+    if not release_request.exists():
         raise Http404()
 
-    return output_request
+    return release_request
 
 
 def workspace_index_view(request):
@@ -142,9 +142,9 @@ def request_index_view(request):
 
 def request_view(request, workspace_name: str, request_id: str, path: str = ""):
     workspace = validate_workspace(request.user, workspace_name)
-    output_request = validate_output_request(request.user, workspace, request_id)
+    release_request = validate_release_request(request.user, workspace, request_id)
 
-    path_item = output_request.get_path(path)
+    path_item = release_request.get_path(path)
 
     if not path_item.exists():
         raise Http404()
@@ -165,7 +165,7 @@ def request_view(request, workspace_name: str, request_id: str, path: str = ""):
 
     context = {
         "workspace": workspace,
-        "output_request": output_request,
+        "release_request": release_request,
         "path_item": path_item,
         "context": "request",
         "title": f"Request {request_id} for workspace {workspace_name}",
@@ -195,9 +195,9 @@ def request_add_file(request, workspace_name):
 @require_http_methods(["POST"])
 def request_release_files(request, workspace_name, request_id):
     workspace = validate_workspace(request.user, workspace_name)
-    output_request = validate_output_request(request.user, workspace, request_id)
+    release_request = validate_release_request(request.user, workspace, request_id)
     try:
-        output_request.release_files(request.user)
+        release_request.release_files(request.user)
     except requests.HTTPError as err:
         if settings.DEBUG:  # pragma: nocover
             return TemplateResponse(
@@ -213,4 +213,4 @@ def request_release_files(request, workspace_name, request_id):
             raise PermissionDenied() from None
         raise
 
-    return redirect(output_request.url())
+    return redirect(release_request.url())

--- a/airlock/workspace_api.py
+++ b/airlock/workspace_api.py
@@ -156,6 +156,23 @@ class ReleaseRequest(Container):
     workspace: Workspace
     request_id: str
 
+    @classmethod
+    def find(cls, request_id):
+        """Temporary method to instantiate from just a request id.
+
+        This better matches an API where the primary source of the request id is external, not on disk
+        """
+        # list of relative workspace/request_id paths
+        request_dirs = [
+            d.relative_to(settings.REQUEST_DIR)
+            for d in settings.REQUEST_DIR.glob("*/*")
+            if d.is_dir()
+        ]
+        requests = {d.parts[1]: d for d in request_dirs}
+        path = requests[request_id]
+        workspace = path.parts[0]
+        return cls(Workspace(workspace), request_id)
+
     def root(self):
         return settings.REQUEST_DIR / self.workspace.name / self.request_id
 
@@ -169,7 +186,6 @@ class ReleaseRequest(Container):
         return reverse(
             "request_home",
             kwargs={
-                "workspace_name": self.workspace.name,
                 "request_id": self.request_id,
             },
         )
@@ -178,7 +194,6 @@ class ReleaseRequest(Container):
         return reverse(
             "request_view",
             kwargs={
-                "workspace_name": self.workspace.name,
                 "request_id": self.request_id,
                 "path": relpath,
             },

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -47,70 +47,84 @@ def tmp_request(tmp_workspace):
 
 def test_workspace_view_index(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/")
+    response = client_with_permission.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert "file.txt" in response.rendered_content
 
 
 def test_workspace_does_not_exist(client_with_permission):
-    response = client_with_permission.get("/workspaces/bad/")
+    response = client_with_permission.get("/workspaces/view/bad/")
     assert response.status_code == 404
 
 
 def test_workspace_view_with_directory(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("some_dir/file.txt")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/some_dir/"
+    )
     assert "file.txt" in response.rendered_content
 
 
 def test_workspace_view_with_file(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt", "foobar")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/file.txt")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/file.txt"
+    )
     assert "foobar" in response.rendered_content
 
 
 def test_workspace_view_with_404(client_with_permission, tmp_workspace):
     response = client_with_permission.get(
-        f"/workspaces/{tmp_workspace.name}/no_such_file.txt"
+        f"/workspaces/view/{tmp_workspace.name}/no_such_file.txt"
     )
     assert response.status_code == 404
 
 
 def test_workspace_view_redirects_to_directory(client_with_permission, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/some_dir")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/some_dir"
+    )
     assert response.status_code == 302
-    assert response.headers["Location"] == f"/workspaces/{tmp_workspace.name}/some_dir/"
+    assert (
+        response.headers["Location"]
+        == f"/workspaces/view/{tmp_workspace.name}/some_dir/"
+    )
 
 
 def test_workspace_view_redirects_to_file(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/file.txt/")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/file.txt/"
+    )
     assert response.status_code == 302
-    assert response.headers["Location"] == f"/workspaces/{tmp_workspace.name}/file.txt"
+    assert (
+        response.headers["Location"]
+        == f"/workspaces/view/{tmp_workspace.name}/file.txt"
+    )
 
 
 def test_workspace_view_index_no_user(client, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
-    response = client.get(f"/workspaces/{tmp_workspace.name}/")
+    response = client.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert response.status_code == 302
 
 
 def test_workspace_view_with_directory_no_user(client, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
-    response = client.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
+    response = client.get(f"/workspaces/view/{tmp_workspace.name}/some_dir/")
     assert response.status_code == 302
 
 
 def test_workspace_view_index_no_permission(client_with_user, tmp_workspace):
     forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspaces/{tmp_workspace.name}/")
+    response = forbidden_client.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert response.status_code == 403
 
 
 def test_workspace_view_with_directory_no_permission(client_with_user, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
     forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
+    response = forbidden_client.get(f"/workspaces/view/{tmp_workspace.name}/some_dir/")
     assert response.status_code == 403
 
 
@@ -131,7 +145,7 @@ def test_workspaces_index_user_permitted_workspaces(client_with_user, tmp_worksp
 
 def test_request_view_index_no_user(client, tmp_request):
     response = client.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
     )
     assert response.status_code == 302
 
@@ -139,25 +153,27 @@ def test_request_view_index_no_user(client, tmp_request):
 def test_request_view_index(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
     )
     assert "file.txt" in response.rendered_content
 
 
 def test_request_workspace_does_not_exist(client_with_permission):
-    response = client_with_permission.get("/requests/bad/id/")
+    response = client_with_permission.get("/requests/view/bad/id/")
     assert response.status_code == 404
 
 
 def test_request_id_does_not_exist(client_with_permission, tmp_workspace):
-    response = client_with_permission.get(f"/requests/{tmp_workspace.name}/bad_id/")
+    response = client_with_permission.get(
+        f"/requests/view/{tmp_workspace.name}/bad_id/"
+    )
     assert response.status_code == 404
 
 
 def test_request_view_with_directory(client_with_permission, tmp_request):
     tmp_request.write_file("some_dir/file.txt")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
     )
     assert "file.txt" in response.rendered_content
 
@@ -165,14 +181,14 @@ def test_request_view_with_directory(client_with_permission, tmp_request):
 def test_request_view_with_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt", "foobar")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
     )
     assert "foobar" in response.rendered_content
 
 
 def test_request_view_with_404(client_with_permission, tmp_request):
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/no_such_file.txt"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/no_such_file.txt"
     )
     assert response.status_code == 404
 
@@ -180,24 +196,24 @@ def test_request_view_with_404(client_with_permission, tmp_request):
 def test_request_view_redirects_to_directory(client_with_permission, tmp_request):
     tmp_request.mkdir("some_dir")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/some_dir"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
     )
 
 
 def test_request_view_redirects_to_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/file.txt/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt/"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
     )
 
 
@@ -219,55 +235,13 @@ def test_requests_index_user_output_checker(client_with_user):
     assert request_ids == {"test-request1", "test-request2"}
 
 
-def test_requests_add_file_creates(client_with_user):
-    client = client_with_user({"workspaces": ["test1"]})
-    user = User.from_session(client.session)
-
-    wf = WorkspaceFactory("test1")
-    wf.write_file("test/path.txt")
-    workspace = wf.get()
-
-    assert workspace.get_current_request(user) is None
-
-    response = client.post("/requests/test1/add", data={"path": "test/path.txt"})
-    assert response.status_code == 302
-
-    request = workspace.get_current_request(user)
-    assert request.request_id.endswith(user.username)
-    assert request.get_path("test/path.txt").exists()
-
-
-def test_requests_add_file_request_already_exists(client_with_user):
-    client = client_with_user({"workspaces": ["test1"]})
-    user = User.from_session(client.session)
-
-    wf = WorkspaceFactory("test1")
-    workspace = wf.get()
-    wf.write_file("test/path.txt")
-    request = wf.create_request_for_user(user).get()
-
-    response = client.post("/requests/test1/add", data={"path": "test/path.txt"})
-    assert response.status_code == 302
-    assert workspace.get_current_request(user) == request
-    assert request.get_path("test/path.txt").exists()
-
-
-def test_requests_add_file_request_path_does_not_exist(client_with_user):
-    client = client_with_user({"workspaces": ["test1"]})
-    WorkspaceFactory("test1")
-
-    response = client.post("/requests/test1/add", data={"path": "test/path.txt"})
-
-    assert response.status_code == 404
-
-
 def test_requests_release_files_success(client_with_permission, release_files_stubber):
     rf = WorkspaceFactory("workspace").create_request("request_id")
     rf.write_file("test/file1.txt", "test1")
     rf.write_file("test/file2.txt", "test2")
 
     api_responses = release_files_stubber(rf.get())
-    response = client_with_permission.post("/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/workspace/request_id")
 
     assert response.status_code == 302
 
@@ -285,7 +259,7 @@ def test_requests_release_files_403(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     # test 403 is handled
-    response = client_with_permission.post("/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/workspace/request_id")
 
     assert response.status_code == 403
 
@@ -301,4 +275,4 @@ def test_requests_release_files_404(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     with pytest.raises(requests.HTTPError):
-        client_with_permission.post("/release/workspace/request_id")
+        client_with_permission.post("/requests/release/workspace/request_id")

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -45,7 +45,7 @@ def tmp_request(tmp_workspace):
     return tmp_workspace.create_request(request_id)
 
 
-def test_workspace_view_index(client_with_permission, tmp_workspace):
+def test_workspace_view(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt")
     response = client_with_permission.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert "file.txt" in response.rendered_content
@@ -143,18 +143,62 @@ def test_workspaces_index_user_permitted_workspaces(client_with_user, tmp_worksp
     assert "test2" not in response.rendered_content
 
 
-def test_request_view_index_no_user(client, tmp_request):
-    response = client.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
+def test_workspace_request_file_creates(client_with_user):
+    client = client_with_user({"workspaces": ["test1"]})
+    user = User.from_session(client.session)
+
+    wf = WorkspaceFactory("test1")
+    wf.write_file("test/path.txt")
+    workspace = wf.get()
+
+    assert workspace.get_current_request(user) is None
+
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
     )
+    assert response.status_code == 302
+
+    request = workspace.get_current_request(user)
+    assert request.request_id.endswith(user.username)
+    assert request.get_path("test/path.txt").exists()
+
+
+def test_workspace_request_file_request_already_exists(client_with_user):
+    client = client_with_user({"workspaces": ["test1"]})
+    user = User.from_session(client.session)
+
+    wf = WorkspaceFactory("test1")
+    workspace = wf.get()
+    wf.write_file("test/path.txt")
+    request = wf.create_request_for_user(user).get()
+
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
+    )
+    assert response.status_code == 302
+    assert workspace.get_current_request(user) == request
+    assert request.get_path("test/path.txt").exists()
+
+
+def test_workspace_request_file_request_path_does_not_exist(client_with_user):
+    client = client_with_user({"workspaces": ["test1"]})
+    WorkspaceFactory("test1")
+
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
+    )
+
+    assert response.status_code == 404
+
+
+def test_request_index_no_user(client, tmp_request):
+    response = client.get(f"/requests/view/{tmp_request.request_id}/")
     assert response.status_code == 302
 
 
 def test_request_view_index(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
-    response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
-    )
+    response = client_with_permission.get(f"/requests/view/{tmp_request.request_id}/")
     assert "file.txt" in response.rendered_content
 
 
@@ -164,16 +208,14 @@ def test_request_workspace_does_not_exist(client_with_permission):
 
 
 def test_request_id_does_not_exist(client_with_permission, tmp_workspace):
-    response = client_with_permission.get(
-        f"/requests/view/{tmp_workspace.name}/bad_id/"
-    )
+    response = client_with_permission.get("/requests/view/bad_id/")
     assert response.status_code == 404
 
 
 def test_request_view_with_directory(client_with_permission, tmp_request):
     tmp_request.write_file("some_dir/file.txt")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        f"/requests/view/{tmp_request.request_id}/some_dir/"
     )
     assert "file.txt" in response.rendered_content
 
@@ -181,14 +223,14 @@ def test_request_view_with_directory(client_with_permission, tmp_request):
 def test_request_view_with_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt", "foobar")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        f"/requests/view/{tmp_request.request_id}/file.txt"
     )
     assert "foobar" in response.rendered_content
 
 
 def test_request_view_with_404(client_with_permission, tmp_request):
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/no_such_file.txt"
+        f"/requests/view/{tmp_request.request_id}/no_such_file.txt"
     )
     assert response.status_code == 404
 
@@ -196,28 +238,28 @@ def test_request_view_with_404(client_with_permission, tmp_request):
 def test_request_view_redirects_to_directory(client_with_permission, tmp_request):
     tmp_request.mkdir("some_dir")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir"
+        f"/requests/view/{tmp_request.request_id}/some_dir"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        == f"/requests/view/{tmp_request.request_id}/some_dir/"
     )
 
 
 def test_request_view_redirects_to_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt/"
+        f"/requests/view/{tmp_request.request_id}/file.txt/"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        == f"/requests/view/{tmp_request.request_id}/file.txt"
     )
 
 
-def test_requests_index_user_permitted_requests(client_with_user):
+def test_request_index_user_permitted_requests(client_with_user):
     permitted_client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(permitted_client.session)
     rf = WorkspaceFactory("test1").create_request_for_user(user)
@@ -226,7 +268,7 @@ def test_requests_index_user_permitted_requests(client_with_user):
     assert request_ids == {rf.request_id}
 
 
-def test_requests_index_user_output_checker(client_with_user):
+def test_request_index_user_output_checker(client_with_user):
     WorkspaceFactory("test1").create_request("test-request1")
     WorkspaceFactory("test2").create_request("test-request2")
     permitted_client = client_with_user({"workspaces": [], "output_checker": True})
@@ -235,13 +277,13 @@ def test_requests_index_user_output_checker(client_with_user):
     assert request_ids == {"test-request1", "test-request2"}
 
 
-def test_requests_release_files_success(client_with_permission, release_files_stubber):
+def test_request_release_files_success(client_with_permission, release_files_stubber):
     rf = WorkspaceFactory("workspace").create_request("request_id")
     rf.write_file("test/file1.txt", "test1")
     rf.write_file("test/file2.txt", "test2")
 
     api_responses = release_files_stubber(rf.get())
-    response = client_with_permission.post("/requests/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/request_id")
 
     assert response.status_code == 302
 
@@ -259,7 +301,7 @@ def test_requests_release_files_403(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     # test 403 is handled
-    response = client_with_permission.post("/requests/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/request_id")
 
     assert response.status_code == 403
 
@@ -275,4 +317,4 @@ def test_requests_release_files_404(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     with pytest.raises(requests.HTTPError):
-        client_with_permission.post("/requests/release/workspace/request_id")
+        client_with_permission.post("/requests/release/request_id")


### PR DESCRIPTION
- Fix left over use of the term "output_request"
- Explict view urls

This is a url refactor pulled out of WIP change to add submit/reject views.

