### PR TITLE
Fix `backpopulate_file_id` command

### DIFF
--- a/local_db/management/commands/backpopulate_file_id.py
+++ b/local_db/management/commands/backpopulate_file_id.py
@@ -12,9 +12,7 @@ class Command(BaseCommand):
         for file_meta in list(empty_file_ids):
             request_id = file_meta.filegroup.request_id
             request = bll.get_release_request(request_id)
-            original_path = (
-                request.root() / file_meta.filegroup.name / file_meta.relpath
-            )
+            original_path = request.root() / file_meta.relpath
             file_meta.file_id = store_file(request, original_path)
             file_meta.save()
             original_path.unlink()

--- a/tests/integration/management/commands/test_backpopulate_file_id.py
+++ b/tests/integration/management/commands/test_backpopulate_file_id.py
@@ -16,9 +16,9 @@ def test_command():
 
     # Determine its current path and its "old style" path
     file_meta = RequestFileMetadata.objects.get()
-    full_relpath = f"{file_meta.filegroup.name}/{file_meta.relpath}"
-    path_with_hash = release_request.abspath(full_relpath)
-    old_style_path = release_request.root() / full_relpath
+    relpath_with_group = f"{file_meta.filegroup.name}/{file_meta.relpath}"
+    path_with_hash = release_request.abspath(relpath_with_group)
+    old_style_path = release_request.root() / file_meta.relpath
 
     # Move the file to its old location
     old_style_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
The previous version (and its test code) was based on an incorrect understanding of where files used to be stored.