### PR TITLE
Custom otel traces

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -101,7 +101,15 @@ just assets/update
 ## Opentelemetry
 
 To log opentelemetry traces to the console in local environments,
-set the `OTEL_EXPORTER_CONSOLE` environment variable in your `.env` file. 
+set the `OTEL_EXPORTER_CONSOLE` environment variable in your `.env` file.
+
+To reduce some of the noise for local development, some instrumentations
+can be turned off; to run a local server and disable everything except
+tracing we explicitly add in Airlock code, run:
+
+```
+OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=django,sqlite3,requests
+```
 
 ## Testing
 

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -89,6 +89,9 @@ class Workspace:
         if not self.root().exists():
             raise BusinessLogicLayer.WorkspaceNotFound(self.name)
 
+    def __str__(self):
+        return self.get_id()
+
     def project(self):
         return self.metadata.get("project", None)
 
@@ -214,6 +217,9 @@ class ReleaseRequest:
 
     def __post_init__(self):
         self.root().mkdir(parents=True, exist_ok=True)
+
+    def __str__(self):
+        return self.get_id()
 
     def root(self):
         return settings.REQUEST_DIR / self.workspace / self.id

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 from airlock.business_logic import ROOT_PATH, AirlockContainer, UrlPath
+from services.tracing import instrument
 
 
 class PathType(Enum):
@@ -199,6 +200,7 @@ class PathItem:
         return "\n".join(build_string(self, ""))
 
 
+@instrument(arg_attributes={"workspace": 0})
 def get_workspace_tree(workspace, selected_path=ROOT_PATH, selected_only=False):
     """Recursively build workspace tree from the root dir.
 
@@ -240,6 +242,7 @@ def get_workspace_tree(workspace, selected_path=ROOT_PATH, selected_only=False):
     return root_node
 
 
+@instrument(arg_attributes={"release_request": 0})
 def get_request_tree(release_request, selected_path=ROOT_PATH, selected_only=False):
     """Build a tree recursively for a ReleaseRequest
 

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -42,7 +42,6 @@ def workspace_index(request):
 @instrument(kwarg_attributes={"workspace": "workspace_name"})
 def workspace_view(request, workspace_name: str, path: str = ""):
     workspace = get_workspace_or_raise(request.user, workspace_name)
-
     template = "file_browser/index.html"
     selected_only = False
 
@@ -50,8 +49,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
         template = "file_browser/contents.html"
         selected_only = True
 
-    with tracer.start_as_current_span("build_workspace_tree") as _span:
-        tree = get_workspace_tree(workspace, path, selected_only)
+    tree = get_workspace_tree(workspace, path, selected_only)
 
     path_item = get_path_item_from_tree_or_404(tree, path)
 

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -97,18 +97,20 @@ def instrument(
                 name, record_exception=record_exception
             ) as span:
                 attributes_dict = attributes or {}
-                if kwarg_attributes:
-                    attributes_dict.update(
-                        {
-                            k: str(kwargs[v])
-                            for k, v in kwarg_attributes.items()
-                            if v in kwargs
-                        }
-                    )
-                if arg_attributes:
-                    attributes_dict.update(
-                        {k: str(args[v]) for k, v in arg_attributes.items()}
-                    )
+                if kwarg_attributes is not None:
+                    for k, v in kwarg_attributes.items():
+                        assert (
+                            v in kwargs
+                        ), f"Expected kwarg {v} not found in function signature"
+                        attributes_dict[k] = str(kwargs[v])
+
+                if arg_attributes is not None:
+                    for k, v in arg_attributes.items():
+                        assert (
+                            len(args) > v
+                        ), f"Expected positional arg at index {v} not found in function signature"
+                        attributes_dict[k] = str(args[v])
+
                 _set_attributes(span, attributes_dict)
                 return func(*args, **kwargs)
 

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -1,4 +1,6 @@
 import os
+from functools import wraps
+from typing import Dict
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -58,3 +60,40 @@ def setup_default_tracing(set_global=True):
     )
 
     return provider
+
+
+def instrument(
+    _func=None,
+    *,
+    span_name: str = "",
+    record_exception: bool = True,
+    attributes: Dict[str, str] = None,
+    existing_tracer: trace.Tracer = None,
+):
+    """
+    A decorator to instrument a function with an OTEL tracing span.
+    """
+
+    def span_decorator(func):
+        tracer = existing_tracer or trace.get_tracer("airlock")
+
+        def _set_attributes(span, attributes_dict):
+            if attributes_dict:
+                for att in attributes_dict:
+                    span.set_attribute(att, attributes_dict[att])
+
+        @wraps(func)
+        def wrap_with_span(*args, **kwargs):
+            name = span_name or func.__qualname__
+            with tracer.start_as_current_span(
+                name, record_exception=record_exception
+            ) as span:
+                _set_attributes(span, attributes)
+                return func(*args, **kwargs)
+
+        return wrap_with_span
+
+    if _func is None:
+        return span_decorator
+    else:
+        return span_decorator(_func)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -59,3 +59,22 @@ def test_setup_default_tracing_otlp_with_env(monkeypatch):
     assert isinstance(exporter, OTLPSpanExporter)
     assert exporter._endpoint == "https://endpoint/v1/traces"
     assert exporter._headers == {"foo": "bar"}
+
+
+def test_not_instrument_decorator():
+    assert tracing.trace.get_current_span().is_recording() is False
+
+
+@tracing.instrument
+def test_instrument_decorator():
+    current_span = tracing.trace.get_current_span()
+    assert current_span.is_recording() is True
+    assert current_span.name == "test_instrument_decorator"
+
+
+@tracing.instrument(span_name="testing", attributes={"foo": "bar"})
+def test_instrument_decorator_with_name_and_attributes():
+    current_span = tracing.trace.get_current_span()
+    assert current_span.is_recording() is True
+    assert current_span.name == "testing"
+    assert current_span.attributes == {"foo": "bar"}

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,6 +1,7 @@
 import os
 
 import opentelemetry.exporter.otlp.proto.http.trace_exporter
+import pytest
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter
 
@@ -80,12 +81,42 @@ def test_instrument_decorator_with_name_and_attributes():
     assert current_span.attributes == {"foo": "bar"}
 
 
-@tracing.instrument(kwarg_attributes={"number": "num"})
-def assert_function_attributes(*, num):
-    current_span = tracing.trace.get_current_span()
-    assert current_span.attributes == {"number": num}
-    return num
+def test_instrument_decorator_with_function_kwarg_attributes():
+    @tracing.instrument(kwarg_attributes={"number": "num"})
+    def assert_function_kwarg_attributes(*, num):
+        current_span = tracing.trace.get_current_span()
+        assert current_span.attributes == {"number": str(num)}
+
+    assert_function_kwarg_attributes(num=1)
 
 
-def test_instrument_decorator_with_function_attributes():
-    assert_function_attributes(num=1)
+def test_instrument_decorator_with_function_arg_attributes():
+    @tracing.instrument(arg_attributes={"number": 0})
+    def assert_function_arg_attributes(num):
+        current_span = tracing.trace.get_current_span()
+        assert current_span.attributes == {"number": str(num)}
+
+    assert_function_arg_attributes(1)
+
+
+@pytest.mark.parametrize(
+    "instrument_params,expect_ok",
+    [
+        ({"kwarg_attributes": {"number": "foo"}}, False),
+        ({"arg_attributes": {"number": 1}}, False),
+        ({"arg_attributes": {"number": 0}}, True),
+    ],
+)
+def test_instrument_decorator_with_invalid_function_attributes(
+    instrument_params, expect_ok
+):
+    @tracing.instrument(**instrument_params)
+    def decorated_function(num):
+        current_span = tracing.trace.get_current_span()
+        assert current_span.attributes == {"number": str(num)}
+
+    if expect_ok:
+        decorated_function(1)
+    else:
+        with pytest.raises(AssertionError, match="not found in function signature"):
+            decorated_function(1)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -78,3 +78,14 @@ def test_instrument_decorator_with_name_and_attributes():
     assert current_span.is_recording() is True
     assert current_span.name == "testing"
     assert current_span.attributes == {"foo": "bar"}
+
+
+@tracing.instrument(kwarg_attributes={"number": "num"})
+def assert_function_attributes(*, num):
+    current_span = tracing.trace.get_current_span()
+    assert current_span.attributes == {"number": num}
+    return num
+
+
+def test_instrument_decorator_with_function_attributes():
+    assert_function_attributes(num=1)

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -11,6 +11,7 @@ from airlock.file_browser_api import (
     get_workspace_tree,
 )
 from tests import factories
+from tests.conftest import get_trace
 
 
 @pytest.fixture
@@ -421,3 +422,21 @@ def test_filter_files():
         UrlPath("foo/bar/child1"),
         UrlPath("foo/bar/child2"),
     ]
+
+
+def test_get_workspace_tree_tracing(workspace):
+    selected_path = UrlPath("some_dir/file_a.txt")
+    get_workspace_tree(workspace, selected_path)
+    traces = get_trace()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.attributes == {"workspace": workspace.name}
+
+
+@pytest.mark.django_db
+def test_get_request_tree_tracing(release_request):
+    get_request_tree(release_request)
+    traces = get_trace()
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.attributes == {"release_request": release_request.id}


### PR DESCRIPTION
Adds an `@instrument` function decorator, following [this post](https://betterprogramming.pub/using-decorators-to-instrument-python-code-with-opentelemetry-traces-d7f1c7d6f632), plus some extra options to retrieve arg/kwarg values from the function signature, so we can add in the workspace name / request id.

Adds tracing for all request views, workspace views, `get_workspace_tree` and `get_request_tree`. Leaving the rendering for another PR.