### PR TITLE
Tighten up iframe security

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -88,6 +88,14 @@ class PathItem:
             raise Exception(f"contents_url called on non-file path {self.relpath}")
         return self.container.get_contents_url(self.relpath, download=download)
 
+    def iframe_sandbox(self):
+        # we allow csv files to use scripts, as we render those ourselves
+        if self.relpath.suffix == ".csv":
+            return "allow-scripts"
+
+        # disable everything by default
+        return ""
+
     def download_url(self):
         return self.contents_url(download=True)
 

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -227,11 +227,9 @@ SESSION_COOKIE_NAME = "airlock-sessionid"
 
 # login is painful, so reduce the frequency that users need to do it after inactivity.
 SESSION_COOKIE_AGE = 8 * 7 * 24 * 60 * 60  # 8 weeks
+
 # time before we refresh users authorisation
 AIRLOCK_AUTHZ_TIMEOUT = 15 * 60  # 15 minutes
-
-# Enable frames
-X_FRAME_OPTIONS = "SAMEORIGIN"
 
 # Serve files from static dirs directly. This removes the need to run collectstatic
 # https://whitenoise.readthedocs.io/en/latest/django.html#WHITENOISE_USE_FINDERS

--- a/airlock/templates/file_browser/contents.html
+++ b/airlock/templates/file_browser/contents.html
@@ -83,6 +83,7 @@
                 frameborder=0
                 height=1000
                 style="width: 100%;"
+                sandbox="{{ path_item.iframe_sandbox }}"
         ></iframe>
       </div>
     {% /card %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -6,6 +6,7 @@ from django.http import Http404
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.vary import vary_on_headers
 from opentelemetry import trace
@@ -106,6 +107,7 @@ def request_view(request, request_id: str, path: str = ""):
 
 
 @instrument(func_attributes={"release_request": "request_id"})
+@xframe_options_sameorigin
 @require_http_methods(["GET"])
 def request_contents(request, request_id: str, path: str):
     release_request = get_release_request_or_raise(request.user, request_id)

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -5,6 +5,7 @@ from django.http import Http404, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.vary import vary_on_headers
 from opentelemetry import trace
@@ -102,6 +103,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
 
 
 @instrument(func_attributes={"workspace": "workspace_name"})
+@xframe_options_sameorigin
 @require_http_methods(["GET"])
 def workspace_contents(request, workspace_name: str, path: str):
     workspace = get_workspace_or_raise(request.user, workspace_name)


### PR DESCRIPTION
This makes two changes:

 - only set X-Frame-Options: SameOrigin for the two views that need it
   rather than globally

 - disable everything in frames, including js, with an exception for csv
   files, which a) we control the rendering of and b) uses some small
   amount of js, and likely will use more in the future.

The motivation as blocking js in html from executing.
