### PR TITLE
File downloading

### DIFF
--- a/airlock/api.py
+++ b/airlock/api.py
@@ -52,8 +52,10 @@ class AirlockContainer(Protocol):
     def get_url(self, path: UrlPath = ROOT_PATH) -> str:
         """Get the url for the container object with path"""
 
-    def get_contents_url(self, path: UrlPath = ROOT_PATH) -> str:
-        """Get the url for the container object with path"""
+    def get_contents_url(
+        self, path: UrlPath = ROOT_PATH, download: bool = False
+    ) -> str:
+        """Get the url for the contents of the container object with path"""
 
 
 @dataclass
@@ -85,7 +87,7 @@ class Workspace:
             kwargs={"workspace_name": self.name, "path": relpath},
         )
 
-    def get_contents_url(self, relpath):
+    def get_contents_url(self, relpath, download=False):
         return reverse(
             "workspace_contents",
             kwargs={"workspace_name": self.name, "path": relpath},
@@ -168,11 +170,14 @@ class ReleaseRequest:
             },
         )
 
-    def get_contents_url(self, relpath):
-        return reverse(
+    def get_contents_url(self, relpath, download=False):
+        url = reverse(
             "request_contents",
             kwargs={"request_id": self.id, "path": relpath},
         )
+        if download:
+            url += "?download"
+        return url
 
     def abspath(self, relpath):
         """Returns abspath to the file on disk.

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -91,6 +91,9 @@ class PathItem:
             raise Exception(f"contents_url called on non-file path {self.relpath}")
         return self.container.get_contents_url(f"{self.relpath}", download=download)
 
+    def download_url(self):
+        return self.contents_url(download=True)
+
     def siblings(self):
         if not self.relpath.parents:
             return []

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -86,10 +86,10 @@ class PathItem:
         suffix = "/" if self.is_directory() else ""
         return self.container.get_url(f"{self.relpath}{suffix}")
 
-    def contents_url(self):
+    def contents_url(self, download=False):
         if self.type != PathType.FILE:
             raise Exception(f"contents_url called on non-file path {self.relpath}")
-        return self.container.get_contents_url(f"{self.relpath}")
+        return self.container.get_contents_url(f"{self.relpath}", download=download)
 
     def siblings(self):
         if not self.relpath.parents:

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -175,7 +175,8 @@
                 {% csrf_token %}
                 {% #button type="submit" tooltip="Remove this file from this request" variant="warning" %}Remove File from Request{% /button %}
               </form>
-
+            {% elif is_output_checker %}
+              {% #button variant="primary" type="link" href=path_item.download_url id="download-button" %}Download file{% /button %}
             {% endif %}
           {% endfragment %}
 

--- a/airlock/views/helpers.py
+++ b/airlock/views/helpers.py
@@ -40,11 +40,11 @@ def validate_release_request(user, request_id):
     return release_request
 
 
-def serve_file(abspath):
+def serve_file(abspath, download=False):
     stat = abspath.stat()
     # use same ETag format as whitenoise
     headers = {
         "Last-Modified": formatdate(stat.st_mtime, usegmt=True),
         "ETag": f'"{int(stat.st_mtime):x}-{stat.st_size:x}"',
     }
-    return FileResponse(abspath.open("rb"), headers=headers)
+    return FileResponse(abspath.open("rb"), headers=headers, as_attachment=download)

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 
 from airlock.api import Status
-from airlock.file_browser_api import get_request_tree
+from airlock.file_browser_api import get_request_tree, UrlPath
 from local_db.api import LocalDBProvider
 
 from .helpers import serve_file, validate_release_request
@@ -96,7 +96,8 @@ def request_contents(request, request_id: str, path: str):
     if not abspath.is_file():
         return HttpResponseBadRequest()
 
-    return serve_file(abspath)
+    download = "download" in request.GET
+    return serve_file(abspath, download)
 
 
 @require_http_methods(["POST"])

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -177,6 +177,18 @@ def test_e2e_release_files(page, live_server, dev_users, release_files_stubber):
     find_and_click(page.locator("#outstanding-requests").get_by_role("link"))
     expect(page.locator("body")).to_contain_text(request_id)
 
+    # Reuse the locators from the workspace view to click on filegroup and then file
+    # Click to open the filegroup tree
+    find_and_click(filegroup_link)
+    find_and_click(file_link)
+    expect(page.locator("body")).to_contain_text("I am the file content")
+
+    # Download the file
+    with page.expect_download() as download_info:
+        find_and_click(page.locator("#download-button"))
+    download = download_info.value
+    assert download.suggested_filename == "file.txt"
+
     # Mock the responses from job-server
     release_request = api.get_release_request(request_id)
     release_files_stubber(release_request)

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -186,6 +186,19 @@ def test_request_tree_urls(release_request, path, url):
     assert tree.get_path(path).url().endswith(url)
 
 
+@pytest.mark.django_db
+def test_request_tree_download_url(release_request):
+    tree = get_request_tree(release_request)
+    assert (
+        tree.get_path("group1/some_dir/file_a.txt")
+        .download_url()
+        .endswith("group1/some_dir/file_a.txt?download")
+    )
+
+    with pytest.raises(Exception):
+        assert tree.get_path("some_dir").download_url()
+
+
 def test_workspace_tree_breadcrumbs(workspace):
     tree = get_workspace_tree(workspace)
     path = tree.get_path("some_dir/file_a.txt")


### PR DESCRIPTION
Uses the existing `contents_url`, and the default for the download filename (i.e. uses the existing filename). I don't think there's a need to include group names or paths in the downloaded filename.

As discussed, only output-checkers can download release request files, and only for requests that they did not author. We don't restrict the types of files that can be downloaded by output-checkers. No workspace files can be downloaded by anyone. 

Fixes #126 