### PR TITLE
Clean up the otel config

### DIFF
--- a/dotenv-sample
+++ b/dotenv-sample
@@ -21,13 +21,9 @@ AIRLOCK_API_TOKEN=
 AIRLOCK_API_ENDPOINT="https://localhost:9000/api/v2"
 
 # Opentelemetry
-export OTEL_EXPORTER_OTLP_ENDPOINT="https://api.honeycomb.io"
-# key will be for specific prod/test/dev honeycomb environment
-export OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=VALIDKEY1234"
-
 # Set to True to log opentelemetry traces to the console in local env
-export OTEL_EXPORTER_CONSOLE=True
+# Warning can be verbose:
+OTEL_EXPORTER_CONSOLE=False
 
-# OTEL requires these, it needs to access settings before other stuff has initialised
-DJANGO_SETTINGS_MODULE="airlock.settings"
-PYTHONPATH="/usr/local/bin/python"
+# To send to honecomb in dev, create a token for the development and set it here.
+# OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=TOKEN34"

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,3 +1,5 @@
+import os
+
 import services.tracing as tracing
 
 
@@ -13,5 +15,7 @@ bind = "0.0.0.0"
 # in gunicorn's post_fork method in order to instrument our application process, see:
 # https://opentelemetry-python.readthedocs.io/en/latest/examples/fork-process-model/README.html
 def post_fork(server, worker):
+    # opentelemetry initialisation needs this, so ensure its set
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "airlock.settings")
     server.log.info("Worker spawned (pid: %s)", worker.pid)
     tracing.setup_default_tracing()

--- a/justfile
+++ b/justfile
@@ -126,10 +126,13 @@ fix: devenv
     $BIN/ruff --fix .
     $BIN/djhtml --tabwidth 2 airlock/
 
-
+# run airlock with django dev server
 run *ARGS: devenv
     $BIN/python manage.py runserver "$@"
 
+# run airlock with gunicorn, like in production
+gunicorn *args: devenv
+    $BIN/gunicorn --config gunicorn.conf.py airlock.wsgi {{ args }}
 
 # run Django's manage.py entrypoint
 manage *ARGS: devenv

--- a/justfile
+++ b/justfile
@@ -131,7 +131,7 @@ run *ARGS: devenv
     $BIN/python manage.py runserver "$@"
 
 # run airlock with gunicorn, like in production
-gunicorn *args: devenv
+run-gunicorn *args: devenv
     $BIN/gunicorn --config gunicorn.conf.py airlock.wsgi {{ args }}
 
 # run Django's manage.py entrypoint

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -50,12 +50,14 @@ def setup_default_tracing(set_global=True):
 
         add_exporter(provider, OTLPSpanExporter())
 
-    if "OTEL_EXPORTER_CONSOLE" in os.environ:
+    if os.environ.get("OTEL_EXPORTER_CONSOLE", "").lower() == "true":
         add_exporter(provider, ConsoleSpanExporter())
 
     if set_global:  # pragma: nocover
         trace.set_tracer_provider(provider)
 
+    # bug: this code requires some envvars to be set, so ensure they are
+    os.environ.setdefault("PYTHONPATH", "")
     from opentelemetry.instrumentation.auto_instrumentation import (  # noqa: F401
         sitecustomize,
     )

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -17,7 +17,7 @@ def test_setup_default_tracing_empty_env(monkeypatch):
 
 
 def test_setup_default_tracing_console(monkeypatch):
-    env = {"PYTHONPATH": "", "OTEL_EXPORTER_CONSOLE": "1"}
+    env = {"PYTHONPATH": "", "OTEL_EXPORTER_CONSOLE": "true"}
     monkeypatch.setattr(os, "environ", env)
     provider = setup_default_tracing(set_global=False)
 


### PR DESCRIPTION
The value of PYTHONPATH made no sense. And its only required to be present in the env, it can be set to nothing.  So I incorporated that in the code

Likewise, set a default DJANGO_SETTINGS_MODULE in the right place.

Also flipped OTEL_EXPORTER_CONSOLE to off by default, as its very
verbose.
