### PR TITLE
Refactor the instrument decorator to use inspect to find arguments

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -202,7 +202,7 @@ class PathItem:
         return "\n".join(build_string(self, ""))
 
 
-@instrument(arg_attributes={"workspace": 0})
+@instrument(func_attributes={"workspace": "workspace"})
 def get_workspace_tree(workspace, selected_path=ROOT_PATH, selected_only=False):
     """Recursively build workspace tree from the root dir.
 
@@ -244,7 +244,7 @@ def get_workspace_tree(workspace, selected_path=ROOT_PATH, selected_only=False):
     return root_node
 
 
-@instrument(arg_attributes={"release_request": 0})
+@instrument(func_attributes={"release_request": "release_request"})
 def get_request_tree(release_request, selected_path=ROOT_PATH, selected_only=False):
     """Build a tree recursively for a ReleaseRequest
 

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -45,7 +45,7 @@ def request_index(request):
 
 # we return different content if it is a HTMX request.
 @vary_on_headers("HX-Request")
-@instrument(kwarg_attributes={"release_request": "request_id"})
+@instrument(func_attributes={"release_request": "request_id"})
 def request_view(request, request_id: str, path: str = ""):
     release_request = get_release_request_or_raise(request.user, request_id)
 
@@ -99,7 +99,7 @@ def request_view(request, request_id: str, path: str = ""):
     return TemplateResponse(request, template, context)
 
 
-@instrument(kwarg_attributes={"release_request": "request_id"})
+@instrument(func_attributes={"release_request": "request_id"})
 @require_http_methods(["GET"])
 def request_contents(request, request_id: str, path: str):
     release_request = get_release_request_or_raise(request.user, request_id)
@@ -124,7 +124,7 @@ def request_contents(request, request_id: str, path: str):
     return serve_file(request, abspath, release_request.get_request_file(path))
 
 
-@instrument(kwarg_attributes={"release_request": "request_id"})
+@instrument(func_attributes={"release_request": "request_id"})
 @require_http_methods(["POST"])
 def request_submit(request, request_id):
     release_request = get_release_request_or_raise(request.user, request_id)
@@ -138,7 +138,7 @@ def request_submit(request, request_id):
     return redirect(release_request.get_url())
 
 
-@instrument(kwarg_attributes={"release_request": "request_id"})
+@instrument(func_attributes={"release_request": "request_id"})
 @require_http_methods(["POST"])
 def request_reject(request, request_id):
     release_request = get_release_request_or_raise(request.user, request_id)
@@ -152,7 +152,7 @@ def request_reject(request, request_id):
     return redirect(release_request.get_url())
 
 
-@instrument(kwarg_attributes={"release_request": "request_id"})
+@instrument(func_attributes={"release_request": "request_id"})
 @require_http_methods(["POST"])
 def request_release_files(request, request_id):
     release_request = get_release_request_or_raise(request.user, request_id)

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -39,7 +39,7 @@ def workspace_index(request):
 
 # we return different content if it is a HTMX request.
 @vary_on_headers("HX-Request")
-@instrument(kwarg_attributes={"workspace": "workspace_name"})
+@instrument(func_attributes={"workspace": "workspace_name"})
 def workspace_view(request, workspace_name: str, path: str = ""):
     workspace = get_workspace_or_raise(request.user, workspace_name)
     template = "file_browser/index.html"
@@ -99,7 +99,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     )
 
 
-@instrument(kwarg_attributes={"workspace": "workspace_name"})
+@instrument(func_attributes={"workspace": "workspace_name"})
 @require_http_methods(["GET"])
 def workspace_contents(request, workspace_name: str, path: str):
     workspace = get_workspace_or_raise(request.user, workspace_name)
@@ -115,7 +115,7 @@ def workspace_contents(request, workspace_name: str, path: str):
     return serve_file(request, abspath)
 
 
-@instrument(kwarg_attributes={"workspace": "workspace_name"})
+@instrument(func_attributes={"workspace": "workspace_name"})
 @require_http_methods(["POST"])
 def workspace_add_file_to_request(request, workspace_name):
     workspace = get_workspace_or_raise(request.user, workspace_name)

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -1,5 +1,6 @@
 import os
 from functools import wraps
+from inspect import Parameter, signature
 from typing import Dict
 
 from opentelemetry import trace
@@ -68,50 +69,67 @@ def instrument(
     span_name: str = "",
     record_exception: bool = True,
     attributes: Dict[str, str] = None,
-    arg_attributes: Dict[str, int] = None,
-    kwarg_attributes: Dict[str, str] = None,
+    func_attributes: Dict[str, str] = None,
     existing_tracer: trace.Tracer = None,
 ):
     """
     A decorator to instrument a function with an OTEL tracing span.
+
+    span_name: custom name for the span, defaults to name of decorated functionvv
+    record_exception: passed to `start_as_current_span`; whether to record
+      exceptions when they happen.
     attributes: custom attributes to set on the span
-    arg_attributes: k, v pairs of attribute name to index of positional
-       arg. Sets the span attribute k to the str representation of the
-       the arg at index v
-    kwarg_attributes: k, v pairs of attribute name to function
-       kwarg. Sets the span attribute k to the str representation of
-       the function kwarg v
+    func_attributes: k, v pairs of attribute name to function parameter
+      name. Sets the span attribute k to the str representation of
+      the function argument v (can be either positional or keyword argument).
+      v must be either a string, or an object that can be passed to str().
+    existing_tracer: pass an optional existing tracer to use. Defaults to
+      a tracer named with the value of the environment variable
+      `OTEL_SERVICE_NAME` if available, or the name of the module containing
+      the decoraated function.
     """
 
     def span_decorator(func):
-        tracer = existing_tracer or trace.get_tracer("airlock")
-
-        def _set_attributes(span, attributes_dict):
-            for att in attributes_dict:
-                span.set_attribute(att, attributes_dict[att])
+        tracer = existing_tracer or trace.get_tracer(
+            os.environ.get("OTEL_SERVICE_NAME", "airlock")
+        )
+        name = span_name or func.__qualname__
+        attributes_dict = attributes or {}
+        func_signature = signature(func)
+        default_params = {
+            param_name: param.default
+            for param_name, param in func_signature.parameters.items()
+            if param and param.default is not Parameter.empty
+        }
 
         @wraps(func)
         def wrap_with_span(*args, **kwargs):
-            name = span_name or func.__qualname__
+            if func_attributes is not None:
+                bound_args = func_signature.bind(*args, **kwargs).arguments
+                for attribute, parameter_name in func_attributes.items():
+                    # Find the value of this parameter by(in order):
+                    # 1) the function kwargs directly; if a function signature takes a parameter
+                    # like `**kwargs`, we can retrieve a named parameter from the keyword arguments
+                    # there
+                    # 2) the bound args retrieved from the function signature; this will find any
+                    # explicity passed values when the function was called.
+                    # 3) the parameter default value, if there is one
+                    # 4) Finally, raises an exception if we can't find a value for the expected parameter
+                    if parameter_name in kwargs:
+                        func_arg = kwargs[parameter_name]
+                    elif parameter_name in bound_args:
+                        func_arg = bound_args[parameter_name]
+                    elif parameter_name in default_params:
+                        func_arg = default_params[parameter_name]
+                    else:
+                        raise AttributeError(
+                            f"Expected argument {parameter_name} not found in function signature"
+                        )
+                    attributes_dict[attribute] = str(func_arg)
+
             with tracer.start_as_current_span(
-                name, record_exception=record_exception
-            ) as span:
-                attributes_dict = attributes or {}
-                if kwarg_attributes is not None:
-                    for k, v in kwarg_attributes.items():
-                        assert (
-                            v in kwargs
-                        ), f"Expected kwarg {v} not found in function signature"
-                        attributes_dict[k] = str(kwargs[v])
-
-                if arg_attributes is not None:
-                    for k, v in arg_attributes.items():
-                        assert (
-                            len(args) > v
-                        ), f"Expected positional arg at index {v} not found in function signature"
-                        attributes_dict[k] = str(args[v])
-
-                _set_attributes(span, attributes_dict)
+                name, record_exception=record_exception, attributes=attributes_dict
+            ):
                 return func(*args, **kwargs)
 
         return wrap_with_span


### PR DESCRIPTION
By using the inspect module to identify the bound arguments passed to the function, we don't need to separate arg and kwarg attributes, and we can handle cases different types of function call, where keywords aren't enforced. We can also now handle keywords captured in a **kwargs parameter.