### PR TITLE
Add allow-same-origin to the iframe sandboxing

### DIFF
--- a/airlock/templates/file_browser/contents.html
+++ b/airlock/templates/file_browser/contents.html
@@ -101,7 +101,7 @@
                 frameborder=0
                 height=1000
                 style="width: 100%;"
-                sandbox="{{ path_item.iframe_sandbox }}"
+                sandbox="{{ path_item.iframe_sandbox }} allow-same-origin"
         ></iframe>
       </div>
     {% /card %}


### PR DESCRIPTION
Importantly, this allowed it to share the brower cache with the host
page. Without, nothing was ever cached!
