### PR TITLE
If there is only one group in a request, go ahead & view it

### DIFF
--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -59,6 +59,16 @@ def request_index(request):
 def request_view(request, request_id: str, path: str = ""):
     release_request = get_release_request_or_raise(request.user, request_id)
 
+    if path == "" and len(release_request.filegroups) == 1 and not request.htmx:
+        only_filegroup_url = reverse(
+            "request_view",
+            kwargs={
+                "request_id": request_id,
+                "path": next(iter(release_request.filegroups)),
+            },
+        )
+        return redirect(only_filegroup_url)
+
     relpath = UrlPath(path)
     template = "file_browser/index.html"
     selected_only = False


### PR DESCRIPTION
* surely when anyone opens a request with one group their next click is going to be to open the group - we can do that for them
* may conflict with https://github.com/opensafely-core/airlock/issues/264 
* the code works but test coverage fails, if we want to keep it I can fix that