### PR TITLE
Fixes empty directory exception

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -281,11 +281,15 @@ def get_workspace_tree(
         # we are only loading a single directory, not an entire tree
         abspath = workspace.abspath(selected_path)
         if abspath.is_dir():
-            for child in abspath.iterdir():
-                path = child.relative_to(root)
-                pathlist.append(path)
-                if child.is_dir():
-                    leaf_directories.add(path)
+            children = list(abspath.iterdir())
+            if children:
+                for child in children:
+                    path = child.relative_to(root)
+                    pathlist.append(path)
+                    if child.is_dir():
+                        leaf_directories.add(path)
+            else:
+                leaf_directories.add(selected_path)
 
     else:
         pathlist, leaf_directories = scantree(root)

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -138,7 +138,7 @@ def test_get_workspace_tree_selected_only_file(workspace):
     assert str(tree).strip() == expected.strip()
 
 
-def test_get_workspace_tree_selected_only_dir(workspace):
+def test_get_workspace_tree_selected_has_empty_dir(workspace):
     selected_path = UrlPath("some_dir")
     # needed for coverage of is_file() branch
     (workspace.root() / "some_dir/subdir").mkdir()
@@ -159,6 +159,24 @@ def test_get_workspace_tree_selected_only_dir(workspace):
     )
 
     assert str(tree).strip() == expected.strip()
+
+
+def test_get_workspace_tree_selected_is_empty_dir(workspace):
+    selected_path = UrlPath("some_dir/subdir")
+    (workspace.root() / selected_path).mkdir()
+    tree = get_workspace_tree(workspace, selected_path, selected_only=True)
+
+    # only the selected path should be in the tree
+    expected = textwrap.dedent(
+        """
+        workspace*
+          some_dir*
+            subdir***
+        """
+    )
+
+    assert str(tree).strip() == expected.strip()
+    assert tree.get_path(selected_path).type == PathType.DIR
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This occured when a) the target was an empty dir and b) you were are
using HTMX and thus selected_only=True.

Fixes #260, and adds test.
