### PR TITLE
SPIKE: Add mypy type checking

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -4,10 +4,7 @@ import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
-
-# we use PurePosixPath as a convenient url path representation
-from pathlib import PurePosixPath as UrlPath
+from pathlib import Path, PurePosixPath
 from typing import Protocol, cast
 
 from django.conf import settings
@@ -18,6 +15,10 @@ from django.utils.module_loading import import_string
 import old_api
 from airlock.users import User
 
+
+# We use PurePosixPath as a convenient URL path representation (we reassign rather than
+# use `import as` to satisfy mypy that we intend to export this name)
+UrlPath = PurePosixPath
 
 ROOT_PATH = UrlPath()  # empty path
 

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -62,6 +62,9 @@ class AirlockContainer(Protocol):
     ) -> str:
         """Get the url for the contents of the container object with path"""
 
+    def abspath(self, path: UrlPath) -> Path:
+        """Get the absolute path of the container object with path"""
+
 
 @dataclass(order=True)
 class Workspace:

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 # we use PurePosixPath as a convenient url path representation
 from pathlib import PurePosixPath as UrlPath
-from typing import Protocol
+from typing import Protocol, cast
 
 from django.conf import settings
 from django.urls import reverse
@@ -564,5 +564,7 @@ def _get_configured_bll():
 
 
 # We follow the Django pattern of using a lazy object which configures itself on first
-# access so as to avoid reading `settings` during import
-bll = SimpleLazyObject(_get_configured_bll)
+# access so as to avoid reading `settings` during import. The `cast` here is a runtime
+# no-op, but indicates to the type-checker that this should be treated as an instance of
+# BusinessLogicLayer not SimpleLazyObject.
+bll = cast(BusinessLogicLayer, SimpleLazyObject(_get_configured_bll))

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -261,11 +261,36 @@ def store_file(release_request: ReleaseRequest, abspath: Path) -> str:
     return digest
 
 
-class DataAccessLayerProtocol:
+class DataAccessLayerProtocol(Protocol):
     """
-    Placeholder for a structural type class we can use to define what a data access
-    layer should look like, once we've settled what that is.
+    Structural type class for the Data Access Layer
+
+    Implementations aren't obliged to subclass this as long as they implement the
+    specified methods, though it may be clearer to do so.
     """
+
+    def get_release_request(self, request_id: str):
+        raise NotImplementedError()
+
+    def create_release_request(self, **kwargs):
+        raise NotImplementedError()
+
+    def get_active_requests_for_workspace_by_user(self, workspace: str, username: str):
+        raise NotImplementedError()
+
+    def get_requests_authored_by_user(self, username: str):
+        raise NotImplementedError()
+
+    def get_outstanding_requests_for_review(self):
+        raise NotImplementedError()
+
+    def set_status(self, request_id: str, status: Status):
+        raise NotImplementedError()
+
+    def add_file_to_request(
+        self, request_id, relpath: UrlPath, file_id: str, group_name: str
+    ):
+        raise NotImplementedError()
 
 
 class BusinessLogicLayer:

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path, PurePosixPath
-from typing import Protocol, cast
+from typing import Protocol, Self, cast
 
 from django.conf import settings
 from django.urls import reverse
@@ -129,7 +129,7 @@ class RequestFile:
     file_id: str
 
     @classmethod
-    def from_dict(cls, attrs):
+    def from_dict(cls, attrs) -> Self:
         return cls(**attrs)
 
 
@@ -143,7 +143,7 @@ class FileGroup:
     files: list[RequestFile]
 
     @classmethod
-    def from_dict(cls, attrs):
+    def from_dict(cls, attrs) -> Self:
         return cls(
             **{k: v for k, v in attrs.items() if k != "files"},
             files=[RequestFile.from_dict(value) for value in attrs.get("files", ())],
@@ -171,7 +171,7 @@ class ReleaseRequest:
     selected_path: UrlPath = ROOT_PATH
 
     @classmethod
-    def from_dict(cls, attrs):
+    def from_dict(cls, attrs) -> Self:
         return cls(
             **{k: v for k, v in attrs.items() if k != "filegroups"},
             filegroups=cls._filegroups_from_dict(attrs.get("filegroups", {})),

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 # we use PurePosixPath as a convenient url path representation
 from pathlib import PurePosixPath as UrlPath
-from typing import Optional, Protocol
+from typing import Protocol
 
 from django.conf import settings
 from django.shortcuts import reverse
@@ -164,7 +164,7 @@ class ReleaseRequest:
     author: str
     created_at: datetime
     status: Status = Status.PENDING
-    filegroups: dict[FileGroup] = field(default_factory=dict)
+    filegroups: dict[str, FileGroup] = field(default_factory=dict)
 
     # can be set to mark the currently selected path in this release request
     selected_path: UrlPath = ROOT_PATH
@@ -350,7 +350,7 @@ class BusinessLogicLayer:
 
     def get_current_request(
         self, workspace_name: str, user: User, create: bool = False
-    ) -> ReleaseRequest:
+    ) -> ReleaseRequest | None:
         """Get the current request for the a workspace/user.
 
         If create is True, create one.
@@ -486,7 +486,7 @@ class BusinessLogicLayer:
         release_request: ReleaseRequest,
         relpath: UrlPath,
         user: User,
-        group_name: Optional[str] = "default",
+        group_name: str = "default",
     ):
         if user.username != release_request.author:
             raise self.RequestPermissionDenied(

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -13,7 +13,9 @@ from django.utils.functional import SimpleLazyObject
 from django.utils.module_loading import import_string
 
 import old_api
-from airlock.users import User
+
+# Pointless alias tells mypy that we do intend to export this name
+from airlock.users import User as User
 
 
 # We use PurePosixPath as a convenient URL path representation (we reassign rather than
@@ -84,16 +86,16 @@ class Workspace:
         if not self.root().exists():
             raise BusinessLogicLayer.WorkspaceNotFound(self.name)
 
-    def project(self):
+    def project(self) -> str | None:
         return self.metadata.get("project", None)
 
-    def root(self):
+    def root(self) -> Path:
         return settings.WORKSPACE_DIR / self.name
 
     def get_id(self):
         return self.name
 
-    def get_url(self, relpath=ROOT_PATH):
+    def get_url(self, relpath: UrlPath = ROOT_PATH) -> str:
         return reverse(
             "workspace_view",
             kwargs={"workspace_name": self.name, "path": relpath},
@@ -105,7 +107,7 @@ class Workspace:
             kwargs={"workspace_name": self.name, "path": relpath},
         )
 
-    def abspath(self, relpath):
+    def abspath(self, relpath: UrlPath | str) -> Path:
         """Get absolute path for file
 
         Protects against traversal, and ensures the path exists."""
@@ -187,13 +189,13 @@ class ReleaseRequest:
     def __post_init__(self):
         self.root().mkdir(parents=True, exist_ok=True)
 
-    def root(self):
+    def root(self) -> Path:
         return settings.REQUEST_DIR / self.workspace / self.id
 
     def get_id(self):
         return self.id
 
-    def get_url(self, relpath=ROOT_PATH):
+    def get_url(self, relpath: UrlPath = ROOT_PATH) -> str:
         return reverse(
             "request_view",
             kwargs={
@@ -211,7 +213,7 @@ class ReleaseRequest:
             url += "?download"
         return url
 
-    def abspath(self, relpath):
+    def abspath(self, relpath: UrlPath | str) -> Path:
         """Returns abspath to the file on disk.
 
         The first part of the relpath is the group, so we parse and validate that first.
@@ -231,7 +233,7 @@ class ReleaseRequest:
 
         return self.root() / request_file.file_id
 
-    def file_set(self):
+    def file_set(self) -> set[UrlPath]:
         return {
             request_file.relpath
             for filegroup in self.filegroups.values()

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -11,7 +11,7 @@ from pathlib import PurePosixPath as UrlPath
 from typing import Protocol
 
 from django.conf import settings
-from django.shortcuts import reverse
+from django.urls import reverse
 from django.utils.functional import SimpleLazyObject
 from django.utils.module_loading import import_string
 

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -375,38 +375,47 @@ class BusinessLogicLayer:
         return release_request
 
     def get_current_request(
-        self, workspace_name: str, user: User, create: bool = False
+        self, workspace_name: str, user: User
     ) -> ReleaseRequest | None:
-        """Get the current request for the a workspace/user.
-
-        If create is True, create one.
-        """
+        """Get the current request for a workspace/user."""
         active_requests = self._dal.get_active_requests_for_workspace_by_user(
             workspace=workspace_name,
             username=user.username,
         )
 
         n = len(active_requests)
-        if n > 1:
-            raise Exception(
-                f"Multiple active release requests for user {user.username} in workspace {workspace_name}"
-            )
+        if n == 0:
+            return None
         elif n == 1:
             return ReleaseRequest.from_dict(active_requests[0])
-        elif create:
-            # To create a request, you must have explicit workspace permissions.
-            # Output checkers can view all workspaces, but are not allowed to
-            # create requests for all workspaces.
-            if workspace_name not in user.workspaces:
-                raise BusinessLogicLayer.RequestPermissionDenied(workspace_name)
-
-            new_request = self._dal.create_release_request(
-                workspace=workspace_name,
-                author=user.username,
-            )
-            return ReleaseRequest.from_dict(new_request)
         else:
-            return None
+            raise Exception(
+                f"Multiple active release requests for user {user.username} in "
+                f"workspace {workspace_name}"
+            )
+
+    def get_or_create_current_request(
+        self, workspace_name: str, user: User
+    ) -> ReleaseRequest:
+        """
+        Get the current request for a workspace/user, or create a new one if there is
+        none.
+        """
+        request = self.get_current_request(workspace_name, user)
+        if request is not None:
+            return request
+
+        # To create a request, you must have explicit workspace permissions.  Output
+        # checkers can view all workspaces, but are not allowed to create requests for
+        # all workspaces.
+        if workspace_name not in user.workspaces:
+            raise BusinessLogicLayer.RequestPermissionDenied(workspace_name)
+
+        new_request = self._dal.create_release_request(
+            workspace=workspace_name,
+            author=user.username,
+        )
+        return ReleaseRequest.from_dict(new_request)
 
     def get_requests_authored_by_user(self, user: User) -> list[ReleaseRequest]:
         """Get all current requests authored by user."""

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -71,7 +71,7 @@ class Workspace:
     """
 
     name: str
-    metadata: dict = field(default_factory=dict)
+    metadata: dict[str, str] = field(default_factory=dict)
 
     # can be set to mark the currently selected path in this workspace
     selected_path: UrlPath = ROOT_PATH

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
 
@@ -35,8 +37,8 @@ class PathItem:
     relpath: UrlPath
 
     type: PathType | None = None
-    children: list["PathItem"] = field(default_factory=list)
-    parent: "PathItem" | None = None
+    children: list[PathItem] = field(default_factory=list)
+    parent: PathItem | None = None
 
     # is this the currently selected path?
     selected: bool = False

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -145,7 +145,7 @@ class PathItem:
         distinguish file/dirs, and maybe even file types, in the UI, in case we
         need to.
         """
-        classes = [self.type.value.lower()]
+        classes = [self.type.value.lower()] if self.type else []
 
         if self.type == PathType.FILE:
             classes.append(self.file_type())

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -86,18 +86,18 @@ class PathItem:
 
     def url(self):
         suffix = "/" if self.is_directory() else ""
-        return self.container.get_url(f"{self.relpath}{suffix}")
+        return self.container.get_url(self.relpath) + suffix
 
     def contents_url(self, download=False):
         if self.type != PathType.FILE:
             raise Exception(f"contents_url called on non-file path {self.relpath}")
-        return self.container.get_contents_url(f"{self.relpath}", download=download)
+        return self.container.get_contents_url(self.relpath, download=download)
 
     def download_url(self):
         return self.contents_url(download=True)
 
     def siblings(self):
-        if not self.relpath.parents:
+        if self.parent is None:
             return []
         else:
             return self.parent.children

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -34,9 +34,9 @@ class PathItem:
     container: AirlockContainer
     relpath: UrlPath
 
-    type: PathType = None
+    type: PathType | None = None
     children: list["PathItem"] = field(default_factory=list)
-    parent: "PathItem" = None
+    parent: "PathItem" | None = None
 
     # is this the currently selected path?
     selected: bool = False
@@ -45,7 +45,7 @@ class PathItem:
 
     # what to display for this node when rendering the tree. Defaults to name,
     # but this allow it to be overridden.
-    display_text: str = None
+    display_text: str | None = None
 
     DISPLAY_TYPES = {
         "html": "iframe",

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -324,6 +324,9 @@ def filter_files(selected, files):
             yield f
 
 
+NestedStrList = list[str] | list["NestedStrList"]
+
+
 def get_path_tree(
     container,
     pathlist,
@@ -335,7 +338,7 @@ def get_path_tree(
 
     def build_path_tree(path_parts, parent):
         # group multiple paths into groups by first part of path
-        grouped = dict()
+        grouped: dict[str, NestedStrList] = dict()
         for child, *descendants in path_parts:
             if child not in grouped:
                 grouped[child] = []

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -24,7 +24,7 @@ class AddFileForm(forms.Form):
         self.fields["new_filegroup"]
 
     def clean_new_filegroup(self):
-        new_filegroup = self.cleaned_data.get("new_filegroup").lower()
+        new_filegroup = self.cleaned_data.get("new_filegroup", "").lower()
         if new_filegroup in [fg.lower() for fg in self.filegroup_names]:
             self.add_error(
                 "new_filegroup",

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -17,10 +17,8 @@ class AddFileForm(forms.Form):
             self.filegroup_names = release_request.filegroups.keys()
         else:
             self.filegroup_names = set()
-        group_choices = {
-            (name, name) for name in self.filegroup_names if name != "default"
-        }
-        group_choices = [("default", "default"), *sorted(group_choices)]
+        group_names = sorted(self.filegroup_names - {"default"})
+        group_choices = [(name, name) for name in ["default", *group_names]]
         self.fields["filegroup"].choices = group_choices
         self.fields["new_filegroup"]
 

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -19,6 +19,7 @@ class AddFileForm(forms.Form):
             self.filegroup_names = set()
         group_names = sorted(self.filegroup_names - {"default"})
         group_choices = [(name, name) for name in ["default", *group_names]]
+        assert isinstance(self.fields["filegroup"], forms.ChoiceField)
         self.fields["filegroup"].choices = group_choices
         self.fields["new_filegroup"]
 

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -10,7 +10,7 @@ class AddFileForm(forms.Form):
     filegroup = forms.ChoiceField(required=False)
     new_filegroup = forms.CharField(required=False)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         release_request = kwargs.pop("release_request")
         super().__init__(*args, **kwargs)
         if release_request:

--- a/airlock/login_api.py
+++ b/airlock/login_api.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import requests
 from django.conf import settings
@@ -13,7 +14,7 @@ class LoginError(Exception):
 
 def get_user_data(user: str, token: str):
     if settings.AIRLOCK_DEV_USERS_FILE and not settings.AIRLOCK_API_TOKEN:
-        return get_user_data_dev(user, token)
+        return get_user_data_dev(settings.AIRLOCK_DEV_USERS_FILE, user, token)
     else:
         return get_user_data_prod(user, token)
 
@@ -31,9 +32,9 @@ def get_user_data_prod(user: str, token: str):
     return response.json()
 
 
-def get_user_data_dev(user: str, token: str):
+def get_user_data_dev(dev_users_file: Path, user: str, token: str):
     try:
-        dev_users = json.loads(settings.AIRLOCK_DEV_USERS_FILE.read_text())
+        dev_users = json.loads(dev_users_file.read_text())
     except FileNotFoundError as e:  # pragma: no cover
         e.add_note(
             "You may want to run:\n\n    just load-example-data\n\nto create one."

--- a/airlock/middleware.py
+++ b/airlock/middleware.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlencode
 
-from django.shortcuts import redirect, reverse
+from django.shortcuts import redirect
+from django.urls import reverse
 
 from airlock.users import User
 

--- a/airlock/nav.py
+++ b/airlock/nav.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from django.http import HttpRequest
 from django.urls import reverse
 
 
@@ -12,7 +13,7 @@ def default_predicate(request):
 class NavItem:
     name: str
     url_name: str
-    predicate: Callable = default_predicate
+    predicate: Callable[[HttpRequest], bool] = default_predicate
 
 
 def iter_nav(items, request):

--- a/airlock/nav.py
+++ b/airlock/nav.py
@@ -16,7 +16,7 @@ class NavItem:
     predicate: Callable[[HttpRequest], bool] = default_predicate
 
 
-def iter_nav(items, request):
+def iter_nav(items: list[NavItem], request: HttpRequest):
     for item in items:
         if not item.predicate(request):
             continue

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -37,7 +37,7 @@ things properly.
 """
 
 
-def get_env_var(name):
+def get_env_var(name: str) -> str:
     try:
         return os.environ[name]
     except KeyError:

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -10,7 +10,7 @@ class User:
     """
 
     username: str
-    workspaces: dict = dataclasses.field(default_factory=dict)
+    workspaces: dict[str, dict[str, str]] = dataclasses.field(default_factory=dict)
     output_checker: bool = dataclasses.field(default=False)
 
     def __post_init__(self):

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import Any, Self
 
 
 @dataclasses.dataclass(frozen=True)
@@ -17,10 +18,10 @@ class User:
         assert isinstance(self.workspaces, dict)
 
     @classmethod
-    def from_session(cls, session_data):
+    def from_session(cls, session_data: dict[str, Any]) -> Self | None:
         user = session_data.get("user")
         if user is None:
-            return
+            return None
         workspaces = user.get("workspaces", dict())
         output_checker = user.get("output_checker", False)
         return cls(user["username"], workspaces, output_checker)
@@ -38,7 +39,7 @@ class User:
             self.output_checker or self.can_create_request(workspace_name)
         )
 
-    def can_create_request(self, workspace_name):
+    def can_create_request(self, workspace_name: str) -> bool:
         # Only users with explict access to the workspace can create release
         # requests.
         return workspace_name in self.workspaces

--- a/airlock/views/__init__.py
+++ b/airlock/views/__init__.py
@@ -14,3 +14,20 @@ from .workspace import (
     workspace_index,
     workspace_view,
 )
+
+
+__all__ = [
+    "login",
+    "logout",
+    "index",
+    "request_contents",
+    "request_index",
+    "request_reject",
+    "request_release_files",
+    "request_submit",
+    "request_view",
+    "workspace_add_file_to_request",
+    "workspace_contents",
+    "workspace_index",
+    "workspace_view",
+]

--- a/airlock/views/auth.py
+++ b/airlock/views/auth.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.forms import Form
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -41,7 +42,7 @@ def login(request):
     )
 
 
-def get_user_data_or_set_form_errors(form):
+def get_user_data_or_set_form_errors(form: Form):
     if not form.is_valid():
         return
     try:

--- a/airlock/views/helpers.py
+++ b/airlock/views/helpers.py
@@ -1,9 +1,10 @@
 from email.utils import formatdate
+from pathlib import Path
 
 from django.core.exceptions import PermissionDenied
 from django.http import FileResponse, Http404
 
-from airlock.business_logic import bll
+from airlock.business_logic import ReleaseRequest, User, Workspace, bll
 
 
 def login_exempt(view):
@@ -11,7 +12,7 @@ def login_exempt(view):
     return view
 
 
-def get_workspace_or_raise(user, workspace_name):
+def get_workspace_or_raise(user: User, workspace_name: str) -> Workspace:
     """Get the workspace, converting any errors to http codes."""
     try:
         workspace = bll.get_workspace(workspace_name, user)
@@ -23,7 +24,7 @@ def get_workspace_or_raise(user, workspace_name):
     return workspace
 
 
-def get_release_request_or_raise(user, request_id):
+def get_release_request_or_raise(user: User, request_id: str) -> ReleaseRequest:
     """Get the release request, converting any errors to http codes."""
     try:
         release_request = bll.get_release_request(request_id, user)
@@ -35,7 +36,7 @@ def get_release_request_or_raise(user, request_id):
     return release_request
 
 
-def serve_file(abspath, download=False, filename=None):
+def serve_file(abspath: Path, download=False, filename: str = "") -> FileResponse:
     stat = abspath.stat()
     # use same ETag format as whitenoise
     headers = {

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -119,7 +119,7 @@ def workspace_add_file_to_request(request, workspace_name):
     except bll.FileNotFound:
         raise Http404()
 
-    release_request = bll.get_current_request(workspace_name, request.user, create=True)
+    release_request = bll.get_or_create_current_request(workspace_name, request.user)
     form = AddFileForm(request.POST, release_request=release_request)
     if form.is_valid():
         group_name = request.POST.get("new_filegroup") or request.POST.get("filegroup")

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -134,8 +134,9 @@ def workspace_add_file_to_request(request, workspace_name):
                 request, f"File has been added to request (file group '{group_name}')"
             )
     else:
-        for error in form.errors.values():
-            messages.error(request, error)
+        for error_list in form.errors.values():
+            for error in error_list:
+                messages.error(request, str(error))
 
     # Redirect to the file in the workspace
     return redirect(workspace.get_url(relpath))

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from collections.abc import Iterable
 
 from django.contrib import messages
 from django.http import Http404, HttpResponseBadRequest
@@ -8,14 +9,16 @@ from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.vary import vary_on_headers
 
-from airlock.business_logic import UrlPath, bll
+from airlock.business_logic import UrlPath, Workspace, bll
 from airlock.file_browser_api import get_workspace_tree
 from airlock.forms import AddFileForm
 
 from .helpers import get_workspace_or_raise, serve_file
 
 
-def grouped_workspaces(workspaces):
+def grouped_workspaces(
+    workspaces: Iterable[Workspace],
+) -> Iterable[tuple[str | None, list[Workspace]]]:
     workspaces_by_project = defaultdict(list)
     for workspace in workspaces:
         workspaces_by_project[workspace.project()].append(workspace)

--- a/assets/base_views.py
+++ b/assets/base_views.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 
 from django import forms
+from django.http import HttpRequest
 from django.template.response import TemplateResponse
 
 
@@ -40,7 +41,7 @@ class ExampleForm(forms.Form):
         )
 
 
-def components(request):
+def components(request: HttpRequest) -> TemplateResponse:
     example_date = datetime.fromtimestamp(1667317153, tz=UTC)
     form = ExampleForm({"example_select": "french", "example_email": "you@example.com"})
     form.is_valid()

--- a/assets/base_views.py
+++ b/assets/base_views.py
@@ -8,11 +8,11 @@ class ExampleForm(forms.Form):
 
     example_select = forms.ChoiceField(
         choices=[
-            ["", "Please select a language"],
-            ["english", "English"],
-            ["french", "French"],
-            ["german", "German"],
-            ["spanish", "Spanish"],
+            ("", "Please select a language"),
+            ("english", "English"),
+            ("french", "French"),
+            ("german", "German"),
+            ("spanish", "Spanish"),
         ],
         label="Language select",
         initial="french",
@@ -24,10 +24,10 @@ class ExampleForm(forms.Form):
 
     example_radios = forms.ChoiceField(
         choices=[
-            ["english", "English"],
-            ["french", "French"],
-            ["german", "German"],
-            ["spanish", "Spanish"],
+            ("english", "English"),
+            ("french", "French"),
+            ("german", "German"),
+            ("spanish", "Spanish"),
         ],
         label="Language select",
         initial="french",

--- a/justfile
+++ b/justfile
@@ -105,6 +105,7 @@ check: devenv
     check "$BIN/djhtml --tabwidth 2 --check airlock/"
     check "docker run --rm -i ghcr.io/hadolint/hadolint:v2.12.0-alpine < docker/Dockerfile"
     check "find docker/ airlock/ job-server -name \*.sh -print0 | xargs -0 docker run --rm -v \"$PWD:/mnt\" koalaman/shellcheck:v0.9.0"
+    check "$BIN/mypy airlock/ local_db/ assets/"
 
     if [[ $failed > 0 ]]; then
       echo -en "\e[1;31m"

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -6,6 +6,7 @@ from airlock.business_logic import (
     BusinessLogicLayer,
     DataAccessLayerProtocol,
     Status,
+    UrlPath,
 )
 from local_db.models import FileGroupMetadata, RequestFileMetadata, RequestMetadata
 
@@ -15,7 +16,7 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
     Implementation of DataAccessLayerProtocol using local_db models to store data
     """
 
-    def _request(self, metadata: RequestMetadata = None):
+    def _request(self, metadata: RequestMetadata):
         """Unpack the db data into the Request object."""
         return dict(
             id=metadata.id,
@@ -94,7 +95,7 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
             metadata.save()
 
     def add_file_to_request(
-        self, request_id, relpath: Path, file_id: str, group_name: str
+        self, request_id, relpath: UrlPath, file_id: str, group_name: str
     ):
         with transaction.atomic():
             # Get/create the FileGroupMetadata if it doesn't already exist

--- a/local_db/models.py
+++ b/local_db/models.py
@@ -12,7 +12,9 @@ def local_request_id():
     return str(ulid())
 
 
-class StatusField(models.TextField):
+# Without the "ignore" this raises: Missing type parameters for generic type "TextField"
+# https://github.com/typeddjango/django-stubs/issues/285
+class StatusField(models.TextField):  # type: ignore
     """Custom field that ensures correct types for status column.
 
     Specifically, dasta is stored in the db as the string name, e.g.

--- a/local_db/models.py
+++ b/local_db/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.utils import timezone
-from ulid import ulid
+
+# We could create our own type stubs for this module but our use of it is so simple that
+# it's not really worth it
+from ulid import ulid  # type: ignore
 
 from airlock.business_logic import Status
 

--- a/old_api/__init__.py
+++ b/old_api/__init__.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 import requests
 from django.conf import settings
 
-from old_api.schema import FileList, FileMetadata
+from old_api.schema import FileList, FileMetadata, UrlFileName
 
 
 session = requests.Session()
@@ -16,11 +16,11 @@ def create_filelist(paths):
     for relpath, abspath in paths:
         files.append(
             FileMetadata(
-                name=str(relpath),
+                name=UrlFileName(relpath),
                 size=abspath.stat().st_size,
                 sha256=hashlib.sha256(abspath.read_bytes()).hexdigest(),
                 date=modified_time(abspath),
-                url=str(relpath),  # not needed, but has to be set
+                url=UrlFileName(relpath),  # not needed, but has to be set
                 metadata={"tool": "airlock"},
             )
         )

--- a/old_api/__init__.py
+++ b/old_api/__init__.py
@@ -1,5 +1,6 @@
 import hashlib
 from datetime import datetime, timezone
+from pathlib import Path
 
 import requests
 from django.conf import settings
@@ -63,6 +64,6 @@ def upload_file(release_id, relpath, abspath, username):
     return response
 
 
-def modified_time(path):
+def modified_time(path: Path) -> str:
     mtime = path.stat().st_mtime
     return datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()

--- a/old_api/schema.py
+++ b/old_api/schema.py
@@ -38,12 +38,12 @@ class FileMetadata(BaseModel):
     """Metadata for a workspace file."""
 
     name: UrlFileName
-    url: UrlFileName = None  # Url to path on release-hatch instance
+    url: UrlFileName | None = None  # Url to path on release-hatch instance
     size: int  # size in bytes
     sha256: str  # sha256 of file
     date: datetime  # last modified in ISO date format
-    metadata: dict = None  # user supplied metadata about this file
-    review: FileReview = None  # any review metadata for this file
+    metadata: dict | None = None  # user supplied metadata about this file
+    review: FileReview | None = None  # any review metadata for this file
 
 
 class FileList(BaseModel):
@@ -53,8 +53,8 @@ class FileList(BaseModel):
     """
 
     files: list[FileMetadata]
-    metadata: dict = None  # user supplied metadata about thse Release
-    review: dict = None  # review comments for the whole Release
+    metadata: dict | None = None  # user supplied metadata about thse Release
+    review: dict | None = None  # review comments for the whole Release
 
     def get(self, name):  # pragma: no cover
         name = str(name)

--- a/old_api/schema.py
+++ b/old_api/schema.py
@@ -31,7 +31,7 @@ class ReviewStatus(Enum):
 
 class FileReview(BaseModel):
     status: ReviewStatus
-    comments: dict
+    comments: dict[str, str]
 
 
 class FileMetadata(BaseModel):
@@ -42,7 +42,7 @@ class FileMetadata(BaseModel):
     size: int  # size in bytes
     sha256: str  # sha256 of file
     date: datetime  # last modified in ISO date format
-    metadata: dict | None = None  # user supplied metadata about this file
+    metadata: dict[str, str] | None = None  # user supplied metadata about this file
     review: FileReview | None = None  # any review metadata for this file
 
 
@@ -53,8 +53,8 @@ class FileList(BaseModel):
     """
 
     files: list[FileMetadata]
-    metadata: dict | None = None  # user supplied metadata about thse Release
-    review: dict | None = None  # review comments for the whole Release
+    metadata: dict[str, str] | None = None  # user supplied metadata about thse Release
+    review: dict[str, str] | None = None  # review comments for the whole Release
 
     def get(self, name):  # pragma: no cover
         name = str(name)

--- a/old_api/schema.py
+++ b/old_api/schema.py
@@ -5,7 +5,6 @@
 #
 # Until then, do not make local changes, rather copy the latest version of this
 # file into your project.
-from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel
@@ -41,7 +40,7 @@ class FileMetadata(BaseModel):
     url: UrlFileName | None = None  # Url to path on release-hatch instance
     size: int  # size in bytes
     sha256: str  # sha256 of file
-    date: datetime  # last modified in ISO date format
+    date: str  # last modified in ISO date format
     metadata: dict[str, str] | None = None  # user supplied metadata about this file
     review: FileReview | None = None  # any review metadata for this file
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ exclude_blocks = [
 plugins = ["mypy_django_plugin.main"]
 disallow_any_generics = true
 no_implicit_reexport = true
+warn_return_any = true
 
 [tool.django-stubs]
 django_settings_module = "airlock.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ exclude_blocks = [
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
 disallow_any_generics = true
+no_implicit_reexport = true
 
 [tool.django-stubs]
 django_settings_module = "airlock.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ exclude_blocks = [
 
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
+disallow_any_generics = true
 
 [tool.django-stubs]
 django_settings_module = "airlock.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,9 @@ exclude_blocks = [
 
 [tool.ruff.lint.per-file-ignores]
 "airlock/views/__init__.py" = ["F401"]
+
+[tool.mypy]
+plugins = ["mypy_django_plugin.main"]
+
+[tool.django-stubs]
+django_settings_module = "airlock.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ plugins = ["mypy_django_plugin.main"]
 disallow_any_generics = true
 no_implicit_reexport = true
 warn_return_any = true
+check_untyped_defs = true
 
 [tool.django-stubs]
 django_settings_module = "airlock.settings"

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -15,3 +15,8 @@ responses
 # Currently using our fork of django_coverage_plugin, pending
 # upstream PR https://github.com/nedbat/django_coverage_plugin/pull/93
 https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip
+
+# Type-checking and type stubs
+mypy
+django-stubs[compatible-mypy]
+types-requests

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -180,6 +180,8 @@ django==5.0.2 \
     # via
     #   -c requirements.prod.txt
     #   django-debug-toolbar
+    #   django-stubs
+    #   django-stubs-ext
 django-coverage-plugin @ https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip \
     --hash=sha256:db70db8737dd269c346f7af6e0c735a3d6462b944302f6bc0178c7bac9a4c7ee
     # via -r requirements.dev.in
@@ -193,6 +195,14 @@ django-debug-toolbar-template-profiler==2.1.0 \
     --hash=sha256:740d4fa90f9c72fe97c896d5a395abc535cf8e9d571c1710186aa775a861d7f4 \
     --hash=sha256:7c77b3d96a0f64a47ed80dec88bad0832fe2834d17da5cd77f86639680b56a8b
     # via -r requirements.dev.in
+django-stubs==4.2.7 \
+    --hash=sha256:4cf4de258fa71adc6f2799e983091b9d46cfc67c6eebc68fe111218c9a62b3b8 \
+    --hash=sha256:8ccd2ff4ee5adf22b9e3b7b1a516d2e1c2191e9d94e672c35cc2bc3dd61e0f6b
+    # via -r requirements.dev.in
+django-stubs-ext==4.2.7 \
+    --hash=sha256:45a5d102417a412e3606e3c358adb4744988a92b7b58ccf3fd64bddd5d04d14c \
+    --hash=sha256:519342ac0849cda1559746c9a563f03ff99f636b0ebe7c14b75e816a00dfddc3
+    # via django-stubs
 djhtml==3.0.6 \
     --hash=sha256:abfc4d7b4730432ca6a98322fbdf8ae9d6ba254ea57ba3759a10ecb293bc57de
     # via -r requirements.dev.in
@@ -266,6 +276,41 @@ iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     # via pytest
+mypy==1.7.1 \
+    --hash=sha256:12cce78e329838d70a204293e7b29af9faa3ab14899aec397798a4b41be7f340 \
+    --hash=sha256:1484b8fa2c10adf4474f016e09d7a159602f3239075c7bf9f1627f5acf40ad49 \
+    --hash=sha256:204e0d6de5fd2317394a4eff62065614c4892d5a4d1a7ee55b765d7a3d9e3f82 \
+    --hash=sha256:2643d145af5292ee956aa0a83c2ce1038a3bdb26e033dadeb2f7066fb0c9abce \
+    --hash=sha256:2c6e4464ed5f01dc44dc9821caf67b60a4e5c3b04278286a85c067010653a0eb \
+    --hash=sha256:2f7f6985d05a4e3ce8255396df363046c28bea790e40617654e91ed580ca7c51 \
+    --hash=sha256:31902408f4bf54108bbfb2e35369877c01c95adc6192958684473658c322c8a5 \
+    --hash=sha256:40716d1f821b89838589e5b3106ebbc23636ffdef5abc31f7cd0266db936067e \
+    --hash=sha256:4b901927f16224d0d143b925ce9a4e6b3a758010673eeded9b748f250cf4e8f7 \
+    --hash=sha256:4fc3d14ee80cd22367caaaf6e014494415bf440980a3045bf5045b525680ac33 \
+    --hash=sha256:5cf3f0c5ac72139797953bd50bc6c95ac13075e62dbfcc923571180bebb662e9 \
+    --hash=sha256:6dbdec441c60699288adf051f51a5d512b0d818526d1dcfff5a41f8cd8b4aaf1 \
+    --hash=sha256:72cf32ce7dd3562373f78bd751f73c96cfb441de147cc2448a92c1a308bd0ca6 \
+    --hash=sha256:75aa828610b67462ffe3057d4d8a4112105ed211596b750b53cbfe182f44777a \
+    --hash=sha256:75c4d2a6effd015786c87774e04331b6da863fc3fc4e8adfc3b40aa55ab516fe \
+    --hash=sha256:78e25b2fd6cbb55ddfb8058417df193f0129cad5f4ee75d1502248e588d9e0d7 \
+    --hash=sha256:84860e06ba363d9c0eeabd45ac0fde4b903ad7aa4f93cd8b648385a888e23200 \
+    --hash=sha256:8c5091ebd294f7628eb25ea554852a52058ac81472c921150e3a61cdd68f75a7 \
+    --hash=sha256:944bdc21ebd620eafefc090cdf83158393ec2b1391578359776c00de00e8907a \
+    --hash=sha256:9c7ac372232c928fff0645d85f273a726970c014749b924ce5710d7d89763a28 \
+    --hash=sha256:d9b338c19fa2412f76e17525c1b4f2c687a55b156320acb588df79f2e6fa9fea \
+    --hash=sha256:ee5d62d28b854eb61889cde4e1dbc10fbaa5560cb39780c3995f6737f7e82120 \
+    --hash=sha256:f2c2521a8e4d6d769e3234350ba7b65ff5d527137cdcde13ff4d99114b0c8e7d \
+    --hash=sha256:f6efc9bd72258f89a3816e3a98c09d36f079c223aa345c659622f056b760ab42 \
+    --hash=sha256:f7c5d642db47376a0cc130f0de6d055056e010debdaf0707cd2b0fc7e7ef30ea \
+    --hash=sha256:fcb6d9afb1b6208b4c712af0dafdc650f518836065df0d4fb1d800f5d6773db2 \
+    --hash=sha256:fcd2572dd4519e8a6642b733cd3a8cfc1ef94bafd0c1ceed9c94fe736cb65b6a
+    # via
+    #   -r requirements.dev.in
+    #   django-stubs
+mypy-extensions==1.0.0 \
+    --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
+    --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
+    # via mypy
 packaging==23.2 \
     --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
     --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
@@ -425,11 +470,26 @@ text-unidecode==1.3 \
     --hash=sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8 \
     --hash=sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93
     # via python-slugify
+types-pytz==2024.1.0.20240203 \
+    --hash=sha256:9679eef0365db3af91ef7722c199dbb75ee5c1b67e3c4dd7bfbeb1b8a71c21a3 \
+    --hash=sha256:c93751ee20dfc6e054a0148f8f5227b9a00b79c90a4d3c9f464711a73179c89e
+    # via django-stubs
+types-pyyaml==6.0.12.20240311 \
+    --hash=sha256:a9e0f0f88dc835739b0c1ca51ee90d04ca2a897a71af79de9aec5f38cb0a5342 \
+    --hash=sha256:b845b06a1c7e54b8e5b4c683043de0d9caf205e7434b3edc678ff2411979b8f6
+    # via django-stubs
+types-requests==2.31.0.20240311 \
+    --hash=sha256:47872893d65a38e282ee9f277a4ee50d1b28bd592040df7d1fdaffdf3779937d \
+    --hash=sha256:b1c1b66abfb7fa79aae09097a811c4aa97130eb8831c60e47aee4ca344731ca5
+    # via -r requirements.dev.in
 typing-extensions==4.9.0 \
     --hash=sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783 \
     --hash=sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd
     # via
     #   -c requirements.prod.txt
+    #   django-stubs
+    #   django-stubs-ext
+    #   mypy
     #   pyee
 urllib3==2.2.0 \
     --hash=sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20 \
@@ -438,6 +498,7 @@ urllib3==2.2.0 \
     #   -c requirements.prod.txt
     #   requests
     #   responses
+    #   types-requests
 wheel==0.42.0 \
     --hash=sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d \
     --hash=sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -188,7 +188,7 @@ def test_provider_get_current_request_for_user(bll):
     factories.create_release_request(workspace, other_user)
     assert bll.get_current_request("workspace", user) is None
 
-    release_request = bll.get_current_request("workspace", user, create=True)
+    release_request = bll.get_or_create_current_request("workspace", user)
     assert release_request.workspace == "workspace"
     assert release_request.author == user.username
 
@@ -205,7 +205,7 @@ def test_provider_get_current_request_for_user_output_checker(bll):
     user = factories.create_user("output_checker", [], True)
 
     with pytest.raises(bll.RequestPermissionDenied):
-        bll.get_current_request("workspace", user, create=True)
+        bll.get_or_create_current_request("workspace", user)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is spike to get a sense of what would be involved in adding type checking to Airlock and how it might benefit us.

This involves installing `mypy` and also type stubs and a mypy plugin to get it to play nicely with Django.

Worth noting is that the latest release of the Django type stubs supports neither the latest version of mypy nor the latest version Django:
https://github.com/typeddjango/django-stubs?tab=readme-ov-file#version-compatibility

However, in practice it seems to have worked without issue in the sense that I don't think any of the problems I've hit have been the result of django-stubs.

I started by getting `mypy` passing on its default settings. This involved a little bit of faff to correct some of our type signatures and a few other bits and pieces. It wasn't too much work, but then neither did it expose any interesting bugs.

I then started enabling all the flags involved in `mypy --strict` mode. Enabling them one-by-one in rough order of how many issues they seemed to find and making the necessary fixes. This did expose some small genuine bugs, but nothing earth shattering.

At first this work progressed quite quickly and I got as far as these three final flags:

    --disallow-untyped-calls
    --disallow-incomplete-defs
    --disallow-untyped-defs

However, what I discovered is that `mypy` had been merrily ignoring all the untyped parts of the codebase and the more of it I added types to the more issues it found.

Some of the work here is pretty straightforward and mechanical (e.g. adding `-> str:` to the end of a lot of function defs) but some of it, in particular the recursive tree walking code where nested structures are getting passed around, is difficult. I think _probably_ the pressure from `mypy` here is good in the sense that easier to type code would also be easier to understand. But it's not quite as simple as just slapping a few annotations on and calling it a day.