### PR TITLE
Fix htmx

### DIFF
--- a/airlock/templates/file_browser/contents.html
+++ b/airlock/templates/file_browser/contents.html
@@ -83,7 +83,7 @@
                 frameborder=0
                 height=1000
                 style="width: 100%;"
-        />
+        ></iframe>
       </div>
     {% /card %}
 


### PR DESCRIPTION
Bad iframe tag had broken the htmx script from loading.

We hadn't noticed because it gracefully degrades, and works fine with
out it. Which is good I guess
