### PR TITLE
Unfreeze core objects.

### DIFF
--- a/local_db/api.py
+++ b/local_db/api.py
@@ -135,7 +135,7 @@ class LocalDBProvider(ProviderAPI):
         relpath: Path,
         user: User,
         group_name: Optional[str] = "default",
-    ) -> ReleaseRequest:
+    ):
         with transaction.atomic():
             # Get/create the FileGroupMetadata if it doesn't already exist
             filegroupmetadata = self._get_or_create_filegroupmetadata(
@@ -163,5 +163,6 @@ class LocalDBProvider(ProviderAPI):
             # state that allows adding files.
             super().add_file_to_request(release_request, relpath, user, group_name)
 
-        # return a new request object with the updated groups
-        return self._request(self._find_metadata(release_request.id))
+        # update instance
+        metadata = self._find_metadata(release_request.id)
+        release_request.filegroups = self._get_filegroups(metadata)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -294,7 +294,7 @@ def test_release_request_filegroups_with_no_files(api):
 def test_release_request_filegroups_default_filegroup(api):
     release_request, path, author = setup_empty_release_request()
     assert release_request.filegroups == {}
-    release_request = api.add_file_to_request(release_request, path, author)
+    api.add_file_to_request(release_request, path, author)
     assert len(release_request.filegroups) == 1
     filegroup = release_request.filegroups["default"]
     assert filegroup.name == "default"
@@ -305,9 +305,7 @@ def test_release_request_filegroups_default_filegroup(api):
 def test_release_request_filegroups_named_filegroup(api):
     release_request, path, author = setup_empty_release_request()
     assert release_request.filegroups == {}
-    release_request = api.add_file_to_request(
-        release_request, path, author, "test_group"
-    )
+    api.add_file_to_request(release_request, path, author, "test_group")
     assert len(release_request.filegroups) == 1
     filegroup = release_request.filegroups["test_group"]
     assert filegroup.name == "test_group"
@@ -317,9 +315,7 @@ def test_release_request_filegroups_named_filegroup(api):
 
 def test_release_request_filegroups_multiple_filegroups(api):
     release_request, path, author = setup_empty_release_request()
-    release_request = api.add_file_to_request(
-        release_request, path, author, "test_group"
-    )
+    api.add_file_to_request(release_request, path, author, "test_group")
     assert len(release_request.filegroups) == 1
 
     workspace = api.get_workspace("workspace")
@@ -347,7 +343,7 @@ def test_release_request_filegroups_multiple_filegroups(api):
 def test_release_request_add_same_file(api):
     release_request, path, author = setup_empty_release_request()
     assert release_request.filegroups == {}
-    release_request = api.add_file_to_request(release_request, path, author)
+    api.add_file_to_request(release_request, path, author)
     assert len(release_request.filegroups) == 1
     assert len(release_request.filegroups["default"].files) == 1
 


### PR DESCRIPTION
Update the two places we mutate state to mutate the object.

Manually made Workspace hashable, for convenience in tests, but also it
is just one bit of immutable data.