### PR TITLE
Be strict about missing template variables

### DIFF
--- a/airlock/templates/base.html
+++ b/airlock/templates/base.html
@@ -12,7 +12,7 @@
 
     {% block extra_meta %}{% endblock %}
 
-    <script type="module" nonce="{{ request.csp_nonce }}">
+    <script type="module">
       document.documentElement.classList.remove("no-js");
       document.documentElement.classList.add("js");
 

--- a/airlock/templates/base.html
+++ b/airlock/templates/base.html
@@ -79,7 +79,7 @@
                 </a>
             </li>
             {% endfor %}
-            {% if not request.user.is_authenticated %}
+            {% if not request.user or not request.user.is_authenticated %}
             <li>
                 <a
                 class="


### PR DESCRIPTION
We achieve this by converting them into warnings and then relying on our "zero warnings in tests" enforcement to catch them.

This means it's still possible to exploit the default missing variable behaviour when hacking around locally, but it shouldn't be possible to get these into production. And it should be obvious from the console output that there are missing variables.

Closes #84