### PR TITLE
Move utility functions from api.py to old_api

### DIFF
--- a/airlock/api.py
+++ b/airlock/api.py
@@ -1,7 +1,6 @@
 import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
-from datetime import timezone as stdlib_timezone
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -11,11 +10,6 @@ from django.shortcuts import reverse
 
 import old_api
 from airlock.users import User
-
-
-def modified_time(path):
-    mtime = path.stat().st_mtime
-    return datetime.fromtimestamp(mtime, tz=stdlib_timezone.utc).isoformat()
 
 
 class Status(Enum):
@@ -48,13 +42,6 @@ class AirlockContainer:
 
     def get_url_for_path(self):
         raise NotImplementedError()
-
-    def filelist(self):
-        """List all files recursively."""
-        path = self.root()
-        return list(
-            sorted(p.relative_to(path) for p in path.glob("**/*") if p.is_file())
-        )
 
 
 @dataclass(frozen=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 import responses as _responses
 from django.conf import settings
 
+import old_api
 import tests.factories
 from local_db.api import LocalDBProvider
 
@@ -49,7 +50,7 @@ def release_files_stubber(responses):
         )
 
         if not isinstance(body, Exception):
-            for path in request.filelist():
+            for path in old_api.list_files(request.root()):
                 responses.post(
                     f"{settings.AIRLOCK_API_ENDPOINT}/releases/release/{jobserver_id}",
                     status=201,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import old_api
-from airlock.api import ProviderAPI, Status, Workspace, modified_time
+from airlock.api import ProviderAPI, Status, Workspace
 from airlock.users import User
 from tests import factories
 
@@ -79,7 +79,7 @@ def test_provider_request_release_files(mock_old_api):
                 "url": "test/file.txt",
                 "size": 4,
                 "sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
-                "date": modified_time(abspath),
+                "date": old_api.modified_time(abspath),
                 "metadata": {"tool": "airlock"},
                 "review": None,
             }


### PR DESCRIPTION
They didn't really belong in the main API, as they're only used for
talking to job server.