### PR TITLE
Strip quotes from OTEL_EXPORTER_OTLP_HEADERS values

### DIFF
--- a/services/tracing.py
+++ b/services/tracing.py
@@ -37,6 +37,11 @@ def setup_default_tracing(set_global=True):
 
     """Inspect environment variables and set up exporters accordingly."""
     if "OTEL_EXPORTER_OTLP_HEADERS" in os.environ:
+        # workaround for env file parsing issues
+        cleaned_headers = os.environ["OTEL_EXPORTER_OTLP_HEADERS"].strip("\"'")
+        # put back into env to be parsed properlh
+        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = cleaned_headers
+
         if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ:
             os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://api.honeycomb.io"
 

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -39,7 +39,7 @@ def setup_default_tracing(set_global=True):
     if "OTEL_EXPORTER_OTLP_HEADERS" in os.environ:
         # workaround for env file parsing issues
         cleaned_headers = os.environ["OTEL_EXPORTER_OTLP_HEADERS"].strip("\"'")
-        # put back into env to be parsed properlh
+        # put back into env to be parsed properly
         os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = cleaned_headers
 
         if "OTEL_EXPORTER_OTLP_ENDPOINT" not in os.environ:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -24,7 +24,8 @@ def test_setup_default_tracing_console(monkeypatch):
 
 
 def test_setup_default_tracing_otlp_defaults(monkeypatch):
-    env = {"PYTHONPATH": "", "OTEL_EXPORTER_OTLP_HEADERS": "foo=bar"}
+    # add single quotes to test quote stripping
+    env = {"PYTHONPATH": "", "OTEL_EXPORTER_OTLP_HEADERS": "'foo=bar'"}
     monkeypatch.setattr(os, "environ", env)
     monkeypatch.setattr(
         opentelemetry.exporter.otlp.proto.http.trace_exporter, "environ", env


### PR DESCRIPTION
Workaround a bug in docker-compose
