### PR TITLE
Add support for adding a file to a new or existing file group on a request

### DIFF
--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -1,0 +1,30 @@
+from django import forms
+
+
+class AddFileForm(forms.Form):
+    filegroup = forms.ChoiceField(required=False)
+    new_filegroup = forms.CharField(required=False)
+
+    def __init__(self, *args, **kwargs):
+        release_request = kwargs.pop("release_request")
+        super().__init__(*args, **kwargs)
+        if release_request:
+            self.filegroup_names = {group.name for group in release_request.filegroups}
+        else:
+            self.filegroup_names = set()
+        group_choices = {
+            (name, name) for name in self.filegroup_names if name != "default"
+        }
+        group_choices = [("default", "default"), *sorted(group_choices)]
+        self.fields["filegroup"].choices = group_choices
+        self.fields["new_filegroup"]
+
+    def clean_new_filegroup(self):
+        new_filegroup = self.cleaned_data.get("new_filegroup").lower()
+        if new_filegroup in [fg.lower() for fg in self.filegroup_names]:
+            self.add_error(
+                "new_filegroup",
+                f"File group with name '{new_filegroup}' already exists",
+            )
+        else:
+            return new_filegroup

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load django_vite %}
+
 {% block full_width_content %}
 
 {% fragment as action_button %}
@@ -91,14 +93,25 @@
       {% /card %}
 
     {% else %}
-
       {% fragment as add_button %}
         {% if context == "workspace" %}
-          <form action="{{ request_file_url }}" method="POST">
-            {% csrf_token %}
-            <input type=hidden name="path" value="{{ path_item.relpath }}"/>
-            {% #button type="submit" tooltip="Add this file to the current request, starting a new one if needed" variant="success" %}Add File to Request{% /button %}
-          </form>
+            {% #button variant="success" type="button" tooltip="Add this file to the current request, starting a new one if needed" data-modal="addRequestFile" id="add-file-button"%}
+              Add File to Request
+            {% /button %}
+            {% #modal id="addRequestFile" %}
+              {% #card container=True title="Add a file" %}
+                <form action="{{ request_file_url }}" method="POST">
+                  {% csrf_token %}
+                  {% form_select class="w-full max-w-lg mx-auto" label="Select a file group" field=form.filegroup choices=form.filegroup.field.choices %}
+                  {% form_input class="w-full max-w-lg mx-auto" label="Or create a new file group" field=form.new_filegroup %}
+                  <input type=hidden name="path" value="{{ path_item.relpath }}"/>
+                  <div class="mt-2">
+                    {% #button type="submit" variant="success" %}Add File to Request{% /button %}
+                    {% #button variant="danger" type="cancel" %}Cancel{% /button %}
+                  </div>
+                </form>
+                {% /card %}
+            {% /modal %}
         {% elif is_author %}
           <form action="" method="POST">
             {% csrf_token %}
@@ -133,3 +146,7 @@
 </div>
 
 {% endblock full_width_content %}
+
+{% block extra_js %}
+  {% vite_asset "templates/_components/modal/modal.js" %}
+{% endblock %}

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -67,7 +67,33 @@
           {% endfor %}
         {% endif %}
       {% /list_group %}
-    {% /card %}
+
+    {% #card_footer no_container=False %}
+      {% if context == "request" %}
+        <div class="px-4">
+          {% #button variant="primary-outline" type="button" data-modal="viewFileGroups" %}
+            View File Groups
+          {% /button %}
+        </div>
+        {% #modal id="viewFileGroups" %}
+          {% #card container=True title="File Groups for this request" %}
+            {% for group in release_request.filegroups %}
+              {{ group.name}}
+              {% #list_group %}
+              {% for file in group.files %}
+                {% #list_group_item %}
+                  {{ file.relpath }}
+                {% /list_group_item %}
+              {% endfor %}
+              {% /list_group %}
+            {% endfor %}
+            {% #button variant="secondary" type="cancel" %}Close{% /button %}
+          {% /card %}
+        {% /modal %}
+        {% endif %}
+      {% /card_footer %}
+
+  {% /card %}
 
   </div>
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -49,3 +49,7 @@ def write_request_file(request, path, contents=""):
 
 def create_filegroup(release_request, group_name):
     return api._get_or_create_filegroupmetadata(release_request.id, group_name)
+
+
+def refresh_release_request(release_request):
+    return api.get_release_request(release_request.id)

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -1,0 +1,67 @@
+import pytest
+
+from airlock.forms import AddFileForm
+from tests import factories
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_add_file_form_no_release_request():
+    form = AddFileForm(release_request=None)
+    assert form.fields["filegroup"].choices == [("default", "default")]
+
+
+def test_add_file_form_empty_release_request():
+    release_request = factories.create_release_request("workspace")
+    form = AddFileForm(release_request=release_request)
+    assert form.fields["filegroup"].choices == [("default", "default")]
+
+
+def test_add_file_form_filegroup_choices():
+    release_request = factories.create_release_request("workspace")
+    for group in ["b_group", "a_group"]:
+        factories.create_filegroup(release_request, group)
+    release_request = factories.refresh_release_request(release_request)
+
+    other_release_request = factories.create_release_request("workspace1")
+    factories.create_filegroup(other_release_request, "other_group")
+
+    form = AddFileForm(release_request=release_request)
+    # default group is always first, other choices are sorted
+    assert form.fields["filegroup"].choices == [
+        ("default", "default"),
+        ("a_group", "a_group"),
+        ("b_group", "b_group"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "new_group_name,is_valid",
+    [
+        # Can create a new default group if one doesn't already exist
+        ("default", True),
+        # Can't create a duplicate group
+        ("test", False),
+        # Can't create a duplicate group, case insensitive
+        ("Test", False),
+        # Can create a group with the same name as a group on another request
+        ("test 1", True),
+    ],
+)
+def test_add_file_form_new_filegroup(new_group_name, is_valid):
+    release_request = factories.create_release_request("workspace")
+    factories.create_filegroup(release_request, "test")
+    release_request = factories.refresh_release_request(release_request)
+
+    other_release_request = factories.create_release_request("workspace1")
+    factories.create_filegroup(other_release_request, "test 1")
+
+    data = {
+        # a filegroup is always in the POST data, ignored if
+        # new_filegroup also present
+        "filegroup": "default",
+        "new_filegroup": new_group_name,
+    }
+    form = AddFileForm(data, release_request=release_request)
+    assert form.is_valid() == is_valid


### PR DESCRIPTION
Fixes #77 

Adds a modal to the "Add file to request" button, with an option to select a file group, or to add a name to create a new one. 
![Screenshot from 2024-02-19 11-44-29](https://github.com/opensafely-core/airlock/assets/6770950/f010d8f3-8500-4909-911b-6a4cbd726b9d)

For now, in the release request view, I've added a button and modal to view the file groups. I expect this will change with the new tree browser UI, so this is intended to be just a temporary (and easily removable) way of seeing which files have been added to which groups. 
![Screenshot from 2024-02-19 11-45-56](https://github.com/opensafely-core/airlock/assets/6770950/6566b535-347f-470d-bd9f-b907b0357713)
![Screenshot from 2024-02-19 11-48-25](https://github.com/opensafely-core/airlock/assets/6770950/e43998a1-668d-47a1-ad3e-1ad9cd7e40f4)

