### PR TITLE
Add coverage for django templates

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -77,7 +77,6 @@ ul.tree {
 {% endfragment %}
 
 {% #card title=title custom_button=action_button %}  
-
 {% if context == "request" %}
 {% #description_item title="Status:" %}{{ release_request.status.name }}{% /description_item %}
 {% endif %}

--- a/airlock/templates/login.html
+++ b/airlock/templates/login.html
@@ -2,15 +2,6 @@
 
 {% block metatitle %}Login | OpenSAFELY Airlock{% endblock metatitle %}
 
-{% block breadcrumbs %}
-  {% url "home" as home_url %}
-
-  {% #breadcrumbs %}
-    {% breadcrumb title="Home" url=home_url %}
-    {% breadcrumb title="Login" active=True %}
-  {% /breadcrumbs %}
-{% endblock breadcrumbs %}
-
 {% block content %}
 <section class="flex flex-col max-w-2xl gap-y-4">
   <h1 class="text-3xl break-words font-bold text-slate-900 mt-2 md:mt-0 md:col-span-3 md:text-4xl">

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -300,7 +300,7 @@ def request_release_files(request, request_id):
     except api.RequestPermissionDenied as exc:
         raise PermissionDenied(str(exc))
     except requests.HTTPError as err:
-        if settings.DEBUG:  # pragma: nocover
+        if settings.DEBUG:
             return TemplateResponse(
                 request,
                 "jobserver-error.html",

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -37,6 +37,8 @@ def login(request):
 
     if request.method != "POST":
         next_url = request.GET.get("next", default_next_url)
+        if request.user is not None:
+            return redirect(next_url)
         token_login_form = TokenLoginForm()
     else:
         next_url = request.POST.get("next", default_next_url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,9 @@ exclude_also = [
     # this indicates that a method should be defined in a subclass
     "raise NotImplementedError",
 ]
+
+[tool.coverage.django_coverage_plugin]
+template_extensions = "html"
+exclude_blocks = [
+    "\\/\\w+"
+]

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -9,3 +9,6 @@ pytest-cov
 pytest-django
 pytest-playwright
 responses
+# Currently using our fork of django_coverage_plugin, pending
+# upstream PR https://github.com/nedbat/django_coverage_plugin/pull/93
+https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -168,6 +168,9 @@ coverage==7.4.0 \
     # via
     #   coverage
     #   pytest-cov
+django-coverage-plugin @ https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip \
+    --hash=sha256:db70db8737dd269c346f7af6e0c735a3d6462b944302f6bc0178c7bac9a4c7ee
+    # via -r requirements.dev.in
 greenlet==3.0.3 \
     --hash=sha256:01bc7ea167cf943b4c802068e178bbf70ae2e8c080467070d01bfa02f337ee67 \
     --hash=sha256:0448abc479fab28b00cb472d278828b3ccca164531daab4e970a0458786055d6 \

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -47,7 +47,11 @@ def write_request_file(request, path, contents=""):
     path.write_text(contents)
 
 
-def create_filegroup(release_request, group_name):
+def create_filegroup(release_request, group_name, filepaths=None):
+    for filepath in filepaths or []:
+        api.add_file_to_request(
+            release_request, filepath, User(1, release_request.author), group_name
+        )
     return api._get_or_create_filegroupmetadata(release_request.id, group_name)
 
 

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -6,6 +6,12 @@ import pytest
 pytestmark = pytest.mark.django_db
 
 
+def test_login_get(client):
+    response = client.get("/login/")
+    assert response.status_code == 200
+    assert "token_login_form" in response.context
+
+
 @mock.patch("airlock.login_api.requests.post", autospec=True)
 def test_login(requests_post, client, settings):
     settings.AIRLOCK_API_TOKEN = "test_api_token"

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -12,6 +12,16 @@ def test_login_get(client):
     assert "token_login_form" in response.context
 
 
+def test_login_already_logged_in(client):
+    session_user = {"id": 1, "username": "test"}
+    session = client.session
+    session["user"] = session_user
+    session.save()
+    response = client.get("/login/")
+    assert response.status_code == 302
+    assert response.url == ("/workspaces/")
+
+
 @mock.patch("airlock.login_api.requests.post", autospec=True)
 def test_login(requests_post, client, settings):
     settings.AIRLOCK_API_TOKEN = "test_api_token"

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -307,11 +307,27 @@ def test_request_view_with_directory(client_with_permission, ui_options):
 
 def test_request_view_with_file(client_with_permission, ui_options):
     release_request = factories.create_release_request("workspace")
-    factories.write_request_file(release_request, "file.txt", "foobar")
+    factories.write_workspace_file("workspace", "file.txt", "foobar")
+    factories.create_filegroup(
+        release_request,
+        group_name="default_group",
+        filepaths=["file.txt"]
+    )
+
     response = client_with_permission.get(
         f"/requests/view/{release_request.id}/file.txt"
     )
+    assert "default_group" in response.rendered_content
     assert "foobar" in response.rendered_content
+
+
+def test_request_view_with_submitted_request(client_with_permission, ui_options):
+    release_request = factories.create_release_request("workspace", status=Status.SUBMITTED)
+    response = client_with_permission.get(
+        f"/requests/view/{release_request.id}", follow=True
+    )
+    assert "Reject Request" in response.rendered_content
+    assert "Release Files" in response.rendered_content
 
 
 def test_request_view_with_404(client_with_permission):


### PR DESCRIPTION
Adds coverage for templates, using the existing django_coverage_plugin, but with a tweak to handle slippers components.
This means we (hopefully temporarily) have our own [fork](https://github.com/opensafely-core/django_coverage_plugin) of the plugin, until [this PR](https://github.com/nedbat/django_coverage_plugin/pull/93) gets in. Without it, any slippers component end tags that are on their own line - which is lots of them - get marked as uncovered.

As a result of writing the tests for the uncovered template lines, I found a breadcrumbs block in the login template that was unused, and noticed that if you go to the login page when you're already logged in, you weren't getting redirect anywhere, you just got the login page again.