### PR TITLE
Refactor how we create and use test users

### DIFF
--- a/airlock/users.py
+++ b/airlock/users.py
@@ -14,6 +14,9 @@ class User:
     workspaces: dict = dataclasses.field(default_factory=dict)
     output_checker: bool = dataclasses.field(default=False)
 
+    def __post_init__(self):
+        assert isinstance(self.workspaces, dict)
+
     @classmethod
     def from_session(cls, session_data):
         user = session_data.get("user")
@@ -22,6 +25,14 @@ class User:
         workspaces = user.get("workspaces", dict())
         output_checker = user.get("output_checker", False)
         return cls(user["id"], user["username"], workspaces, output_checker)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "username": self.username,
+            "workspaces": self.workspaces,
+            "output_checker": self.output_checker,
+        }
 
     def has_permission(self, workspace_name):
         return (

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -9,7 +9,6 @@ class User:
     is a convenience for passing that information around.
     """
 
-    id: int
     username: str
     workspaces: dict = dataclasses.field(default_factory=dict)
     output_checker: bool = dataclasses.field(default=False)
@@ -24,11 +23,10 @@ class User:
             return
         workspaces = user.get("workspaces", dict())
         output_checker = user.get("output_checker", False)
-        return cls(user["id"], user["username"], workspaces, output_checker)
+        return cls(user["username"], workspaces, output_checker)
 
     def to_dict(self):
         return {
-            "id": self.id,
             "username": self.username,
             "workspaces": self.workspaces,
             "output_checker": self.output_checker,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -30,11 +30,7 @@ def ensure_workspace(workspace_or_name):
     raise Exception(f"Invalid workspace: {workspace_or_name})")  # pragma: nocover
 
 
-def create_workspace(name, user=None):
-    # create a default user with permission on workspace
-    if user is None:
-        user = create_user(workspaces=[name])
-
+def create_workspace(name):
     workspace_dir = settings.WORKSPACE_DIR / name
     workspace_dir.mkdir(exist_ok=True, parents=True)
     return bll.get_workspace(name)
@@ -52,7 +48,7 @@ def create_release_request(workspace, user=None, **kwargs):
 
     # create a default user with permission on workspace
     if user is None:
-        user = create_user(workspaces=[workspace.name])
+        user = create_user("author", workspaces=[workspace.name])
 
     release_request = bll._create_release_request(
         workspace=workspace.name, author=user.username, **kwargs

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,11 +4,21 @@ from airlock.business_logic import Workspace, bll
 from airlock.users import User
 
 
-default_user = User(1, "testuser")
+def create_user(username="testuser", workspaces=None, output_checker=False):
+    """Factory to create a user.
 
-
-def get_user(*, username="testuser", workspaces=[], output_checker=False):
-    return User(1, username, workspaces, output_checker)
+    For ease of use, workspaces can either be a list of workspaces, which is
+    converted into an appropriate dict. Or it can be an explicit dict.
+    """
+    if workspaces is None:
+        workspaces_dict = {}
+    elif isinstance(workspaces, dict):
+        workspaces_dict = workspaces
+    else:
+        workspaces_dict = {
+            workspace: {"project": "project"} for workspace in workspaces
+        }
+    return User(1, username, workspaces_dict, output_checker)
 
 
 def ensure_workspace(workspace_or_name):
@@ -20,7 +30,11 @@ def ensure_workspace(workspace_or_name):
     raise Exception(f"Invalid workspace: {workspace_or_name})")  # pragma: nocover
 
 
-def create_workspace(name):
+def create_workspace(name, user=None):
+    # create a default user with permission on workspace
+    if user is None:
+        user = create_user(workspaces=[name])
+
     workspace_dir = settings.WORKSPACE_DIR / name
     workspace_dir.mkdir(exist_ok=True, parents=True)
     return bll.get_workspace(name)
@@ -38,7 +52,7 @@ def create_release_request(workspace, user=None, **kwargs):
 
     # create a default user with permission on workspace
     if user is None:
-        user = get_user(workspaces=[workspace.name])
+        user = create_user(workspaces=[workspace.name])
 
     release_request = bll._create_release_request(
         workspace=workspace.name, author=user.username, **kwargs
@@ -56,16 +70,15 @@ def write_request_file(request, group, path, contents="", user=None):
 
     # create a default user with permission on workspace
     if user is None:  # pragma: nocover
-        user = get_user(username=request.author, workspaces=[request.workspace])
+        user = create_user(request.author, workspaces=[workspace.name])
 
     bll.add_file_to_request(request, relpath=path, user=user, group_name=group)
 
 
 def create_filegroup(release_request, group_name, filepaths=None):
+    user = create_user(release_request.author, [release_request.workspace])
     for filepath in filepaths or []:  # pragma: nocover
-        bll.add_file_to_request(
-            release_request, filepath, User(1, release_request.author), group_name
-        )
+        bll.add_file_to_request(release_request, filepath, user, group_name)
     return bll._dal._get_or_create_filegroupmetadata(release_request.id, group_name)
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -18,7 +18,7 @@ def create_user(username="testuser", workspaces=None, output_checker=False):
         workspaces_dict = {
             workspace: {"project": "project"} for workspace in workspaces
         }
-    return User(1, username, workspaces_dict, output_checker)
+    return User(username, workspaces_dict, output_checker)
 
 
 def ensure_workspace(workspace_or_name):

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,6 +6,8 @@ import pytest
 from django.conf import settings
 from django.contrib.sessions.models import Session
 
+from tests import factories
+
 
 @pytest.fixture(scope="session", autouse=True)
 def set_env():
@@ -38,8 +40,9 @@ def login_as_user(live_server, context, user_dict):
     Creates a session with relevant user data and
     sets the session cookie.
     """
+    user = factories.create_user(**user_dict)
     session_store = Session.get_session_store_class()()
-    session_store["user"] = user_dict
+    session_store["user"] = user.to_dict()
     session_store.save()
     context.add_cookies(
         [
@@ -58,7 +61,6 @@ def output_checker_user(live_server, context):
         live_server,
         context,
         {
-            "id": "test_output_checker",
             "username": "test_output_checker",
             "workspaces": {"test-dir2": {"project": "Project 2"}},
             "output_checker": True,
@@ -72,7 +74,6 @@ def researcher_user(live_server, context):
         live_server,
         context,
         {
-            "id": "test_researcher",
             "username": "test_researcher",
             "workspaces": {"test-dir1": {"project": "Project 1"}},
             "output_checker": False,

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -227,7 +227,7 @@ def test_e2e_reject_request(page, live_server, dev_users):
     find_and_click(page.get_by_test_id("nav-requests"))
 
     # View submitted request
-    find_and_click(page.get_by_role("link", name="test-workspace by testuser"))
+    find_and_click(page.get_by_role("link", name="test-workspace by author"))
 
     # Reject request
     find_and_click(page.locator("#reject-request-button"))
@@ -235,4 +235,4 @@ def test_e2e_reject_request(page, live_server, dev_users):
     expect(page.locator("body")).to_contain_text("Request has been rejected")
     # Requests view does not show rejected request
     find_and_click(page.get_by_test_id("nav-requests"))
-    expect(page.locator("body")).not_to_contain_text("test-workspace by testuser")
+    expect(page.locator("body")).not_to_contain_text("test-workspace by author")

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -21,7 +21,7 @@ def dev_users(tmp_path, settings):
                         "fullname": "Output Checker",
                         "output_checker": True,
                         "staff": True,
-                        "workspaces": [],
+                        "workspaces": {},
                     },
                 },
                 "researcher": {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,16 +1,17 @@
 import pytest
 
-from airlock.users import User
+from tests import factories
 
 
 @pytest.fixture
 def client_with_user(client):
     def _client(session_user):
-        session_user = {"id": 1, "username": "test", **session_user}
+        session_user.setdefault("username", "test")
+        user = factories.create_user(**session_user)
         session = client.session
-        session["user"] = session_user
+        session["user"] = user.to_dict()
         session.save()
-        client.user = User.from_session(session)
+        client.user = user
         return client
 
     return _client

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,23 +1,21 @@
 import pytest
+from django.test import Client
 
 from tests import factories
 
 
-@pytest.fixture
-def client_with_user(client):
-    def _client(session_user):
-        session_user.setdefault("username", "test")
-        user = factories.create_user(**session_user)
-        session = client.session
+class AirlockClient(Client):
+    def login(self, username="testuser", workspaces=None, output_checker=False):
+        user = factories.create_user(username, workspaces, output_checker)
+        self.login_with_user(user)
+
+    def login_with_user(self, user):
+        session = self.session
         session["user"] = user.to_dict()
         session.save()
-        client.user = user
-        return client
-
-    return _client
+        self.user = user
 
 
 @pytest.fixture
-def client_with_permission(client_with_user):
-    output_checker = {"output_checker": True}
-    yield client_with_user(output_checker)
+def airlock_client():
+    return AirlockClient()

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -184,13 +184,11 @@ def test_request_download_file(client_with_permission):
     [
         (  # Different non-output-checker author and output-checker user
             {
-                "id": 1,
                 "username": "output-checker",
                 "workspaces": ["workspace"],
                 "output_checker": False,
             },
             {
-                "id": 2,
                 "username": "author",
                 "workspaces": ["workspace"],
                 "output_checker": True,
@@ -199,13 +197,11 @@ def test_request_download_file(client_with_permission):
         ),
         (  # Different output-checker author and output-checker user
             {
-                "id": 1,
                 "username": "output-checker",
                 "workspaces": ["workspace"],
                 "output_checker": True,
             },
             {
-                "id": 2,
                 "username": "author",
                 "workspaces": ["workspace"],
                 "output_checker": True,
@@ -214,13 +210,11 @@ def test_request_download_file(client_with_permission):
         ),
         (  # Different non-output-checker author and non-output-checker user
             {
-                "id": 1,
                 "username": "researcher",
                 "workspaces": ["workspace"],
                 "output_checker": False,
             },
             {
-                "id": 2,
                 "username": "author",
                 "workspaces": ["workspace"],
                 "output_checker": False,
@@ -229,13 +223,11 @@ def test_request_download_file(client_with_permission):
         ),
         (  # Same output-checker author and user
             {
-                "id": 1,
                 "username": "output-checker",
                 "workspaces": ["workspace"],
                 "output_checker": True,
             },
             {
-                "id": 1,
                 "username": "output-checker",
                 "workspaces": ["workspace"],
                 "output_checker": True,
@@ -248,7 +240,7 @@ def test_request_download_file_permissions(
     client_with_user, request_author, session_user, can_download
 ):
     client = client_with_user(session_user)
-    author = User(**request_author)
+    author = factories.create_user(**request_author)
     release_request = factories.create_release_request(
         "workspace", id="id", user=author
     )
@@ -280,7 +272,7 @@ def test_request_index_user_output_checker(client_with_user):
         {"workspaces": ["test_workspace"], "output_checker": True}
     )
     user = User.from_session(permitted_client.session)
-    other = User(1, "other")
+    other = factories.create_user("other")
     r1 = factories.create_release_request(
         "test_workspace", user=user, status=Status.SUBMITTED
     )
@@ -310,7 +302,7 @@ def test_request_submit_author(client_with_user):
 
 def test_request_submit_not_author(client_with_user):
     permitted_client = client_with_user({"workspaces": ["test1"]})
-    other_user = User(2, "other", [], False)
+    other_user = factories.create_user("other", [], False)
     release_request = factories.create_release_request(
         "test1", user=other_user, status=Status.PENDING
     )
@@ -324,7 +316,7 @@ def test_request_submit_not_author(client_with_user):
 
 
 def test_request_reject_output_checker(client_with_permission):
-    author = User(1, "author", ["test1"], False)
+    author = factories.create_user("author", ["test1"], False)
     release_request = factories.create_release_request(
         "test1",
         user=author,
@@ -341,7 +333,7 @@ def test_request_reject_output_checker(client_with_permission):
 
 def test_request_reject_not_output_checker(client_with_user):
     client = client_with_user({"workspaces": ["test1"]})
-    author = User(1, "author", ["test1"], False)
+    author = factories.create_user("author", ["test1"], False)
     release_request = factories.create_release_request(
         "test1",
         user=author,

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -43,7 +43,7 @@ def test_session_user_no_user_set():
 @pytest.mark.parametrize(
     "output_checker,workspaces,has_permission",
     [
-        (True, [], True),
+        (True, {}, True),
         (True, {"other": {}, "other1": {}}, True),
         (False, {"test": {}, "other": {}, "other1": {}}, True),
         (False, {"other": {}, "other1": {}}, False),
@@ -65,7 +65,7 @@ def test_session_user_has_permission(output_checker, workspaces, has_permission)
 @pytest.mark.parametrize(
     "output_checker,workspaces,can_create_request",
     [
-        (True, [], False),
+        (True, {}, False),
         (True, {"other": {}, "other1": {}}, False),
         (False, {"test": {}, "other": {}, "other1": {}}, True),
         (False, {"other": {}, "other1": {}}, False),


### PR DESCRIPTION
In preparation for pushing more user validation checks down into the BLL, this change refactors test user creation to be easier and more consistant, now that User.workspaces must be a dict.
