### PR TITLE
Expand all files in the request tree by default.

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -359,7 +359,7 @@ def get_request_tree(
                 f"{name} ({len(group.output_files)} requested file{_pluralise(group.output_files)})"
             ),
             selected=selected,
-            expanded=selected or expanded,
+            expanded=True,
         )
 
         if expanded or not selected_only:
@@ -371,7 +371,7 @@ def get_request_tree(
                 pathlist=pathlist,
                 parent=group_node,
                 selected_path=selected_path,
-                expanded=expanded,
+                expand_all=True,
             )
 
         root_node.children.append(group_node)
@@ -431,7 +431,7 @@ def get_path_tree(
     pathlist: list[UrlPath],
     parent: PathItem,
     selected_path: UrlPath = ROOT_PATH,
-    expanded: bool = False,
+    expand_all: bool = False,
     leaf_directories: set[UrlPath] | None = None,
 ):
     """Walk a flat list of paths and create a tree from them."""
@@ -469,7 +469,7 @@ def get_path_tree(
                 node.children = build_path_tree(descendants, parent=node)
 
                 # expand all regardless of selected state, used for request filegroup trees
-                if expanded:
+                if expand_all:
                     node.expanded = True
                 else:
                     node.expanded = selected or (path in (selected_path.parents or []))

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -215,11 +215,9 @@ def test_e2e_release_files(page, live_server, dev_users, release_files_stubber):
     expect(filegroup_link).to_be_visible()
     expect(filegroup_link).to_contain_text(re.compile("my-new-group", flags=re.I))
 
-    # In the initial request view, the tree is collapsed
     # Locate the link by its name, because later when we're looking at
     # the request, there will be 2 files that match .locator(".file:scope")
     file_link = page.get_by_role("link", name="file.txt").locator(".file:scope")
-    assert file_link.all() == []
 
     # Click to open the filegroup tree
     filegroup_link.click()

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -98,8 +98,8 @@ def test_get_request_tree_general(release_request):
             some_dir*
               file_a.txt**
               file_c.txt
-          group2
-            some_dir
+          group2*
+            some_dir*
               file_b.txt
         """
     )
@@ -192,7 +192,7 @@ def test_get_request_tree_selected_only_file(release_request):
             some_dir*
               file_a.txt**
               file_c.txt
-          group2
+          group2*
         """
     )
 
@@ -212,7 +212,7 @@ def test_get_request_tree_selected_only_group(release_request):
             some_dir*
               file_a.txt
               file_c.txt
-          group2
+          group2*
         """
     )
 


### PR DESCRIPTION
We rarely expect >20 files here. Expanding all by default saves the user
clicks, and gives them  a) full view of the status of every file and b)
one click navigation to every file.

They can always collapse if they need to.
