### PR TITLE
Use a session for job-server requests

### DIFF
--- a/airlock/login_api.py
+++ b/airlock/login_api.py
@@ -4,6 +4,9 @@ import requests
 from django.conf import settings
 
 
+session = requests.Session()
+
+
 class LoginError(Exception):
     pass
 
@@ -16,7 +19,7 @@ def get_user_data(user: str, token: str):
 
 
 def get_user_data_prod(user: str, token: str):
-    response = requests.post(
+    response = session.post(
         f"{settings.AIRLOCK_API_ENDPOINT}/releases/authenticate",
         headers={"Authorization": settings.AIRLOCK_API_TOKEN},
         json={"user": user, "token": token},

--- a/tests/functional/test_login.py
+++ b/tests/functional/test_login.py
@@ -3,7 +3,7 @@ from unittest import mock
 from playwright.sync_api import expect
 
 
-@mock.patch("airlock.login_api.requests.post", autospec=True)
+@mock.patch("airlock.login_api.session.post", autospec=True)
 def test_login(requests_post, settings, page, live_server):
     settings.AIRLOCK_API_TOKEN = "test_api_token"
 

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -22,7 +22,7 @@ def test_login_already_logged_in(client):
     assert response.url == ("/workspaces/")
 
 
-@mock.patch("airlock.login_api.requests.post", autospec=True)
+@mock.patch("airlock.login_api.session.post", autospec=True)
 def test_login(requests_post, client, settings):
     settings.AIRLOCK_API_TOKEN = "test_api_token"
 
@@ -58,7 +58,7 @@ def test_login(requests_post, client, settings):
     assert response.url == "/workspaces/"
 
 
-@mock.patch("airlock.login_api.requests.post")
+@mock.patch("airlock.login_api.session.post")
 def test_login_invalid_token(requests_post, client, settings):
     settings.AIRLOCK_API_TOKEN = "test_api_token"
 


### PR DESCRIPTION
This will keep a TLS connection open and amortize the DNS/TLS/tcp connection
costs.
