### PR TITLE
Split API for authored requests vs requests to review

### DIFF
--- a/airlock/api.py
+++ b/airlock/api.py
@@ -224,8 +224,12 @@ class ProviderAPI:
         """
         raise NotImplementedError()
 
-    def get_requests_for_user(self, user: User) -> list[ReleaseRequest]:
-        """Get all current requests authored by user"""
+    def get_requests_authored_by_user(self, user: User) -> list[ReleaseRequest]:
+        """Get all current requests authored by user."""
+        raise NotImplementedError()
+
+    def get_outstanding_requests_for_review(self, user: User):
+        """Get all request that need review."""
         raise NotImplementedError()
 
     VALID_STATE_TRANSITIONS = {

--- a/airlock/templates/requests.html
+++ b/airlock/templates/requests.html
@@ -1,11 +1,23 @@
 {% extends "base.html" %}
 
 {% block content %}
-{% #card title="Requests for "|add:request.user.username %}
+
+{% #card title="Requests by "|add:request.user.username %}
   {% #list_group %}
-    {% for request in requests %} 
-    {% #list_group_item href=request.get_absolute_url %}{{ request.id }}{% /list_group_item %}
+    {% for request in authored_requests %} 
+    {% #list_group_item href=request.get_absolute_url %}{{ request.workspace }}: {{ request.status.name }}{% /list_group_item %}
     {% endfor %}
   {% /list_group %}
 {% /card %}
+
+{% if request.user.output_checker %}
+{% #card title="Outstanding requests awaiting review" %}
+  {% #list_group %}
+    {% for request in outstanding_requests %} 
+    {% #list_group_item href=request.get_absolute_url %}{{ request.workspace }} by {{ request.author }}{% /list_group_item %}
+    {% endfor %}
+  {% /list_group %}
+{% /card %}
+{% endif %}
+
 {% endblock content %}

--- a/airlock/views.py
+++ b/airlock/views.py
@@ -161,8 +161,20 @@ def workspace_add_file_to_request(request, workspace_name):
 
 
 def request_index(request):
-    requests = api.get_requests_for_user(request.user)
-    return TemplateResponse(request, "requests.html", {"requests": requests})
+    authored_requests = api.get_requests_authored_by_user(request.user)
+
+    outstanding_requests = []
+    if request.user.output_checker:
+        outstanding_requests = api.get_outstanding_requests_for_review(request.user)
+
+    return TemplateResponse(
+        request,
+        "requests.html",
+        {
+            "authored_requests": authored_requests,
+            "outstanding_requests": outstanding_requests,
+        },
+    )
 
 
 def request_view(request, request_id: str, path: str = ""):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -101,21 +101,17 @@ def test_provider_request_release_files(mock_old_api):
     [
         ([], False, []),
         (["allowed"], False, ["r1"]),
-        (
-            [],
-            True,
-            [
-                "r1",
-                "r2",
-                "r3",
-            ],
-        ),
+        # output checkers can't create requests unless explit permission for workspace
+        ([], True, []),
+        (["allowed"], True, ["r1"]),
         (["allowed", "notexist"], False, ["r1"]),
-        (["notexist", "notexist"], False, []),
+        (["notexist"], False, []),
         (["no-request-dir", "notexist"], False, []),
     ],
 )
-def test_provider_get_requests_for_user(workspaces, output_checker, expected, api):
+def test_provider_get_requests_authored_by_user(
+    workspaces, output_checker, expected, api
+):
     user = User(1, "test", workspaces, output_checker)
     other_user = User(1, "other", [], False)
     factories.create_release_request("allowed", user, id="r1")
@@ -123,7 +119,7 @@ def test_provider_get_requests_for_user(workspaces, output_checker, expected, ap
     factories.create_release_request("not-allowed", user, id="r3")
     factories.create_workspace("no-request-dir")
 
-    assert set(r.id for r in api.get_requests_for_user(user)) == set(expected)
+    assert set(r.id for r in api.get_requests_authored_by_user(user)) == set(expected)
 
 
 def test_provider_get_current_request_for_user(api):


### PR DESCRIPTION
Previously, the same function retrieved both sets.  Now, there are
separate API functions, and the Eequests page lists them separatedly.

Specifically, as now an author who is also and output checker cannot
review their own request, then those requests are exclude from the "to
review" list.
