### PR TITLE
Fix csv column sorting by adding a data-order attribute

### DIFF
--- a/airlock/templates/file_browser/csv.html
+++ b/airlock/templates/file_browser/csv.html
@@ -48,7 +48,7 @@
           {% for row in rows %}
             <tr>
               {% for cell in row %}
-                <td>{{ cell }}</td>
+                <td data-order="{{ cell }}">{{ cell }}</td>
               {% endfor %}
             </tr>
           {% endfor %}


### PR DESCRIPTION
As per the docs[1] this is converted to an integer if numeric. Seems to
work.

Fixes #251

[1] https://fiduswriter.github.io/simple-datatables/documentation/Getting-Started#initial-data
