### PR TITLE
factoryfactor

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -81,7 +81,7 @@
 
       {% fragment as add_button %}
         {% if context == "workspace" %}
-          <form action="{{ add_file_url }}" method="POST">
+          <form action="{{ request_file_url }}" method="POST">
             {% csrf_token %}
             <input type=hidden name="path" value="{{ path_item.relpath }}"/>
             {% #button type="submit" tooltip="Add this file to the current output request, starting a new one if needed" variant="success" %}Add File to Output Request{% /button %}

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -7,7 +7,7 @@
     <form action="" method="POST">
     {% csrf_token %}
     <input type=hidden name="workspace" value="{{ workspace.name }}"/>
-    <input type=hidden name="output_request" value="{{ output_request.request_id }}"/>
+    <input type=hidden name="release_request" value="{{ release_request.request_id }}"/>
     {% #button type="submit" tooltip="This output request is ready to be reviewed" variant="success" %}Submit Output Request For Review{% /button %}
     </form>
   {% elif is_output_checker %}
@@ -91,7 +91,7 @@
             {% csrf_token %}
             <input type=hidden name="file" value="{{ path_item.relpath }}"/>
             <input type=hidden name="workspace" value="{{ workspace.name }}"/>
-            <input type=hidden name="output_request" value="{{ output_request.request_id }}"/>
+            <input type=hidden name="release_request" value="{{ release_request.request_id }}"/>
             {% #button type="submit" tooltip="Remove this file from this output request" variant="warning" %}Remove File from Output Request{% /button %}
           </form>
  

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -28,42 +28,42 @@ urlpatterns = [
     # workspaces
     path(
         "workspaces/",
-        airlock.views.workspace_index_view,
+        airlock.views.workspace_index,
         name="workspace_index",
     ),
     path(
-        "workspaces/<str:workspace_name>/",
+        "workspaces/view/<str:workspace_name>/",
         airlock.views.workspace_view,
         name="workspace_home",
     ),
     path(
-        "workspaces/<str:workspace_name>/<path:path>",
+        "workspaces/view/<str:workspace_name>/<path:path>",
         airlock.views.workspace_view,
         name="workspace_view",
+    ),
+    path(
+        "workspaces/request-file/<str:workspace_name>",
+        airlock.views.workspace_request_file,
+        name="workspace_request_file",
     ),
     # requests
     path(
         "requests/",
-        airlock.views.request_index_view,
+        airlock.views.request_index,
         name="request_index",
     ),
     path(
-        "requests/<str:workspace_name>/<str:request_id>/",
+        "requests/view/<str:workspace_name>/<str:request_id>/",
         airlock.views.request_view,
         name="request_home",
     ),
     path(
-        "requests/<str:workspace_name>/<str:request_id>/<path:path>",
+        "requests/view/<str:workspace_name>/<str:request_id>/<path:path>",
         airlock.views.request_view,
         name="request_view",
     ),
     path(
-        "requests/<str:workspace_name>/add",
-        airlock.views.request_add_file,
-        name="request_add_file",
-    ),
-    path(
-        "release/<str:workspace_name>/<str:request_id>",
+        "requests/release/<str:workspace_name>/<str:request_id>",
         airlock.views.request_release_files,
         name="request_release_files",
     ),

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -53,17 +53,17 @@ urlpatterns = [
         name="request_index",
     ),
     path(
-        "requests/view/<str:workspace_name>/<str:request_id>/",
+        "requests/view/<str:request_id>/",
         airlock.views.request_view,
         name="request_home",
     ),
     path(
-        "requests/view/<str:workspace_name>/<str:request_id>/<path:path>",
+        "requests/view/<str:request_id>/<path:path>",
         airlock.views.request_view,
         name="request_view",
     ),
     path(
-        "requests/release/<str:workspace_name>/<str:request_id>",
+        "requests/release/<str:request_id>",
         airlock.views.request_release_files,
         name="request_release_files",
     ),

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -94,14 +94,14 @@ def validate_workspace(user, workspace_name):
     return workspace
 
 
-def validate_output_request(user, workspace, request_id):
+def validate_release_request(user, workspace, request_id):
     """Ensure the release request exists for this workspace."""
-    output_request = ReleaseRequest(workspace, request_id)
+    release_request = ReleaseRequest(workspace, request_id)
     # TODO output request authorization?
-    if not output_request.exists():
+    if not release_request.exists():
         raise Http404()
 
-    return output_request
+    return release_request
 
 
 def workspace_index_view(request):
@@ -142,9 +142,9 @@ def request_index_view(request):
 
 def request_view(request, workspace_name: str, request_id: str, path: str = ""):
     workspace = validate_workspace(request.user, workspace_name)
-    output_request = validate_output_request(request.user, workspace, request_id)
+    release_request = validate_release_request(request.user, workspace, request_id)
 
-    path_item = output_request.get_path(path)
+    path_item = release_request.get_path(path)
 
     if not path_item.exists():
         raise Http404()
@@ -165,7 +165,7 @@ def request_view(request, workspace_name: str, request_id: str, path: str = ""):
 
     context = {
         "workspace": workspace,
-        "output_request": output_request,
+        "release_request": release_request,
         "path_item": path_item,
         "context": "request",
         "title": f"Request {request_id} for workspace {workspace_name}",
@@ -195,9 +195,9 @@ def request_add_file(request, workspace_name):
 @require_http_methods(["POST"])
 def request_release_files(request, workspace_name, request_id):
     workspace = validate_workspace(request.user, workspace_name)
-    output_request = validate_output_request(request.user, workspace, request_id)
+    release_request = validate_release_request(request.user, workspace, request_id)
     try:
-        output_request.release_files(request.user)
+        release_request.release_files(request.user)
     except requests.HTTPError as err:
         if settings.DEBUG:  # pragma: nocover
             return TemplateResponse(
@@ -213,4 +213,4 @@ def request_release_files(request, workspace_name, request_id):
             raise PermissionDenied() from None
         raise
 
-    return redirect(output_request.url())
+    return redirect(release_request.url())

--- a/airlock/workspace_api.py
+++ b/airlock/workspace_api.py
@@ -156,6 +156,23 @@ class ReleaseRequest(Container):
     workspace: Workspace
     request_id: str
 
+    @classmethod
+    def find(cls, request_id):
+        """Temporary method to instantiate from just a request id.
+
+        This better matches an API where the primary source of the request id is external, not on disk
+        """
+        # list of relative workspace/request_id paths
+        request_dirs = [
+            d.relative_to(settings.REQUEST_DIR)
+            for d in settings.REQUEST_DIR.glob("*/*")
+            if d.is_dir()
+        ]
+        requests = {d.parts[1]: d for d in request_dirs}
+        path = requests[request_id]
+        workspace = path.parts[0]
+        return cls(Workspace(workspace), request_id)
+
     def root(self):
         return settings.REQUEST_DIR / self.workspace.name / self.request_id
 
@@ -169,7 +186,6 @@ class ReleaseRequest(Container):
         return reverse(
             "request_home",
             kwargs={
-                "workspace_name": self.workspace.name,
                 "request_id": self.request_id,
             },
         )
@@ -178,7 +194,6 @@ class ReleaseRequest(Container):
         return reverse(
             "request_view",
             kwargs={
-                "workspace_name": self.workspace.name,
                 "request_id": self.request_id,
                 "path": relpath,
             },

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,63 +1,44 @@
-from dataclasses import dataclass
-
 from django.conf import settings
 
 from airlock.users import User
 from airlock.workspace_api import ReleaseRequest, Workspace, generate_request_id
 
 
-default_user = User(1, "test", [], True)
+default_user = User(1, "testuser")
 
 
-class FileWriterMixin:
-    def path(self):  # pragma: no cover
-        return NotImplemented()
+def ensure_workspace(workspace_or_name):
+    if isinstance(workspace_or_name, str):
+        return create_workspace(workspace_or_name)
+    elif isinstance(workspace_or_name, Workspace):
+        return workspace_or_name
 
-    def mkdir(self, path):
-        fp = self.path() / path
-        fp.mkdir(parents=True, exist_ok=True)
-
-    def write_file(self, path, contents=""):
-        fp = self.path() / path
-        self.mkdir(fp.parent)
-        fp.write_text(contents)
+    raise Exception(f"Invalid workspace: {workspace_or_name})")  # pragma: nocover
 
 
-@dataclass
-class WorkspaceFactory(FileWriterMixin):
-    name: str
-
-    def __post_init__(self):
-        self.path().mkdir(parents=True, exist_ok=True)
-
-    def path(self):
-        return settings.WORKSPACE_DIR / self.name
-
-    def create_request(self, request_id):
-        return ReleaseRequestFactory(request_id, self.name)
-
-    def create_request_for_user(self, user=None):
-        if user is None:
-            user = default_user  # pragma: nocover
-        request_id = generate_request_id(self.name, user)
-        return ReleaseRequestFactory(request_id, self.name)
-
-    def get(self):
-        return Workspace(self.name)
+def create_workspace(name):
+    workspace_dir = settings.WORKSPACE_DIR / name
+    workspace_dir.mkdir(exist_ok=True, parents=True)
+    return Workspace(name)
 
 
-@dataclass
-class ReleaseRequestFactory(FileWriterMixin):
-    request_id: str
-    workspace: str
+def create_request(workspace, user=default_user, request_id=None):
+    workspace = ensure_workspace(workspace)
+    if request_id is None:
+        request_id = generate_request_id(workspace.name, user)
+    release_request = ReleaseRequest(workspace, request_id)
+    release_request.root().mkdir(parents=True, exist_ok=True)
+    return release_request
 
-    def __post_init__(self):
-        self.path().mkdir(parents=True, exist_ok=True)
-        # ensure workspace dir exists
-        WorkspaceFactory(self.workspace)
 
-    def path(self):
-        return settings.REQUEST_DIR / self.workspace / self.request_id
+def write_workspace_file(workspace, path, contents=""):
+    workspace = ensure_workspace(workspace)
+    path = workspace.root() / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
 
-    def get(self):
-        return ReleaseRequest(Workspace(self.workspace), self.request_id)
+
+def write_request_file(request, path, contents=""):
+    path = request.root() / path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -1,13 +1,13 @@
 import pytest
 from playwright.sync_api import expect
 
-from tests.factories import WorkspaceFactory
+from tests import factories
 
 
 @pytest.fixture(autouse=True)
 def workspaces():
-    WorkspaceFactory("test-dir1")
-    WorkspaceFactory("test-dir2")
+    factories.create_workspace("test-dir1")
+    factories.create_workspace("test-dir2")
 
 
 def test_workspaces_index_as_ouput_checker(live_server, page, output_checker_user):

--- a/tests/integration/test_old_api.py
+++ b/tests/integration/test_old_api.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 from django.conf import settings
 
 import old_api
-from tests.factories import WorkspaceFactory
+from tests import factories
 
 
 def test_old_api_create_release(responses):
@@ -22,20 +24,18 @@ def test_old_api_create_release(responses):
 
 
 def test_old_api_upload_file(responses):
-    rf = WorkspaceFactory("workspace").create_request("request-id")
-    rf.write_file("test/file.txt", "test")
-    item = rf.get().get_path("test/file.txt")
+    request = factories.create_request("workspace", request_id="request-id")
+    relpath = Path("test/file.txt")
+    abspath = request.root() / relpath
+    factories.write_request_file(request, relpath, "test")
 
     responses.post(
         f"{settings.AIRLOCK_API_ENDPOINT}/releases/release/release-id",
         status=201,
     )
 
-    old_api.upload_file("release-id", item.relpath, item._absolute_path(), "testuser")
+    old_api.upload_file("release-id", relpath, abspath, "testuser")
     request = responses.calls[0].request
     assert request.body.read() == b"test"
-    assert (
-        request.headers["Content-Disposition"]
-        == f'attachment; filename="{item.relpath}"'
-    )
+    assert request.headers["Content-Disposition"] == f'attachment; filename="{relpath}"'
     assert request.headers["OS-User"] == "testuser"

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -47,70 +47,84 @@ def tmp_request(tmp_workspace):
 
 def test_workspace_view_index(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/")
+    response = client_with_permission.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert "file.txt" in response.rendered_content
 
 
 def test_workspace_does_not_exist(client_with_permission):
-    response = client_with_permission.get("/workspaces/bad/")
+    response = client_with_permission.get("/workspaces/view/bad/")
     assert response.status_code == 404
 
 
 def test_workspace_view_with_directory(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("some_dir/file.txt")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/some_dir/"
+    )
     assert "file.txt" in response.rendered_content
 
 
 def test_workspace_view_with_file(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt", "foobar")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/file.txt")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/file.txt"
+    )
     assert "foobar" in response.rendered_content
 
 
 def test_workspace_view_with_404(client_with_permission, tmp_workspace):
     response = client_with_permission.get(
-        f"/workspaces/{tmp_workspace.name}/no_such_file.txt"
+        f"/workspaces/view/{tmp_workspace.name}/no_such_file.txt"
     )
     assert response.status_code == 404
 
 
 def test_workspace_view_redirects_to_directory(client_with_permission, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/some_dir")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/some_dir"
+    )
     assert response.status_code == 302
-    assert response.headers["Location"] == f"/workspaces/{tmp_workspace.name}/some_dir/"
+    assert (
+        response.headers["Location"]
+        == f"/workspaces/view/{tmp_workspace.name}/some_dir/"
+    )
 
 
 def test_workspace_view_redirects_to_file(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt")
-    response = client_with_permission.get(f"/workspaces/{tmp_workspace.name}/file.txt/")
+    response = client_with_permission.get(
+        f"/workspaces/view/{tmp_workspace.name}/file.txt/"
+    )
     assert response.status_code == 302
-    assert response.headers["Location"] == f"/workspaces/{tmp_workspace.name}/file.txt"
+    assert (
+        response.headers["Location"]
+        == f"/workspaces/view/{tmp_workspace.name}/file.txt"
+    )
 
 
 def test_workspace_view_index_no_user(client, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
-    response = client.get(f"/workspaces/{tmp_workspace.name}/")
+    response = client.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert response.status_code == 302
 
 
 def test_workspace_view_with_directory_no_user(client, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
-    response = client.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
+    response = client.get(f"/workspaces/view/{tmp_workspace.name}/some_dir/")
     assert response.status_code == 302
 
 
 def test_workspace_view_index_no_permission(client_with_user, tmp_workspace):
     forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspaces/{tmp_workspace.name}/")
+    response = forbidden_client.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert response.status_code == 403
 
 
 def test_workspace_view_with_directory_no_permission(client_with_user, tmp_workspace):
     tmp_workspace.mkdir("some_dir")
     forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspaces/{tmp_workspace.name}/some_dir/")
+    response = forbidden_client.get(f"/workspaces/view/{tmp_workspace.name}/some_dir/")
     assert response.status_code == 403
 
 
@@ -131,7 +145,7 @@ def test_workspaces_index_user_permitted_workspaces(client_with_user, tmp_worksp
 
 def test_request_view_index_no_user(client, tmp_request):
     response = client.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
     )
     assert response.status_code == 302
 
@@ -139,25 +153,27 @@ def test_request_view_index_no_user(client, tmp_request):
 def test_request_view_index(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
     )
     assert "file.txt" in response.rendered_content
 
 
 def test_request_workspace_does_not_exist(client_with_permission):
-    response = client_with_permission.get("/requests/bad/id/")
+    response = client_with_permission.get("/requests/view/bad/id/")
     assert response.status_code == 404
 
 
 def test_request_id_does_not_exist(client_with_permission, tmp_workspace):
-    response = client_with_permission.get(f"/requests/{tmp_workspace.name}/bad_id/")
+    response = client_with_permission.get(
+        f"/requests/view/{tmp_workspace.name}/bad_id/"
+    )
     assert response.status_code == 404
 
 
 def test_request_view_with_directory(client_with_permission, tmp_request):
     tmp_request.write_file("some_dir/file.txt")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
     )
     assert "file.txt" in response.rendered_content
 
@@ -165,14 +181,14 @@ def test_request_view_with_directory(client_with_permission, tmp_request):
 def test_request_view_with_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt", "foobar")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
     )
     assert "foobar" in response.rendered_content
 
 
 def test_request_view_with_404(client_with_permission, tmp_request):
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/no_such_file.txt"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/no_such_file.txt"
     )
     assert response.status_code == 404
 
@@ -180,24 +196,24 @@ def test_request_view_with_404(client_with_permission, tmp_request):
 def test_request_view_redirects_to_directory(client_with_permission, tmp_request):
     tmp_request.mkdir("some_dir")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/some_dir"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
     )
 
 
 def test_request_view_redirects_to_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
     response = client_with_permission.get(
-        f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/file.txt/"
+        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt/"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
     )
 
 
@@ -219,7 +235,7 @@ def test_requests_index_user_output_checker(client_with_user):
     assert request_ids == {"test-request1", "test-request2"}
 
 
-def test_requests_add_file_creates(client_with_user):
+def test_requests_request_file_creates(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(client.session)
 
@@ -229,7 +245,9 @@ def test_requests_add_file_creates(client_with_user):
 
     assert workspace.get_current_request(user) is None
 
-    response = client.post("/requests/test1/add", data={"path": "test/path.txt"})
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
+    )
     assert response.status_code == 302
 
     request = workspace.get_current_request(user)
@@ -237,7 +255,7 @@ def test_requests_add_file_creates(client_with_user):
     assert request.get_path("test/path.txt").exists()
 
 
-def test_requests_add_file_request_already_exists(client_with_user):
+def test_requests_request_file_request_already_exists(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(client.session)
 
@@ -246,17 +264,21 @@ def test_requests_add_file_request_already_exists(client_with_user):
     wf.write_file("test/path.txt")
     request = wf.create_request_for_user(user).get()
 
-    response = client.post("/requests/test1/add", data={"path": "test/path.txt"})
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
+    )
     assert response.status_code == 302
     assert workspace.get_current_request(user) == request
     assert request.get_path("test/path.txt").exists()
 
 
-def test_requests_add_file_request_path_does_not_exist(client_with_user):
+def test_requests_request_file_request_path_does_not_exist(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
     WorkspaceFactory("test1")
 
-    response = client.post("/requests/test1/add", data={"path": "test/path.txt"})
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
+    )
 
     assert response.status_code == 404
 
@@ -267,7 +289,7 @@ def test_requests_release_files_success(client_with_permission, release_files_st
     rf.write_file("test/file2.txt", "test2")
 
     api_responses = release_files_stubber(rf.get())
-    response = client_with_permission.post("/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/workspace/request_id")
 
     assert response.status_code == 302
 
@@ -285,7 +307,7 @@ def test_requests_release_files_403(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     # test 403 is handled
-    response = client_with_permission.post("/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/workspace/request_id")
 
     assert response.status_code == 403
 
@@ -301,4 +323,4 @@ def test_requests_release_files_404(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     with pytest.raises(requests.HTTPError):
-        client_with_permission.post("/release/workspace/request_id")
+        client_with_permission.post("/requests/release/workspace/request_id")

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 
 from airlock.users import User
-from tests.factories import WorkspaceFactory
+from tests import factories
 
 
 pytestmark = pytest.mark.django_db
@@ -20,6 +20,7 @@ def client_with_user(client):
         session = client.session
         session["user"] = session_user
         session.save()
+        client.user = User.from_session(session)
         return client
 
     return _client
@@ -35,19 +36,10 @@ workspace_name = "test-workspace"
 request_id = "test-request"
 
 
-@pytest.fixture
-def tmp_workspace():
-    return WorkspaceFactory(workspace_name)
+def test_workspace_view(client_with_permission):
+    factories.write_workspace_file("workspace", "file.txt")
 
-
-@pytest.fixture
-def tmp_request(tmp_workspace):
-    return tmp_workspace.create_request(request_id)
-
-
-def test_workspace_view(client_with_permission, tmp_workspace):
-    tmp_workspace.write_file("file.txt")
-    response = client_with_permission.get(f"/workspaces/view/{tmp_workspace.name}/")
+    response = client_with_permission.get("/workspaces/view/workspace/")
     assert "file.txt" in response.rendered_content
 
 
@@ -56,75 +48,65 @@ def test_workspace_does_not_exist(client_with_permission):
     assert response.status_code == 404
 
 
-def test_workspace_view_with_directory(client_with_permission, tmp_workspace):
-    tmp_workspace.write_file("some_dir/file.txt")
-    response = client_with_permission.get(
-        f"/workspaces/view/{tmp_workspace.name}/some_dir/"
-    )
+def test_workspace_view_with_directory(client_with_permission):
+    factories.write_workspace_file("workspace", "some_dir/file.txt")
+    response = client_with_permission.get("/workspaces/view/workspace/some_dir/")
     assert "file.txt" in response.rendered_content
 
 
-def test_workspace_view_with_file(client_with_permission, tmp_workspace):
-    tmp_workspace.write_file("file.txt", "foobar")
-    response = client_with_permission.get(
-        f"/workspaces/view/{tmp_workspace.name}/file.txt"
-    )
+def test_workspace_view_with_file(client_with_permission):
+    factories.write_workspace_file("workspace", "file.txt", "foobar")
+    response = client_with_permission.get("/workspaces/view/workspace/file.txt")
     assert "foobar" in response.rendered_content
 
 
-def test_workspace_view_with_404(client_with_permission, tmp_workspace):
-    response = client_with_permission.get(
-        f"/workspaces/view/{tmp_workspace.name}/no_such_file.txt"
-    )
+def test_workspace_view_with_404(client_with_permission):
+    factories.create_workspace("workspace")
+    response = client_with_permission.get("/workspaces/view/workspace/no_such_file.txt")
     assert response.status_code == 404
 
 
-def test_workspace_view_redirects_to_directory(client_with_permission, tmp_workspace):
-    tmp_workspace.mkdir("some_dir")
-    response = client_with_permission.get(
-        f"/workspaces/view/{tmp_workspace.name}/some_dir"
-    )
+def test_workspace_view_redirects_to_directory(client_with_permission):
+    workspace = factories.create_workspace("workspace")
+    (workspace.root() / "some_dir").mkdir(parents=True)
+    response = client_with_permission.get("/workspaces/view/workspace/some_dir")
     assert response.status_code == 302
-    assert (
-        response.headers["Location"]
-        == f"/workspaces/view/{tmp_workspace.name}/some_dir/"
-    )
+    assert response.headers["Location"] == "/workspaces/view/workspace/some_dir/"
 
 
-def test_workspace_view_redirects_to_file(client_with_permission, tmp_workspace):
-    tmp_workspace.write_file("file.txt")
-    response = client_with_permission.get(
-        f"/workspaces/view/{tmp_workspace.name}/file.txt/"
-    )
+def test_workspace_view_redirects_to_file(client_with_permission):
+    factories.write_workspace_file("workspace", "file.txt")
+    response = client_with_permission.get("/workspaces/view/workspace/file.txt/")
     assert response.status_code == 302
-    assert (
-        response.headers["Location"]
-        == f"/workspaces/view/{tmp_workspace.name}/file.txt"
-    )
+    assert response.headers["Location"] == "/workspaces/view/workspace/file.txt"
 
 
-def test_workspace_view_index_no_user(client, tmp_workspace):
-    tmp_workspace.mkdir("some_dir")
-    response = client.get(f"/workspaces/view/{tmp_workspace.name}/")
+def test_workspace_view_index_no_user(client):
+    workspace = factories.create_workspace("workspace")
+    (workspace.root() / "some_dir").mkdir(parents=True)
+    response = client.get("/workspaces/view/workspace/")
     assert response.status_code == 302
 
 
-def test_workspace_view_with_directory_no_user(client, tmp_workspace):
-    tmp_workspace.mkdir("some_dir")
-    response = client.get(f"/workspaces/view/{tmp_workspace.name}/some_dir/")
+def test_workspace_view_with_directory_no_user(client):
+    workspace = factories.create_workspace("workspace")
+    (workspace.root() / "some_dir").mkdir(parents=True)
+    response = client.get("/workspaces/view/workspace/some_dir/")
     assert response.status_code == 302
 
 
-def test_workspace_view_index_no_permission(client_with_user, tmp_workspace):
+def test_workspace_view_index_no_permission(client_with_user):
+    factories.create_workspace("workspace")
     forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspaces/view/{tmp_workspace.name}/")
+    response = forbidden_client.get("/workspaces/view/workspace/")
     assert response.status_code == 403
 
 
-def test_workspace_view_with_directory_no_permission(client_with_user, tmp_workspace):
-    tmp_workspace.mkdir("some_dir")
+def test_workspace_view_with_directory_no_permission(client_with_user):
+    workspace = factories.create_workspace("workspace")
+    (workspace.root() / "some_dir").mkdir(parents=True)
     forbidden_client = client_with_user({"workspaces": ["another-workspace"]})
-    response = forbidden_client.get(f"/workspaces/view/{tmp_workspace.name}/some_dir/")
+    response = forbidden_client.get("/workspaces/view/workspace/some_dir/")
     assert response.status_code == 403
 
 
@@ -133,10 +115,10 @@ def test_workspaces_index_no_user(client):
     assert response.status_code == 302
 
 
-def test_workspaces_index_user_permitted_workspaces(client_with_user, tmp_workspace):
+def test_workspaces_index_user_permitted_workspaces(client_with_user):
     permitted_client = client_with_user({"workspaces": ["test1"]})
-    WorkspaceFactory("test1")
-    WorkspaceFactory("test2")
+    factories.create_workspace("test1")
+    factories.create_workspace("test2")
     response = permitted_client.get("/workspaces/")
     workspace_names = {ws.name for ws in response.context["workspaces"]}
     assert workspace_names == {"test1"}
@@ -147,9 +129,8 @@ def test_workspace_request_file_creates(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(client.session)
 
-    wf = WorkspaceFactory("test1")
-    wf.write_file("test/path.txt")
-    workspace = wf.get()
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt")
 
     assert workspace.get_current_request(user) is None
 
@@ -167,10 +148,9 @@ def test_workspace_request_file_request_already_exists(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(client.session)
 
-    wf = WorkspaceFactory("test1")
-    workspace = wf.get()
-    wf.write_file("test/path.txt")
-    request = wf.create_request_for_user(user).get()
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt")
+    request = factories.create_request(workspace, user)
 
     response = client.post(
         "/workspaces/request-file/test1", data={"path": "test/path.txt"}
@@ -182,7 +162,7 @@ def test_workspace_request_file_request_already_exists(client_with_user):
 
 def test_workspace_request_file_request_path_does_not_exist(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
-    WorkspaceFactory("test1")
+    factories.create_workspace("test1")
 
     response = client.post(
         "/workspaces/request-file/test1", data={"path": "test/path.txt"}
@@ -191,14 +171,16 @@ def test_workspace_request_file_request_path_does_not_exist(client_with_user):
     assert response.status_code == 404
 
 
-def test_request_index_no_user(client, tmp_request):
-    response = client.get(f"/requests/view/{tmp_request.request_id}/")
+def test_request_index_no_user(client):
+    request = factories.create_request("workspace")
+    response = client.get(f"/requests/view/{request.request_id}/")
     assert response.status_code == 302
 
 
-def test_request_view_index(client_with_permission, tmp_request):
-    tmp_request.write_file("file.txt")
-    response = client_with_permission.get(f"/requests/view/{tmp_request.request_id}/")
+def test_request_view_index(client_with_permission):
+    request = factories.create_request("workspace", client_with_permission.user)
+    factories.write_request_file(request, "file.txt")
+    response = client_with_permission.get(f"/requests/view/{request.request_id}/")
     assert "file.txt" in response.rendered_content
 
 
@@ -207,83 +189,86 @@ def test_request_workspace_does_not_exist(client_with_permission):
     assert response.status_code == 404
 
 
-def test_request_id_does_not_exist(client_with_permission, tmp_workspace):
+def test_request_id_does_not_exist(client_with_permission):
     response = client_with_permission.get("/requests/view/bad_id/")
     assert response.status_code == 404
 
 
-def test_request_view_with_directory(client_with_permission, tmp_request):
-    tmp_request.write_file("some_dir/file.txt")
+def test_request_view_with_directory(client_with_permission):
+    request = factories.create_request("workspace")
+    factories.write_request_file(request, "some_dir/file.txt")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.request_id}/some_dir/"
+        f"/requests/view/{request.request_id}/some_dir/"
     )
     assert "file.txt" in response.rendered_content
 
 
-def test_request_view_with_file(client_with_permission, tmp_request):
-    tmp_request.write_file("file.txt", "foobar")
+def test_request_view_with_file(client_with_permission):
+    request = factories.create_request("workspace")
+    factories.write_request_file(request, "file.txt", "foobar")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.request_id}/file.txt"
+        f"/requests/view/{request.request_id}/file.txt"
     )
     assert "foobar" in response.rendered_content
 
 
-def test_request_view_with_404(client_with_permission, tmp_request):
+def test_request_view_with_404(client_with_permission):
+    request = factories.create_request("workspace")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.request_id}/no_such_file.txt"
+        f"/requests/view/{request.request_id}/no_such_file.txt"
     )
     assert response.status_code == 404
 
 
-def test_request_view_redirects_to_directory(client_with_permission, tmp_request):
-    tmp_request.mkdir("some_dir")
+def test_request_view_redirects_to_directory(client_with_permission):
+    request = factories.create_request("workspace")
+    (request.root() / "some_dir").mkdir(parents=True)
+
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.request_id}/some_dir"
+        f"/requests/view/{request.request_id}/some_dir"
     )
     assert response.status_code == 302
     assert (
-        response.headers["Location"]
-        == f"/requests/view/{tmp_request.request_id}/some_dir/"
+        response.headers["Location"] == f"/requests/view/{request.request_id}/some_dir/"
     )
 
 
-def test_request_view_redirects_to_file(client_with_permission, tmp_request):
-    tmp_request.write_file("file.txt")
+def test_request_view_redirects_to_file(client_with_permission):
+    request = factories.create_request("workspace")
+    factories.write_request_file(request, "file.txt")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.request_id}/file.txt/"
+        f"/requests/view/{request.request_id}/file.txt/"
     )
     assert response.status_code == 302
     assert (
-        response.headers["Location"]
-        == f"/requests/view/{tmp_request.request_id}/file.txt"
+        response.headers["Location"] == f"/requests/view/{request.request_id}/file.txt"
     )
 
 
 def test_request_index_user_permitted_requests(client_with_user):
     permitted_client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(permitted_client.session)
-    rf = WorkspaceFactory("test1").create_request_for_user(user)
+    request = factories.create_request("test1", user)
     response = permitted_client.get("/requests/")
     request_ids = {r.request_id for r in response.context["requests"]}
-    assert request_ids == {rf.request_id}
+    assert request_ids == {request.request_id}
 
 
 def test_request_index_user_output_checker(client_with_user):
-    WorkspaceFactory("test1").create_request("test-request1")
-    WorkspaceFactory("test2").create_request("test-request2")
+    r1 = factories.create_request("test1")
+    r2 = factories.create_request("test2")
     permitted_client = client_with_user({"workspaces": [], "output_checker": True})
     response = permitted_client.get("/requests/")
     request_ids = {r.request_id for r in response.context["requests"]}
-    assert request_ids == {"test-request1", "test-request2"}
+    assert request_ids == {r1.request_id, r2.request_id}
 
 
 def test_requests_request_file_creates(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(client.session)
 
-    wf = WorkspaceFactory("test1")
-    wf.write_file("test/path.txt")
-    workspace = wf.get()
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt")
 
     assert workspace.get_current_request(user) is None
 
@@ -301,10 +286,9 @@ def test_requests_request_file_request_already_exists(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(client.session)
 
-    wf = WorkspaceFactory("test1")
-    workspace = wf.get()
-    wf.write_file("test/path.txt")
-    request = wf.create_request_for_user(user).get()
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt")
+    request = factories.create_request(workspace, user)
 
     response = client.post(
         "/workspaces/request-file/test1", data={"path": "test/path.txt"}
@@ -316,7 +300,7 @@ def test_requests_request_file_request_already_exists(client_with_user):
 
 def test_requests_request_file_request_path_does_not_exist(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
-    WorkspaceFactory("test1")
+    factories.create_workspace("test1")
 
     response = client.post(
         "/workspaces/request-file/test1", data={"path": "test/path.txt"}
@@ -326,11 +310,11 @@ def test_requests_request_file_request_path_does_not_exist(client_with_user):
 
 
 def test_request_release_files_success(client_with_permission, release_files_stubber):
-    rf = WorkspaceFactory("workspace").create_request("request_id")
-    rf.write_file("test/file1.txt", "test1")
-    rf.write_file("test/file2.txt", "test2")
+    request = factories.create_request("workspace", request_id="request_id")
+    factories.write_request_file(request, "test/file1.txt", "test1")
+    factories.write_request_file(request, "test/file2.txt", "test2")
 
-    api_responses = release_files_stubber(rf.get())
+    api_responses = release_files_stubber(request)
     response = client_with_permission.post("/requests/release/request_id")
 
     assert response.status_code == 302
@@ -340,13 +324,13 @@ def test_request_release_files_success(client_with_permission, release_files_stu
 
 
 def test_requests_release_files_403(client_with_permission, release_files_stubber):
-    rf = WorkspaceFactory("workspace").create_request("request_id")
-    rf.write_file("test/file.txt", "test")
+    request = factories.create_request("workspace", request_id="request_id")
+    factories.write_request_file(request, "test/file.txt", "test")
 
     response = requests.Response()
     response.status_code = 403
     api403 = requests.HTTPError(response=response)
-    release_files_stubber(rf.get(), body=api403)
+    release_files_stubber(request, body=api403)
 
     # test 403 is handled
     response = client_with_permission.post("/requests/release/request_id")
@@ -355,14 +339,14 @@ def test_requests_release_files_403(client_with_permission, release_files_stubbe
 
 
 def test_requests_release_files_404(client_with_permission, release_files_stubber):
-    rf = WorkspaceFactory("workspace").create_request("request_id")
-    rf.write_file("test/file.txt", "test")
+    request = factories.create_request("workspace", request_id="request_id")
+    factories.write_request_file(request, "test/file.txt", "test")
 
     # test 404 results in 500
     response = requests.Response()
     response.status_code = 404
     api403 = requests.HTTPError(response=response)
-    release_files_stubber(rf.get(), body=api403)
+    release_files_stubber(request, body=api403)
 
     with pytest.raises(requests.HTTPError):
         client_with_permission.post("/requests/release/request_id")

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -45,7 +45,7 @@ def tmp_request(tmp_workspace):
     return tmp_workspace.create_request(request_id)
 
 
-def test_workspace_view_index(client_with_permission, tmp_workspace):
+def test_workspace_view(client_with_permission, tmp_workspace):
     tmp_workspace.write_file("file.txt")
     response = client_with_permission.get(f"/workspaces/view/{tmp_workspace.name}/")
     assert "file.txt" in response.rendered_content
@@ -143,18 +143,62 @@ def test_workspaces_index_user_permitted_workspaces(client_with_user, tmp_worksp
     assert "test2" not in response.rendered_content
 
 
-def test_request_view_index_no_user(client, tmp_request):
-    response = client.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
+def test_workspace_request_file_creates(client_with_user):
+    client = client_with_user({"workspaces": ["test1"]})
+    user = User.from_session(client.session)
+
+    wf = WorkspaceFactory("test1")
+    wf.write_file("test/path.txt")
+    workspace = wf.get()
+
+    assert workspace.get_current_request(user) is None
+
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
     )
+    assert response.status_code == 302
+
+    request = workspace.get_current_request(user)
+    assert request.request_id.endswith(user.username)
+    assert request.get_path("test/path.txt").exists()
+
+
+def test_workspace_request_file_request_already_exists(client_with_user):
+    client = client_with_user({"workspaces": ["test1"]})
+    user = User.from_session(client.session)
+
+    wf = WorkspaceFactory("test1")
+    workspace = wf.get()
+    wf.write_file("test/path.txt")
+    request = wf.create_request_for_user(user).get()
+
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
+    )
+    assert response.status_code == 302
+    assert workspace.get_current_request(user) == request
+    assert request.get_path("test/path.txt").exists()
+
+
+def test_workspace_request_file_request_path_does_not_exist(client_with_user):
+    client = client_with_user({"workspaces": ["test1"]})
+    WorkspaceFactory("test1")
+
+    response = client.post(
+        "/workspaces/request-file/test1", data={"path": "test/path.txt"}
+    )
+
+    assert response.status_code == 404
+
+
+def test_request_index_no_user(client, tmp_request):
+    response = client.get(f"/requests/view/{tmp_request.request_id}/")
     assert response.status_code == 302
 
 
 def test_request_view_index(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
-    response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/"
-    )
+    response = client_with_permission.get(f"/requests/view/{tmp_request.request_id}/")
     assert "file.txt" in response.rendered_content
 
 
@@ -164,16 +208,14 @@ def test_request_workspace_does_not_exist(client_with_permission):
 
 
 def test_request_id_does_not_exist(client_with_permission, tmp_workspace):
-    response = client_with_permission.get(
-        f"/requests/view/{tmp_workspace.name}/bad_id/"
-    )
+    response = client_with_permission.get("/requests/view/bad_id/")
     assert response.status_code == 404
 
 
 def test_request_view_with_directory(client_with_permission, tmp_request):
     tmp_request.write_file("some_dir/file.txt")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        f"/requests/view/{tmp_request.request_id}/some_dir/"
     )
     assert "file.txt" in response.rendered_content
 
@@ -181,14 +223,14 @@ def test_request_view_with_directory(client_with_permission, tmp_request):
 def test_request_view_with_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt", "foobar")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        f"/requests/view/{tmp_request.request_id}/file.txt"
     )
     assert "foobar" in response.rendered_content
 
 
 def test_request_view_with_404(client_with_permission, tmp_request):
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/no_such_file.txt"
+        f"/requests/view/{tmp_request.request_id}/no_such_file.txt"
     )
     assert response.status_code == 404
 
@@ -196,28 +238,28 @@ def test_request_view_with_404(client_with_permission, tmp_request):
 def test_request_view_redirects_to_directory(client_with_permission, tmp_request):
     tmp_request.mkdir("some_dir")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir"
+        f"/requests/view/{tmp_request.request_id}/some_dir"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/some_dir/"
+        == f"/requests/view/{tmp_request.request_id}/some_dir/"
     )
 
 
 def test_request_view_redirects_to_file(client_with_permission, tmp_request):
     tmp_request.write_file("file.txt")
     response = client_with_permission.get(
-        f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt/"
+        f"/requests/view/{tmp_request.request_id}/file.txt/"
     )
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == f"/requests/view/{tmp_request.workspace}/{tmp_request.request_id}/file.txt"
+        == f"/requests/view/{tmp_request.request_id}/file.txt"
     )
 
 
-def test_requests_index_user_permitted_requests(client_with_user):
+def test_request_index_user_permitted_requests(client_with_user):
     permitted_client = client_with_user({"workspaces": ["test1"]})
     user = User.from_session(permitted_client.session)
     rf = WorkspaceFactory("test1").create_request_for_user(user)
@@ -226,7 +268,7 @@ def test_requests_index_user_permitted_requests(client_with_user):
     assert request_ids == {rf.request_id}
 
 
-def test_requests_index_user_output_checker(client_with_user):
+def test_request_index_user_output_checker(client_with_user):
     WorkspaceFactory("test1").create_request("test-request1")
     WorkspaceFactory("test2").create_request("test-request2")
     permitted_client = client_with_user({"workspaces": [], "output_checker": True})
@@ -283,13 +325,13 @@ def test_requests_request_file_request_path_does_not_exist(client_with_user):
     assert response.status_code == 404
 
 
-def test_requests_release_files_success(client_with_permission, release_files_stubber):
+def test_request_release_files_success(client_with_permission, release_files_stubber):
     rf = WorkspaceFactory("workspace").create_request("request_id")
     rf.write_file("test/file1.txt", "test1")
     rf.write_file("test/file2.txt", "test2")
 
     api_responses = release_files_stubber(rf.get())
-    response = client_with_permission.post("/requests/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/request_id")
 
     assert response.status_code == 302
 
@@ -307,7 +349,7 @@ def test_requests_release_files_403(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     # test 403 is handled
-    response = client_with_permission.post("/requests/release/workspace/request_id")
+    response = client_with_permission.post("/requests/release/request_id")
 
     assert response.status_code == 403
 
@@ -323,4 +365,4 @@ def test_requests_release_files_404(client_with_permission, release_files_stubbe
     release_files_stubber(rf.get(), body=api403)
 
     with pytest.raises(requests.HTTPError):
-        client_with_permission.post("/requests/release/workspace/request_id")
+        client_with_permission.post("/requests/release/request_id")

--- a/tests/unit/test_workspace_api.py
+++ b/tests/unit/test_workspace_api.py
@@ -16,7 +16,7 @@ from airlock.workspace_api import (
     get_requests_for_user,
     get_workspaces_for_user,
 )
-from tests.factories import WorkspaceFactory
+from tests import factories
 
 
 @pytest.mark.parametrize(
@@ -29,8 +29,8 @@ from tests.factories import WorkspaceFactory
     ],
 )
 def test_get_workspaces_for_user(user_workspaces, output_checker, expected):
-    WorkspaceFactory("allowed")
-    WorkspaceFactory("not-allowed")
+    factories.create_workspace("allowed")
+    factories.create_workspace("not-allowed")
 
     user = User(1, "test", user_workspaces, output_checker)
     assert set(get_workspaces_for_user(user)) == set(expected)
@@ -47,7 +47,7 @@ def test_get_workspaces_for_user(user_workspaces, output_checker, expected):
             [
                 ("allowed", "r1-test"),
                 ("not-allowed", "r3-test"),
-                ("allowed", "r2-otheruser"),
+                ("allowed", "r2-other"),
             ],
         ),
         (["allowed", "notexist"], False, [("allowed", "r1-test")]),
@@ -56,12 +56,13 @@ def test_get_workspaces_for_user(user_workspaces, output_checker, expected):
     ],
 )
 def test_get_requests_for_user(workspaces, output_checker, expected):
-    WorkspaceFactory("allowed").create_request("r1-test")
-    WorkspaceFactory("allowed").create_request("r2-otheruser")
-    WorkspaceFactory("not-allowed").create_request("r3-test")
-    WorkspaceFactory("no-request-dir")
-    expected_requests = set(ReleaseRequest(Workspace(w), rid) for (w, rid) in expected)
     user = User(1, "test", workspaces, output_checker)
+    other_user = User(1, "other", [], False)
+    factories.create_request("allowed", user, "r1-test")
+    factories.create_request("allowed", other_user, "r2-other")
+    factories.create_request("not-allowed", user, "r3-test")
+    factories.create_workspace("no-request-dir")
+    expected_requests = set(ReleaseRequest(Workspace(w), rid) for (w, rid) in expected)
     assert set(get_requests_for_user(user)) == expected_requests
 
 
@@ -74,14 +75,13 @@ def test_workspace_container():
 
 
 def test_workspace_get_current_request_for_user():
-    wf = WorkspaceFactory("workspace")
-    workspace = wf.get()
+    workspace = factories.create_workspace("workspace")
     user = User(1, "testuser", [], True)
     other_user = User(2, "otheruser", [], True)
 
     assert workspace.get_current_request(user) is None
 
-    wf.create_request_for_user(other_user)
+    factories.create_request(workspace, other_user)
     assert workspace.get_current_request(user) is None
 
     request = workspace.get_current_request(user, create=True)
@@ -97,17 +97,15 @@ def test_workspace_get_current_request_for_user():
 
 
 def test_workspace_create_new_request():
-    wf = WorkspaceFactory("workspace")
-    workspace = wf.get()
     user = User(1, "testuser", [], True)
+    request = factories.create_request("workspace", user)
 
-    request = workspace.create_new_request(user)
     assert request.workspace.name == "workspace"
     assert request.request_id.endswith("testuser")
 
 
 def test_request_container():
-    workspace = Workspace("test-workspace")
+    workspace = factories.create_workspace("test-workspace")
 
     output_request = ReleaseRequest(workspace, "test-request")
 
@@ -132,9 +130,8 @@ def mock_old_api(monkeypatch):
 def test_request_release_files(mock_old_api):
     old_api.create_release.return_value = "jobserver_id"
     user = User(1, "testuser", [], True)
-    rf = WorkspaceFactory("workspace").create_request("request_id")
-    rf.write_file("test/file.txt", "test")
-    request = rf.get()
+    request = factories.create_request("workspace", user, request_id="request_id")
+    factories.write_request_file(request, "test/file.txt", "test")
 
     request.release_files(user)
 


### PR DESCRIPTION
- Fix left over use of the term "output_request"
- Explict view urls
- Remove workspace from request url paths
- Refactor the test factories
