### PR TITLE
Add the settings and config for django-coverage-plugin

### DIFF
--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -118,6 +118,7 @@ TEMPLATES = [
             "builtins": [
                 "slippers.templatetags.slippers",  # required for assets library
             ],
+            "debug": DEBUG,  # required for template coverage
         },
     },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ DJANGO_SETTINGS_MODULE = "airlock.settings"
 branch = true
 # Required to get full coverage when using Playwright
 concurrency = ["greenlet", "thread"]
+plugins = ["django_coverage_plugin"]
+omit = ["*/assets/templates/*",]
 
 [tool.coverage.report]
 fail_under = 100


### PR DESCRIPTION
Somehow in #80 I managed not to commit the settings and pyproject.toml config that actual made the template coverage plugin run :facepalm:  