### PR TITLE
Improve workspace index

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -111,9 +111,6 @@ class Workspace:
 
         return path
 
-    def __hash__(self):
-        return hash(self.name)
-
 
 @dataclass(frozen=True)
 class RequestFile:
@@ -283,14 +280,7 @@ class BusinessLogicLayer:
         """Get all the local workspace directories that a user has permission for."""
 
         workspaces = []
-        if user.output_checker:
-            workspace_names = [
-                d.name for d in settings.WORKSPACE_DIR.iterdir() if d.is_dir()
-            ]
-        else:
-            workspace_names = user.workspaces
-
-        for workspace_name in workspace_names:
+        for workspace_name in sorted(user.workspaces):
             try:
                 workspace = self.get_workspace(workspace_name)
             except self.WorkspaceNotFound:

--- a/example-data/dev_users.json
+++ b/example-data/dev_users.json
@@ -6,7 +6,9 @@
       "fullname": "Output Checker",
       "output_checker": true,
       "staff": true,
-      "workspaces": []
+      "workspaces": [
+        "example-workspace"
+      ]
     }
   },
   "researcher_1": {

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -60,7 +60,7 @@ def output_checker_user(live_server, context):
         {
             "id": "test_output_checker",
             "username": "test_output_checker",
-            "workspaces": [],
+            "workspaces": ["test-dir2"],
             "output_checker": True,
         },
     )

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -11,10 +11,11 @@ def workspaces():
 
 
 def test_workspaces_index_as_ouput_checker(live_server, page, output_checker_user):
+    # this should only list their workspaces, even though they can access all workspaces
     page.goto(live_server.url + "/workspaces/")
     expect(page.locator("body")).to_contain_text("Workspaces for test_output_checker")
-    for workspace_name in ["test-dir1", "test-dir2"]:
-        expect(page.locator("body")).to_contain_text(workspace_name)
+    expect(page.locator("body")).not_to_contain_text("test-dir1")
+    expect(page.locator("body")).to_contain_text("test-dir2")
 
 
 def test_workspaces_index_as_researcher(live_server, page, researcher_user):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -42,23 +42,17 @@ def test_request_container():
     )
 
 
-@pytest.mark.parametrize(
-    "user_workspaces,output_checker,expected",
-    [
-        ([], False, []),
-        (["allowed"], False, ["allowed"]),
-        ([], True, ["allowed", "not-allowed"]),
-        (["allowed", "notexist"], False, ["allowed"]),
-    ],
-)
-def test_provider_get_workspaces_for_user(user_workspaces, output_checker, expected):
-    factories.create_workspace("allowed")
+@pytest.mark.parametrize("output_checker", [False, True])
+def test_provider_get_workspaces_for_user(output_checker):
+    factories.create_workspace("foo")
+    factories.create_workspace("bar")
     factories.create_workspace("not-allowed")
-    user = User(1, "test", user_workspaces, output_checker)
+    user = User(1, "test", ["foo", "bar", "not-exists"], output_checker)
 
     bll = BusinessLogicLayer(data_access_layer=None)
 
-    assert set(bll.get_workspaces_for_user(user)) == set(Workspace(w) for w in expected)
+    # sorted alphabetically
+    assert bll.get_workspaces_for_user(user) == [Workspace("bar"), Workspace("foo")]
 
 
 @pytest.fixture


### PR DESCRIPTION
As per #146, this change only shows your specific workspaces on the
index page, and in alphabetical order.
