### PR TITLE
Run playwright tests with chrome v108

### DIFF
--- a/.test.env
+++ b/.test.env
@@ -9,3 +9,4 @@ AIRLOCK_WORK_DIR=workdir/
 # Ensure playwright browser binaries are installed to a path in the
 # mounted volume that the non-root docker user has access to
 PLAYWRIGHT_BROWSERS_PATH=/app/.playwright-browsers/
+PLAYWRIGHT_BROWSER_EXECUTABLE_PATH=/app/.playwright-browsers/chrome-linux/chrome

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -117,7 +117,10 @@ Additional arguments passed to `just test` are passed on to pytest. For example,
 run all the tests _except_ the functional tests, run `just test -k 'not functional'`,
 or to run a single test, run e.g. `just test tests/unit/test_urls.py::test_urls`.
 
-### Debugging functional tests
+
+### Functional tests
+
+#### Debugging
 
 Functional tests run headless by default. To see what's going on, they
 can be run in headed mode. The follwoing command will run just the
@@ -128,6 +131,21 @@ useful.
 ```
 just test -k functional --headed --slowmo 500
 ```
+
+#### Browser configuration
+
+By default, the functional tests run with the latest chromium browser only (the
+Playwright default). In order to test older/different browser version, you can
+pass an environment variable specifying a path to browser executable. E.g. to
+run with the system chrome at /usr/bin/google-chrome:
+
+```
+PLAYWRIGHT_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable just test -k functional
+```
+
+(To verify the custom browser executable, run with `-s` to print an info message to
+the console, or with `--headed` for headed mode.)
+
 
 # Local job-server for integration.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -179,7 +179,8 @@ RUN --mount=type=cache,target=/root/.cache \
     python -m pip install --require-hashes --requirement /tmp/requirements.dev.txt
 
 # Install playwright chromium dependencies. This needs to be done AFTER 
-# playwright is pip-installed
+# playwright is pip-installed. Although we don't use the default playwright
+# chromium browser, this gets us the system dependencies
 RUN playwright install-deps chromium
 
 # Override ENTRYPOINT rather than CMD so we can pass arbitrary commands to the entrypoint script

--- a/docker/justfile
+++ b/docker/justfile
@@ -26,9 +26,21 @@ build env="dev": _dotenv
     # build the thing
     docker compose build --pull {{ env }}
 
+# Fetch and extract the chromium version we need for testing 
+get-chromium:
+    #!/bin/bash
+    # We use chromium v108 for consistency with backends
+    # https://www.chromium.org/getting-involved/download-chromium/#downloading-old-builds-of-chrome-chromium
+    # The chrome executable after unzipping is at ../.playwright-browsers/chrome-linux/chrome
+    chrome_executable=../.playwright-browsers/chrome-linux/chrome
+    if [[ ! -f $chrome_executable ]]; then
+        mkdir -p ../.playwright-browsers
+        wget -O ../.playwright-browsers/chrome-linux.zip https://commondatastorage.googleapis.com/chromium-browser-snapshots/Linux_x64/1058929/chrome-linux.zip
+        unzip ../.playwright-browsers/chrome-linux.zip -d ../.playwright-browsers/ && rm ../.playwright-browsers/chrome-linux.zip
+    fi
 
 # run tests in dev container
-test *pytest_args="": _dotenv build
+test *pytest_args="": _dotenv build get-chromium
     #!/bin/bash
     # Note, we do *not* run coverage in docker, as we want to use xdist, and coverage does not seem to work reliably.
     docker compose run --rm test pytest {{ pytest_args }}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+import pytest
+import pytest_playwright
+from pytest_playwright.pytest_playwright import (
+    VSCODE_PYTHON_EXTENSION_ID,
+    _is_debugger_attached,
+)
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args_with_browser_executable(pytestconfig):  # pragma: no cover
+    launch_options = {}
+    # If present, add the executable path from the environment variable
+    executable_path = os.environ.get("PLAYWRIGHT_BROWSER_EXECUTABLE_PATH")
+    if executable_path:
+        print(
+            f"Running playwright tests with custom browser executable: {executable_path}"
+        )
+        launch_options["executable_path"] = executable_path
+
+    # The rest of this fixture is taken directly from pytest-playwright
+    # https://github.com/microsoft/playwright-pytest/blob/v0.4.4/pytest_playwright/pytest_playwright.py#L128
+    headed_option = pytestconfig.getoption("--headed")
+    if headed_option:
+        launch_options["headless"] = False
+    elif VSCODE_PYTHON_EXTENSION_ID in sys.argv[0] and _is_debugger_attached():
+        # When the VSCode debugger is attached, then launch the browser headed by default
+        launch_options["headless"] = False
+
+    browser_channel_option = pytestconfig.getoption("--browser-channel")
+    if browser_channel_option:
+        launch_options["channel"] = browser_channel_option
+    slowmo_option = pytestconfig.getoption("--slowmo")
+    if slowmo_option:
+        launch_options["slow_mo"] = slowmo_option
+    return launch_options
+
+
+pytest_playwright.pytest_playwright.browser_type_launch_args = (
+    browser_type_launch_args_with_browser_executable
+)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -16,6 +16,10 @@ def set_env():
 
 @pytest.fixture(scope="session", autouse=True)
 def playwright_install(request):
+    if os.environ.get("PLAYWRIGHT_BROWSER_EXECUTABLE_PATH"):  # pragma: no cover
+        # No need to install browsers if we're using a custom
+        # executable path
+        return
     # As this can potentially take a long time when it's first run (and as it is
     # subsequently a silent no-op) we disable output capturing so that progress gets
     # displayed to the user


### PR DESCRIPTION
tl;dr There were 2 fiddly things involved in this:
1) getting playwright to run with an old browser version
2) getting the old browser version (google don't make old chrome versions easily available)

1) Playwright by default only runs with the latest stable browsers.
An [executable_path](https://playwright.dev/python/docs/api/class-browsertype#browser-type-executable-path) can be specified when launching a playwright browser, however, the pytest-playwright plugin doesn't provide a way to pass this option.
(Note that the PLAYWRIGHT_BROWSERS_PATH env var seemed promising initially, but is a way to install the browser binaries that playwright expects to a custom path, and/or to specify that path. Playwright only runs with the latest stable browsers by default, so we can't just point it at a path to an old chrome version.)
So I've monkeypatched the fixture that passes the browser launch config, so it now lets us specify a custom browser executable using the PLAYWRIGHT_BROWSER_EXECUTABLE_PATH environment variable. It also
skips playwright browser installation if this variable is set. If the env var is not set, it'll use the default chromium browser as before.

2) Google does not offer old builds of Chrome, but it is possible to get old builds of chromium that should match the version we need (currently 108 on TPP) for testing.
I followed the [instructions here](https://www.chromium.org/getting-involved/download-chromium/#downloading-old-builds-of-chrome-chromium) to find a v108 chromium.
The just command for `docker/test` now fetches the linux download from the [nearest build](https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Linux_x64/1058929/), unzips it, and puts it it a folder that's mounted into the docker image. We still need to run `playwright install chromium` in the docker image in order ensure the image has the system dependencies chromium needs.

In CI, the non-docker tests will run with the latest chromium, and the docker tests will run with v108.  I didn't want to make the non-docker ones download the old chromium and try to run with it because it'd need to get a different version depending on the OS.