### PR TITLE
Set the min-height of a subdirectory to fill the screen

### DIFF
--- a/airlock/templates/file_browser/contents.html
+++ b/airlock/templates/file_browser/contents.html
@@ -1,4 +1,4 @@
-<div id="selected-contents">
+<div id="selected-contents" class="min-h-screen">
   {% if path_item.type.name == "FILEGROUP" %}
     {% include "file_browser/group.html" %}
   {% elif path_item.type.name == "DIR" %}


### PR DESCRIPTION
* this means that if a user clicks between a file & a directory, the display will not jump around confusingly
* needs to be full screen size rather than filling the available screen, as we need this element on its own to be able to fill the screen for this to work as expected.