### PR TITLE
End to end tests for creating, releasing and rejecting requests

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -99,6 +99,17 @@ Additional arguments passed to `just test` are passed on to pytest. For example,
 run all the tests _except_ the functional tests, run `just test -k 'not functional'`,
 or to run a single test, run e.g. `just test tests/unit/test_urls.py::test_urls`.
 
+### Debugging functional tests
+
+Functional tests run headless by default. To see what's going on, they
+can be run in headed mode. The follwoing command will run just the
+functional tests, in headed mode, slowed down by 500ms. See the
+[playwright docs](https://playwright.dev/python/docs/test-runners#cli-arguments) for additional cli arguments that may be
+useful.
+
+```
+just test -k functional --headed --slowmo 500
+```
 
 # Local job-server for integration.
 

--- a/airlock/templates/base.html
+++ b/airlock/templates/base.html
@@ -73,6 +73,7 @@
                     {% if location.is_active %}border-t-oxford-600/50 text-oxford-600{% endif %}
                 "
                 href="{{ location.url }}"
+                data-testid="nav-{{ location.name|lower }}"
                 >
                 {{ location.name }}
                 {% if location.is_active %}<span class="sr-only">(current)</span>{% endif %}
@@ -89,6 +90,7 @@
                 "
                 href="{{ login_url }}"
                 rel="nofollow"
+                data-testid="nav-login"
                 >
                 Login
                 </a>
@@ -132,6 +134,7 @@
               "
               href="{{ logout_url }}"
               rel="nofollow"
+              data-testid="nav-logout"
               >
               Logout
               </a>

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -56,22 +56,22 @@ ul.tree {
             {% if release_request.status.name == "PENDING" %}
             <form action="{{ request_submit_url }}" method="POST">
                 {% csrf_token %}
-                {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button"%}Submit For Review{% /button %}
+                {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button" id="submit-for-review-button" %}Submit For Review{% /button %}
             </form>
             {% endif %}
         {% elif is_output_checker %}
             {% if release_request.status.name == "SUBMITTED" %}
             <form action="{{ request_reject_url }}" method="POST">
                 {% csrf_token %}
-                {% #button type="submit" tooltip="Reject this request" variant="danger" class="action-button"%}Reject Request{% /button %}
+                {% #button type="submit" tooltip="Reject this request" variant="danger" class="action-button" id="reject-request-button" %}Reject Request{% /button %}
             </form>
             <form action="{{ release_files_url }}" method="POST">
                 {% csrf_token %}
-                {% #button type="submit" tooltip="Release files to jobs.opensafely.org" variant="warning" %}Release Files{% /button %}
+                {% #button type="submit" tooltip="Release files to jobs.opensafely.org" variant="warning" id="release-files-button" %}Release Files{% /button %}
             </form>
             {% endif %}
         {% endif %}
-        {% #button type="link" href=workspace.get_url variant="success" %}Workspace Home{% /button %}
+        {% #button type="link" href=workspace.get_url variant="success" id="workspace-home-button" %}Workspace Home{% /button %}
     {% endif %}
 </div>
 {% endfragment %}
@@ -170,7 +170,7 @@ ul.tree {
     {% else %}
       {% fragment as add_button %}
         {% if context == "workspace" %}
-            {% #button variant="success" type="button" tooltip="Add this file to the current request, starting a new one if needed" data-modal="addRequestFile" id="add-file-button"%}
+            {% #button variant="success" type="button" tooltip="Add this file to the current request, starting a new one if needed" data-modal="addRequestFile" id="add-file-modal-button"%}
               Add File to Request
             {% /button %}
             {% #modal id="addRequestFile" %}
@@ -181,7 +181,7 @@ ul.tree {
                   {% form_input class="w-full max-w-lg mx-auto" label="Or create a new file group" field=form.new_filegroup %}
                   <input type=hidden name="path" value="{{ path_item.relpath }}"/>
                   <div class="mt-2">
-                    {% #button type="submit" variant="success" %}Add File to Request{% /button %}
+                    {% #button type="submit" variant="success" id="add-file-button" %}Add File to Request{% /button %}
                     {% #button variant="danger" type="cancel" %}Cancel{% /button %}
                   </div>
                 </form>

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -175,7 +175,7 @@ ul.tree {
             {% /button %}
             {% #modal id="addRequestFile" %}
               {% #card container=True title="Add a file" %}
-                <form action="{{ request_file_url }}" method="POST">
+                <form action="{{ request_file_url }}" method="POST" aria-label="add-file-form">
                   {% csrf_token %}
                   {% form_select class="w-full max-w-lg mx-auto" label="Select a file group" field=form.filegroup choices=form.filegroup.field.choices %}
                   {% form_input class="w-full max-w-lg mx-auto" label="Or create a new file group" field=form.new_filegroup %}

--- a/airlock/templates/requests.html
+++ b/airlock/templates/requests.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 {% #card title="Requests by "|add:request.user.username %}
-  {% #list_group %}
+  {% #list_group id="authored-requests" %}
     {% for request in authored_requests %} 
     {% #list_group_item href=request.get_url %}{{ request.workspace }}: {{ request.status.name }}{% /list_group_item %}
     {% endfor %}
@@ -12,7 +12,7 @@
 
 {% if request.user.output_checker %}
 {% #card title="Outstanding requests awaiting review" %}
-  {% #list_group %}
+  {% #list_group id="outstanding-requests" %}
     {% for request in outstanding_requests %} 
     {% #list_group_item href=request.get_url %}{{ request.workspace }} by {{ request.author }}{% /list_group_item %}
     {% endfor %}

--- a/airlock/templates/workspaces.html
+++ b/airlock/templates/workspaces.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 {% #card title="Workspaces for "|add:request.user.username %}
-  {% #list_group %}
+  {% #list_group id="workspaces" %}
     {% for workspace in workspaces %} 
     {% #list_group_item href=workspace.get_url %}{{ workspace.name }}{% /list_group_item %}
     {% endfor %}

--- a/assets/templates/_components/button.html
+++ b/assets/templates/_components/button.html
@@ -1,6 +1,6 @@
 {% if type == "link" %}
   <a
-    {% attrs data-table-pagination href %}
+    {% attrs data-table-pagination href id %}
     {% if external %}
       rel="noopener noreferrer"
       target="_blank"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,3 +59,9 @@ def release_files_stubber(responses):
         return responses
 
     return release_files
+
+
+# temporary fixture to test both UI options until we decide on one.
+@pytest.fixture(params=[True, False])
+def ui_options(request, settings):
+    settings.TREE = request.param

--- a/tests/integration/test_views.py
+++ b/tests/integration/test_views.py
@@ -36,12 +36,6 @@ def client_with_permission(client_with_user):
     yield client_with_user(output_checker)
 
 
-# temporary fixture to test both UI options until we decide on one.
-@pytest.fixture(params=[True, False])
-def ui_options(request, settings):
-    settings.TREE = request.param
-
-
 def test_workspace_view(client_with_permission, ui_options):
     factories.write_workspace_file("workspace", "file.txt")
 


### PR DESCRIPTION
Locally these two new e2e tests take 6.5s to run; that will be better when we've settled on a UI, but for now it seems worth running them with the ui_options fixture.

Fixes #79 