### PR TITLE
Code Browser first pass

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import secrets
 import shutil
 from dataclasses import dataclass, field
@@ -17,6 +18,12 @@ from django.utils.module_loading import import_string
 
 import old_api
 from airlock import renderers
+from airlock.lib.git import (
+    GitError,
+    list_files_from_repo,
+    project_name_from_url,
+    read_file_from_repo,
+)
 from airlock.types import UrlPath
 from airlock.users import User
 from airlock.utils import is_valid_file_type
@@ -42,6 +49,7 @@ class RequestFileType(Enum):
     OUTPUT = "output"
     SUPPORTING = "supporting"
     WITHDRAWN = "withdrawn"
+    CODE = "code"
 
 
 class FileReviewStatus(Enum):
@@ -225,6 +233,100 @@ class Workspace:
 
     def request_filetype(self, relpath: UrlPath) -> None:
         return None
+
+
+@dataclass(frozen=True)
+class CodeRepo:
+    workspace: str
+    repo: str
+    name: str
+    commit: str
+    directory: Path
+    pathlist: list[UrlPath]
+
+    class RepoNotFound(Exception):
+        pass
+
+    class CommitNotFound(Exception):
+        pass
+
+    @classmethod
+    def from_workspace(cls, workspace: Workspace, commit: str):
+        manifest_path = workspace.abspath("metadata/manifest.json")
+
+        try:
+            manifest = json.loads(manifest_path.read_text())
+            repo = manifest["repo"]
+        except (json.JSONDecodeError, KeyError):
+            raise cls.RepoNotFound(
+                "Could not parse manifest.json file: {manifest_path}:\n{exc}"
+            )
+
+        try:
+            pathlist = list_files_from_repo(repo, commit)
+        except GitError as exc:
+            raise CodeRepo.CommitNotFound(str(exc))
+
+        return cls(
+            workspace=workspace.name,
+            repo=repo,
+            name=project_name_from_url(repo),
+            commit=commit,
+            directory=settings.GIT_REPO_DIR / workspace.name,
+            pathlist=pathlist,
+        )
+
+    def get_id(self) -> str:
+        return f"{self.name}@{self.commit[:7]}"
+
+    def get_url(self, relpath: UrlPath = ROOT_PATH) -> str:
+        return reverse(
+            "code_view",
+            kwargs={
+                "workspace_name": self.workspace,
+                "commit": self.commit,
+                "path": relpath,
+            },
+        )
+
+    def get_contents_url(
+        self, relpath: UrlPath = ROOT_PATH, download: bool = False
+    ) -> str:
+        # TODO
+        url = reverse(
+            "code_contents",
+            kwargs={
+                "workspace_name": self.workspace,
+                "commit": self.commit,
+                "path": relpath,
+            },
+        )
+
+        renderer = self.get_renderer(relpath)
+        url += f"?cache_id={renderer.cache_id}"
+
+        return url
+
+    def get_renderer(self, relpath: UrlPath) -> renderers.Renderer:
+        # we do not care about valid file types here, so we just get the base renderers
+
+        try:
+            contents = read_file_from_repo(self.repo, self.commit, relpath)
+        except GitError as exc:
+            raise BusinessLogicLayer.FileNotFound(str(exc))
+
+        renderer_class = renderers.get_code_renderer(relpath)
+        # note: we don't actually need an explicit cache_id here, as the commit is
+        # already in the url. But we want to add the template version to the
+        # cache id, so pass an empty string.
+        return renderer_class.from_contents(
+            contents=contents,
+            relpath=relpath,
+            cache_id="",
+        )
+
+    def request_filetype(self, relpath: UrlPath) -> RequestFileType | None:
+        return RequestFileType.CODE
 
 
 @dataclass(frozen=True)

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -292,7 +292,6 @@ class CodeRepo:
     def get_contents_url(
         self, relpath: UrlPath = ROOT_PATH, download: bool = False
     ) -> str:
-        # TODO
         url = reverse(
             "code_contents",
             kwargs={

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -394,15 +394,25 @@ def get_code_tree(
     leaf_directories = set()
 
     if selected_only:
+        # we only want the selected path, and its immediate children if it has any
         pathlist = [selected_path]
-        len_selected = len(selected_path.parts)
 
+        # we only have paths, so we find any child paths of the selected_path
+        len_selected = len(selected_path.parts)
         for path in repo.pathlist:
+            if path == selected_path:
+                continue
             if path.parts[:len_selected] == selected_path.parts:
+                # same prefix, so is a child
                 child_path = UrlPath(*path.parts[: len_selected + 1])
+                pathlist.append(child_path)
+
+                # if this child has >1 additional path segment, it is
+                # a directory.  So, mark it as a leaf directory from this
+                # limited tree view, so it is correctly classified by
+                # get_path_tree as a directory.
                 if len(path.parts) > len_selected + 1:
                     leaf_directories.add(child_path)
-                pathlist.append(child_path)
     else:
         pathlist = repo.pathlist
 

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -154,8 +154,9 @@ class PathItem:
 
         if self.type == PathType.FILE:
             classes.append(self.file_type())
-            if not self.is_valid():
-                classes.append("invalid")
+            if self.request_filetype != RequestFileType.CODE:
+                if not self.is_valid():
+                    classes.append("invalid")
 
         if self.selected:
             classes.append("selected")

--- a/airlock/lib/git.py
+++ b/airlock/lib/git.py
@@ -1,0 +1,414 @@
+"""
+Utility functions for interacting with git
+"""
+
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path, PurePath
+from subprocess import run as subprocess_run
+from urllib.parse import urlparse, urlunparse
+
+### airlock change from job-runner start here
+# from jobrunner import config
+# from jobrunner.lib.string_utils import project_name_from_url
+# from jobrunner.lib.subprocess_utils import subprocess_run
+from airlock import settings as config
+from airlock.types import UrlPath
+
+
+def project_name_from_url(url):
+    """
+    Return the name of a repository from its URL (there's nothing particularly
+    significant about a repository's name but it can make debugging easier to
+    include it in various places)
+    """
+    # "URL" here can in fact be a local path and it may be a Windows path, in
+    # which case we need to convert the slash type so that it gets handled
+    # correctly
+    url = url.replace("\\", "/")
+    name = urlparse(url).path.strip("/").split("/")[-1]
+    if name.endswith(".git"):
+        name = name[:-4]
+    return name
+
+
+def list_files_from_repo(repo_url, commit_sha):
+    repo_dir = get_local_repo_dir(repo_url)
+    try:
+        ensure_commit_fetched(repo_dir, repo_url, commit_sha)
+        response = subprocess_run(
+            ["git", "ls-tree", "--name-only", "-r", commit_sha],
+            capture_output=True,
+            check=True,
+            cwd=repo_dir,
+        )
+    except subprocess.SubprocessError:
+        raise GitError(f"Error reading from {repo_url} @ {commit_sha}")
+    # return a list of UrlPaths
+    return [
+        UrlPath(line) for line in response.stdout.decode("utf8").strip().split("\n")
+    ]
+
+
+### end of airlock changes
+
+
+log = logging.getLogger(__name__)
+
+
+# See `commit_already_fetched`
+SENTINEL_TAG_PREFIX = "fetched/"
+
+# Prevent git from ever prompting for credentials. Hat tip:
+# https://serverfault.com/a/1054253
+NEVER_PROMPT_FOR_AUTH_ENV = dict(
+    os.environ,
+    GIT_TERMINAL_PROMPT="0",
+    GIT_ASKPASS="echo",
+    GCM_INTERACTIVE="never",
+)
+
+
+class GitError(Exception):
+    pass
+
+
+class GitFileNotFoundError(GitError):
+    pass
+
+
+class GitRepoNotReachableError(GitError):
+    pass
+
+
+class GitUnknownRefError(GitError):
+    pass
+
+
+def read_file_from_repo(repo_url, commit_sha, path):
+    """
+    Return the contents of the file at `path` in `repo_url` as of `commit_sha`
+    """
+    repo_dir = get_local_repo_dir(repo_url)
+    ensure_commit_fetched(repo_dir, repo_url, commit_sha)
+    try:
+        response = subprocess_run(
+            ["git", "show", f"{commit_sha}:{path}"],
+            capture_output=True,
+            check=True,
+            cwd=repo_dir,
+        )
+    except subprocess.SubprocessError as e:
+        if e.stderr.startswith(b"fatal: path ") and b"does not exist" in e.stderr:
+            raise GitFileNotFoundError(f"File '{path}' not found in repository")
+        else:
+            log.exception(f"Error reading from {repo_url} @ {commit_sha}")
+            raise GitError(f"Error reading from {repo_url} @ {commit_sha}")
+    # Note the response here is bytes not text as git doesn't know what
+    # encoding the file is supposed to have
+    return response.stdout
+
+
+def checkout_commit(repo_url, commit_sha, target_dir):
+    """
+    Checkout the contents of `repo_url` as of `commit_sha` into `target_dir`
+    """
+    repo_dir = get_local_repo_dir(repo_url)
+    ensure_commit_fetched(repo_dir, repo_url, commit_sha)
+    os.makedirs(target_dir, exist_ok=True)
+    subprocess_run(
+        [
+            "git",
+            f"--work-tree={target_dir}",
+            "checkout",
+            "--quiet",
+            "--force",
+            commit_sha,
+        ],
+        check=True,
+        # Set GIT_DIR rather than changing working directory so that
+        # `target_dir` gets correctly resolved
+        env=dict(os.environ, GIT_DIR=repo_dir),
+    )
+
+
+def commit_reachable_from_ref(repo_url, commit_sha, ref):
+    """
+    Given a `ref` (branch name, tag, etc) on a remote repo, check whether the
+    supplied commit is reachable from that ref.
+    """
+    ref_sha = get_sha_from_remote_ref(repo_url, ref)
+    # The easy case and the case I expect to be hit almost every time as the UI
+    # currently only supports running against the branch head
+    if commit_sha == ref_sha:
+        return True
+    # However a well (or badly) timed push could cause the target sha and the
+    # branch head to diverge, so we need to handle that. In order to do so we
+    # need to fetch the history of the branch. We first fetch just the last 10
+    # commits on the assumption that it's probably one of those. If that fails
+    # we fetch the entire branch history.
+    repo_dir = get_local_repo_dir(repo_url)
+    ensure_git_init(repo_dir)
+    fetch_commit(repo_dir, repo_url, ref_sha, depth=10)
+    if commit_is_ancestor(repo_dir, commit_sha, ref_sha):
+        return True
+    # The below is a git magic number meaning "infinite depth". See:
+    # https://git-scm.com/docs/shallow
+    fetch_commit(repo_dir, repo_url, ref_sha, depth=2147483647)
+    return commit_is_ancestor(repo_dir, commit_sha, ref_sha)
+
+
+def get_sha_from_remote_ref(repo_url, ref):
+    """Gets the SHA of the commit associated with the ref at the repo URL.
+
+    Args:
+        repo_url: A repo URL.
+        ref: A ref, such as a branch name, tag name, etc.
+
+    Returns:
+        The SHA of the commit. For example, if the ref is an annotated tag, then the SHA
+        will be that of the associated commit, rather than that of the annotated tag.
+
+    Raises:
+        GitRepoNotReachableError: We couldn't read from the remote repo
+        GitUnknownRefError: We couldn't find the specified ref in the remote repo
+    """
+    # If `ref` matches an annotated tag, then `deref_ref` will match the associated
+    # commit.
+    deref_ref = f"{ref}^{{}}"
+    try:
+        response = subprocess_run(
+            [
+                "git",
+                "ls-remote",
+                "--quiet",
+                add_access_token_and_proxy(repo_url),
+                ref,
+                deref_ref,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env=NEVER_PROMPT_FOR_AUTH_ENV,
+        )
+        output = response.stdout
+    except subprocess.SubprocessError as exc:
+        redact_token_from_exception(exc)
+        log.exception("Error reading from remote repository")
+        raise GitRepoNotReachableError(f"Could not read from {repo_url}")
+    results = _parse_ls_remote_output(output)
+    for target_ref in [
+        ref,  # e.g. HEAD
+        f"refs/heads/{ref}",  # Branch
+        f"refs/tags/{deref_ref}",  # Annotated tag
+        f"refs/tags/{ref}",  # Lightweight tag
+    ]:
+        if target_ref in results:
+            return results[target_ref]
+    raise GitUnknownRefError(f"Could not find ref '{ref}' in {repo_url}")
+
+
+def _parse_ls_remote_output(output):
+    lines = [line.split() for line in output.splitlines()]
+    return {line[1]: line[0] for line in lines}
+
+
+def get_local_repo_dir(repo_url):
+    # We don't need to worry that repo_name may not be unique here (e.g. if we
+    # end up using repos from different organisations): we're just treating
+    # these directories as big buckets of commits, so we could in principle use
+    # the same local git directory for all repositories and it would work fine.
+    # But it's probably more operationally convenient to split them up like
+    # this.
+    repo_name = project_name_from_url(repo_url)
+    return config.GIT_REPO_DIR / Path(repo_name).with_suffix(".git")
+
+
+def ensure_commit_fetched(repo_dir, repo_url, commit_sha):
+    ensure_git_init(repo_dir)
+    # It's safe to keep re-fetching the same commit, but it requires
+    # talking to the remote repo every time so it's better to avoid it if
+    # we can
+    if not commit_already_fetched(repo_dir, commit_sha):
+        fetch_commit(repo_dir, repo_url, commit_sha)
+
+
+def ensure_git_init(repo_dir):
+    if not os.path.exists(repo_dir / "config"):
+        subprocess_run(["git", "init", "--bare", "--quiet", repo_dir], check=True)
+
+
+def commit_already_fetched(repo_dir, commit_sha):
+    """
+    Return whether a given commit exists in a repo directory
+
+    We used to do this with:
+
+        git cat-file -e 'COMMIT_SHA^{commit}'
+
+    However it's possible that an interrupted fetch leaves the commit object in
+    place without all of its associated blobs, meaning that the above check
+    passes but attempting to check out the commit will fail. To work around
+    this we create a special "sentinel" tag for each commit to indicate that
+    the entire fetch process has completed successfully.
+    """
+    response = subprocess_run(
+        [
+            "git",
+            "tag",
+            "--list",
+            SENTINEL_TAG_PREFIX + commit_sha,
+            "--points-at",
+            commit_sha,
+            "--format",
+            "exists",
+        ],
+        check=True,
+        capture_output=True,
+        cwd=repo_dir,
+    )
+    return response.stdout.strip() == b"exists"
+
+
+def mark_commmit_as_fetched(repo_dir, commit_sha):
+    """
+    Create a special "sentinel" tag to indicate that the supplied commit has
+    been fully fetched (see `commit_already_fetched` above)
+    """
+    subprocess_run(
+        [
+            "git",
+            "tag",
+            "--force",
+            SENTINEL_TAG_PREFIX + commit_sha,
+            commit_sha,
+        ],
+        check=True,
+        capture_output=True,
+        cwd=repo_dir,
+    )
+
+
+def fetch_commit(repo_dir, repo_url, commit_sha, depth=1):
+    # The unfortunate retry complexity here is due to mysterious errors we
+    # sometimes get when fetching commits in the live environment:
+    #
+    #   error: RPC failed; curl 56 GnuTLS recv error (-9): A TLS packed with unexpected length was received
+    #
+    # They are mostly transient (hence the retries) but certain commits seem to
+    # trigger them more often than others so presumably it's something to do
+    # with the precise sequence of packets that get sent. More details here:
+    # https://github.com/opensafely/job-runner/issues/5
+    max_retries = 5
+    sleep = 4
+    attempt = 1
+    authenticated_url = add_access_token_and_proxy(repo_url)
+    while True:
+        try:
+            subprocess_run(
+                [
+                    "git",
+                    "fetch",
+                    "--force",
+                    "--depth",
+                    str(depth),
+                    authenticated_url,
+                    commit_sha,
+                ],
+                check=True,
+                capture_output=True,
+                cwd=repo_dir,
+                env=NEVER_PROMPT_FOR_AUTH_ENV,
+            )
+            mark_commmit_as_fetched(repo_dir, commit_sha)
+            break
+        except subprocess.SubprocessError as e:
+            redact_token_from_exception(e)
+            log.exception(f"Error fetching commit (attempt {attempt}/{max_retries})")
+            if (
+                b"GnuTLS recv error" in e.stderr
+                or b"SSL_read: Connection was reset" in e.stderr
+            ):
+                attempt += 1
+                if attempt > max_retries:
+                    raise GitError(
+                        f"Network error when fetching commit {commit_sha} from"
+                        f" {repo_url}\n"
+                        "(This may work if you try again later)"
+                    )
+                else:
+                    time.sleep(sleep)
+                    sleep *= 2
+            else:
+                raise GitError(f"Error fetching commit {commit_sha} from {repo_url}")
+
+
+def commit_is_ancestor(repo_dir, ancestor_sha, descendant_sha):
+    response = subprocess_run(
+        ["git", "merge-base", "--is-ancestor", ancestor_sha, descendant_sha],
+        cwd=repo_dir,
+        capture_output=True,
+    )
+    return response.returncode == 0
+
+
+def add_access_token_and_proxy(repo_url):
+    # We've already validated that the repo url starts with https://github.com
+    repo_url = repo_url.replace("github.com", config.GIT_PROXY_DOMAIN)
+    # We previously did a complicated thing involving the GIT_ASKPASS
+    # executable which worked OK on Linux but not on Windows or macOS, so we're
+    # doing the more reliable thing of just sticking the token in the URL
+    token = config.PRIVATE_REPO_ACCESS_TOKEN
+    if not token:
+        return repo_url
+    # Ensure we only ever send our token to github.com over https
+    parsed = urlparse(repo_url)
+    if parsed.hostname != config.GIT_PROXY_DOMAIN or parsed.scheme != "https":
+        return repo_url
+    # Don't overwrite existing auth details (not sure why they'd be there but
+    # seems polite)
+    if parsed.username or parsed.password:
+        return repo_url
+    # Github accepts arbitrary usernames when using a PAT so this is just for
+    # easy identification in the proxy logs
+    username = f"jobrunner-{config.BACKEND}"
+    # Add the token to the URL
+    return urlunparse(parsed._replace(netloc=f"{username}:{token}@{parsed.netloc}"))
+
+
+def redact_token_from_exception(exception):
+    # The disadvantage of the above approach is it we have to do some work to
+    # avoid leaking the token into the logs. However, even if it does leak it's
+    # not the end of the world: the developers who have access to the logs have
+    # access to the token in any case; and all it provides is read-only access
+    # to some private git repos which will eventually become public in any
+    # case.
+    token = config.PRIVATE_REPO_ACCESS_TOKEN
+    if not token:
+        return
+    if isinstance(exception.cmd, list):
+        exception.cmd = [redact(arg, token) for arg in exception.cmd]
+    else:
+        exception.cmd = redact(exception.cmd, token)
+    if exception.output is not None:
+        exception.output = redact(exception.output, token)
+    if exception.stderr is not None:
+        exception.stderr = redact(exception.stderr, token)
+
+
+def redact(value, secret):
+    mask = "********"
+    if isinstance(value, str):
+        return value.replace(secret, mask)
+    elif isinstance(value, bytes):
+        return value.replace(secret.encode("ascii"), mask.encode("ascii"))
+    # subprocess arguments can also be pathlib.Path instances (PurePath is the
+    # base class for all platform-specific Path classes). We never put the
+    # token in a path so there's nothing to do here
+    elif isinstance(value, PurePath):
+        return value
+    else:
+        raise ValueError(f"Got {type(value)} expected str, bytes or Path")

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -285,6 +285,12 @@ WORKSPACE_DIR = WORK_DIR / get_env_var("AIRLOCK_WORKSPACE_DIR")
 
 REQUEST_DIR = WORK_DIR / get_env_var("AIRLOCK_REQUEST_DIR")
 
+# This is a cache, so we default to a workdir subdirectory
+GIT_REPO_DIR = WORK_DIR / os.environ.get("AIRLOCK_REPO_DIR", "repos")
+GIT_PROXY_DOMAIN = "github-proxy.opensafely.org"
+PRIVATE_REPO_ACCESS_TOKEN = os.environ.get("PRIVATE_REPO_ACCESS_TOKEN", "")
+
+
 AIRLOCK_API_ENDPOINT = os.environ.get(
     "AIRLOCK_API_ENDPOINT", "https://jobs.opensafely.org/api/v2"
 )

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -8,6 +8,10 @@
   <style>
 
 /* tree styles */
+    ul.root {
+      padding: 0.2rem;
+    }
+
     ul.tree {
       list-style: none;
     }
@@ -124,8 +128,10 @@
         {% #button type="link" href=workspace.get_url variant="success" id="workspace-home-button" %}Workspace Home{% /button %}
       {% elif current_request %}
         {% #button variant="success" type="link" href=current_request.get_url id="current-request-button" %}Current release request{% /button %}
+      {% elif context == "request" or context == "workspace" %}
+        {% #button type="link" href=workspace.get_requests_url variant="success" id="requests-workspace-button" %}All release requests for workspace{% /button %}
       {% endif %}
-      {% #button type="link" href=workspace.get_requests_url variant="success" id="requests-workspace-button" %}All release requests for workspace{% /button %}
+
     </div>
   {% endfragment %}
 

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -20,6 +20,7 @@ from django.urls import include, path
 from django.views.generic import RedirectView
 
 import airlock.views
+import airlock.views.code
 import assets.views
 
 
@@ -126,6 +127,21 @@ urlpatterns = [
         "requests/comment/<str:request_id>/<str:group>",
         airlock.views.group_comment,
         name="group_comment",
+    ),
+    path(
+        "code/view/<str:workspace_name>/<str:commit>/",
+        airlock.views.code.view,
+        name="code_view",
+    ),
+    path(
+        "code/view/<str:workspace_name>/<str:commit>/<path:path>",
+        airlock.views.code.view,
+        name="code_view",
+    ),
+    path(
+        "code/contents/<str:workspace_name>/<str:commit>/<path:path>",
+        airlock.views.code.contents,
+        name="code_contents",
     ),
     path(r"docs/", airlock.views.serve_docs, name="docs_home"),
     path(r"docs/<path:path>", airlock.views.serve_docs),

--- a/airlock/views/code.py
+++ b/airlock/views/code.py
@@ -1,0 +1,83 @@
+from django.http import Http404
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
+from django.views.decorators.clickjacking import xframe_options_sameorigin
+from django.views.decorators.http import require_http_methods
+from django.views.decorators.vary import vary_on_headers
+
+from airlock.business_logic import CodeRepo, bll
+from airlock.file_browser_api import get_code_tree
+from airlock.types import UrlPath
+from airlock.users import User
+from airlock.views.helpers import (
+    get_path_item_from_tree_or_404,
+    get_workspace_or_raise,
+    serve_file,
+)
+from services.tracing import instrument
+
+
+def get_repo_or_raise(user: User, workspace_name: str, commit: str):
+    workspace = get_workspace_or_raise(user, workspace_name)
+
+    try:
+        return CodeRepo.from_workspace(workspace, commit)
+    except bll.FileNotFound:
+        # cannot find manifest.json
+        raise Http404()
+    except (CodeRepo.RepoNotFound, CodeRepo.CommitNotFound):
+        raise Http404()
+
+
+# we return different content if it is a HTMX request.
+@vary_on_headers("HX-Request")
+@instrument(func_attributes={"workspace": "workspace_name", "commit": "commit"})
+def view(request, workspace_name: str, commit: str, path: str = ""):
+    repo = get_repo_or_raise(request.user, workspace_name, commit)
+    template = "file_browser/index.html"
+    selected_only = False
+
+    if request.htmx:
+        template = "file_browser/contents.html"
+        selected_only = True
+
+    tree = get_code_tree(repo, UrlPath(path), selected_only)
+
+    path_item = get_path_item_from_tree_or_404(tree, path)
+
+    is_directory_url = path.endswith("/") or path == ""
+    if path_item.is_directory() != is_directory_url:
+        return redirect(path_item.url())
+
+    current_request = bll.get_current_request(workspace_name, request.user)
+
+    return TemplateResponse(
+        request,
+        template,
+        {
+            "workspace": workspace_name,
+            "repo": repo,
+            "root": tree,
+            "path_item": path_item,
+            "is_supporting_file": False,
+            "is_author": False,
+            "is_output_checker": False,
+            "context": "repo",
+            "title": f"{repo.repo}@{commit[:7]}",
+            "current_request": current_request,
+        },
+    )
+
+
+@instrument(func_attributes={"workspace": "workspace_name", "commit": "commit"})
+@xframe_options_sameorigin
+@require_http_methods(["GET"])
+def contents(request, workspace_name: str, commit: str, path: str):
+    repo = get_repo_or_raise(request.user, workspace_name, commit)
+
+    try:
+        renderer = repo.get_renderer(UrlPath(path))
+    except bll.FileNotFound:
+        raise Http404()
+
+    return serve_file(request, renderer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ concurrency = ["greenlet", "thread"]
 plugins = ["django_coverage_plugin"]
 omit = [
   "*/assets/*",
+  "airlock/lib/git.py",
 ]
 
 
@@ -67,6 +68,9 @@ no_implicit_reexport = true
 warn_return_any = true
 check_untyped_defs = true
 mypy_path = "stubs"
+exclude = [
+   "airlock/lib/git.py",
+]
 
 # Don't follow the import chain into the modules containing code vendored from elsewhere
 [[tool.mypy.overrides]]
@@ -75,6 +79,10 @@ follow_imports = "skip"
 [[tool.mypy.overrides]]
 module = "services.tracing"
 follow_imports = "skip"
+[[tool.mypy.overrides]]
+module = "airlock.lib.git"
+follow_imports = "skip"
+
 
 [tool.django-stubs]
 django_settings_module = "airlock.settings"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,8 +40,10 @@ def temp_storage(settings, tmp_path):
     settings.WORK_DIR = tmp_path
     settings.WORKSPACE_DIR = tmp_path / "workspaces"
     settings.REQUEST_DIR = tmp_path / "requests"
+    settings.GIT_REPO_DIR = tmp_path / "repos"
     settings.WORKSPACE_DIR.mkdir(parents=True)
     settings.REQUEST_DIR.mkdir(parents=True)
+    settings.GIT_REPO_DIR.mkdir(parents=True)
 
 
 @pytest.fixture

--- a/tests/integration/views/test_code.py
+++ b/tests/integration/views/test_code.py
@@ -1,0 +1,82 @@
+import pytest
+
+from airlock.types import UrlPath
+from tests import factories
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_code_view_index(airlock_client):
+    airlock_client.login(output_checker=True)
+    repo = factories.create_repo("workspace")
+
+    response = airlock_client.get(f"/code/view/workspace/{repo.commit}/")
+    assert "project.yaml" in response.rendered_content
+
+
+def test_code_view_file(airlock_client):
+    airlock_client.login(output_checker=True)
+    repo = factories.create_repo("workspace")
+
+    response = airlock_client.get(f"/code/view/workspace/{repo.commit}/project.yaml")
+    assert repo.get_contents_url(UrlPath("project.yaml")) in response.rendered_content
+
+
+def test_code_view_file_htmx(airlock_client):
+    airlock_client.login(output_checker=True)
+    repo = factories.create_repo("workspace")
+
+    response = airlock_client.get(
+        f"/code/view/workspace/{repo.commit}/project.yaml",
+        headers={"HX-Request": "true"},
+    )
+
+    assert repo.get_contents_url(UrlPath("project.yaml")) in response.rendered_content
+    assert response.template_name == "file_browser/contents.html"
+    assert '<ul id="tree"' not in response.rendered_content
+    assert "HX-Request" in response.headers["Vary"]
+
+
+def test_code_view_dir_redirects(airlock_client):
+    airlock_client.login(output_checker=True)
+    repo = factories.create_repo("workspace", files=[("somedir/foo.txt", "")])
+
+    response = airlock_client.get(f"/code/view/workspace/{repo.commit}/somedir")
+    assert response.status_code == 302
+    assert (
+        response.headers["Location"] == f"/code/view/workspace/{repo.commit}/somedir/"
+    )
+
+
+def test_code_view_no_repo(airlock_client):
+    airlock_client.login(output_checker=True)
+    factories.create_workspace("workspace")
+
+    response = airlock_client.get("/code/view/workspace/notexist/")
+    assert response.status_code == 404
+
+
+def test_code_view_no_commit(airlock_client):
+    airlock_client.login(output_checker=True)
+    factories.create_repo("workspace")
+
+    response = airlock_client.get("/code/view/workspace/abcdefg/")
+    assert response.status_code == 404
+
+
+def test_code_contents_file(airlock_client):
+    airlock_client.login(output_checker=True)
+    repo = factories.create_repo("workspace")
+    response = airlock_client.get(
+        f"/code/contents/workspace/{repo.commit}/project.yaml"
+    )
+    assert response.status_code == 200
+    assert response.content == b'<pre class="yaml">\nyaml: true\n</pre>\n'
+
+
+def test_code_contents_not_exists(airlock_client):
+    airlock_client.login(output_checker=True)
+    repo = factories.create_repo("workspace")
+    response = airlock_client.get(f"/code/contents/workspace/{repo.commit}/notexist")
+    assert response.status_code == 404

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -6,7 +6,7 @@ from django.template.loader import render_to_string
 from airlock.file_browser_api import (
     PathType,
     UrlPath,
-    filter_files,
+    get_code_tree,
     get_request_tree,
     get_workspace_tree,
 )
@@ -433,23 +433,6 @@ def test_request_tree_siblings(release_request):
     }
 
 
-def test_filter_files():
-    selected = UrlPath("foo/bar")
-    files = [
-        UrlPath("foo/bar"),
-        UrlPath("foo/bar/child1"),
-        UrlPath("foo/bar/child2"),
-        UrlPath("foo/bar/child1/grandchild"),
-        UrlPath("foo/other"),
-    ]
-
-    assert list(filter_files(selected, files)) == [
-        UrlPath("foo/bar"),
-        UrlPath("foo/bar/child1"),
-        UrlPath("foo/bar/child2"),
-    ]
-
-
 def test_get_workspace_tree_tracing(workspace):
     selected_path = UrlPath("some_dir/file_a.txt")
     get_workspace_tree(workspace, selected_path)
@@ -466,3 +449,46 @@ def test_get_request_tree_tracing(release_request):
     assert len(traces) == 1
     trace = traces[0]
     assert trace.attributes == {"release_request": release_request.id}
+
+
+def test_get_code_tree(workspace):
+    repo = factories.create_repo(
+        workspace,
+        [
+            ("bar/1.txt", ""),
+            ("foo/1.txt", ""),
+            ("foo/2.txt", ""),
+            ("foo/baz/3.txt", ""),
+        ],
+    )
+
+    tree = get_code_tree(repo, UrlPath("foo"), selected_only=False)
+
+    expected = textwrap.dedent(
+        f"""
+        {repo.get_id()}*
+          bar
+            1.txt
+          foo***
+            baz
+              3.txt
+            1.txt
+            2.txt
+        """
+    )
+
+    assert str(tree).strip() == expected.strip()
+
+    tree = get_code_tree(repo, UrlPath("foo"), selected_only=True)
+
+    expected = textwrap.dedent(
+        f"""
+        {repo.get_id()}*
+          foo***
+            baz
+            1.txt
+            2.txt
+        """
+    )
+
+    assert str(tree).strip() == expected.strip()

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -89,11 +89,11 @@ def test_renderers_get_renderer_request(tmp_path, rf, suffix, mimetype, template
 
 
 @pytest.mark.parametrize("suffix,mimetype,template_path", RENDERER_TESTS)
-def test_text_renderer_from_string(suffix, mimetype, template_path):
+def test_code_renderer_from_contents(suffix, mimetype, template_path):
     path = UrlPath("test." + suffix)
 
-    renderer_class = renderers.get_renderer(path)
-    renderer = renderer_class.from_string("test", path, "cache_id")
+    renderer_class = renderers.get_code_renderer(path)
+    renderer = renderer_class.from_contents(b"test", path, "cache_id")
     response = renderer.get_response()
 
     assert response.status_code == 200


### PR DESCRIPTION
This is a preview/spike of the code browser.

We need https://github.com/opensafely-core/job-runner/issues/701 to be done before we can get the commit we need to link to the right code browser.

So there are no links that that will take you to the code browser.  To test it, you will need to:
  - add a metadata/manifest.json file to the workspace directory with the contents: `"repo": "https://github.com/opensafely/$REPO"`
  - manually navigate to `/code/view/$WORKSPACE/$COMMIT/`
  
It rather large as we import some code from job-runner, and add a bunch of new views and logic.