### PR TITLE
Send airlock request id to jobserver when releasing files

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1007,7 +1007,7 @@ class BusinessLogicLayer:
         file_paths = request.get_output_file_paths()
         self.validate_file_types(file_paths)
 
-        filelist = old_api.create_filelist(file_paths)
+        filelist = old_api.create_filelist(file_paths, request)
         jobserver_release_id = old_api.create_release(
             request.workspace, filelist.json(), user.username
         )

--- a/old_api/__init__.py
+++ b/old_api/__init__.py
@@ -11,7 +11,7 @@ from old_api.schema import FileList, FileMetadata, UrlFileName
 session = requests.Session()
 
 
-def create_filelist(paths):
+def create_filelist(paths, release_request):
     files = []
 
     for relpath, abspath in paths:
@@ -26,11 +26,13 @@ def create_filelist(paths):
                 # that make changes which risk changing the output format.
                 date=modified_time(abspath),  # type: ignore[arg-type]
                 url=UrlFileName(relpath),  # not needed, but has to be set
-                metadata={"tool": "airlock"},
+                metadata={"tool": "airlock", "airlock_id": release_request.id},
             )
         )
 
-    return FileList(files=files, metadata={"tool": "airlock"})
+    return FileList(
+        files=files, metadata={"tool": "airlock", "airlock_id": release_request.id}
+    )
 
 
 def create_release(workspace_name, release_json, username):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -167,11 +167,11 @@ def test_provider_request_release_files(mock_old_api):
                 "size": 4,
                 "sha256": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
                 "date": old_api.modified_time(abspath),
-                "metadata": {"tool": "airlock"},
+                "metadata": {"tool": "airlock", "airlock_id": release_request.id},
                 "review": None,
             }
         ],
-        "metadata": {"tool": "airlock"},
+        "metadata": {"tool": "airlock", "airlock_id": release_request.id},
         "review": None,
     }
 


### PR DESCRIPTION
This allows jobserver to use the airlock request ID when it creates a release.

Related job-server PR: https://github.com/opensafely-core/job-server/pull/4295