### PR TITLE
Notifications

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1281,16 +1281,6 @@ class BusinessLogicLayer:
             release_request.id, group, comment, user.username, audit
         )
 
-        if release_request.status != RequestStatus.PENDING:
-            updates = [
-                self._get_notification_update_dict(
-                    NotificationUpdateType.COMMENT_ADDED, group, user
-                )
-            ]
-            self.send_notification(
-                release_request, NotificationEventType.REQUEST_UPDATED, user, updates
-            )
-
     def get_audit_log(
         self,
         user: str | None = None,

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1205,7 +1205,7 @@ class BusinessLogicLayer:
             path=relpath,
         )
 
-        bll._dal.approve_file(release_request.id, relpath, user.username, audit)
+        self._dal.approve_file(release_request.id, relpath, user.username, audit)
 
     def reject_file(
         self, release_request: ReleaseRequest, relpath: UrlPath, user: User
@@ -1221,7 +1221,7 @@ class BusinessLogicLayer:
             path=relpath,
         )
 
-        bll._dal.reject_file(release_request.id, relpath, user.username, audit)
+        self._dal.reject_file(release_request.id, relpath, user.username, audit)
 
     def group_edit(
         self,
@@ -1247,7 +1247,7 @@ class BusinessLogicLayer:
             extra={"context": context, "controls": controls},
         )
 
-        change_notifications = bll._dal.group_edit(
+        change_notifications = self._dal.group_edit(
             release_request.id, group, context, controls, audit
         )
 
@@ -1277,7 +1277,9 @@ class BusinessLogicLayer:
             extra={"comment": comment},
         )
 
-        bll._dal.group_comment(release_request.id, group, comment, user.username, audit)
+        self._dal.group_comment(
+            release_request.id, group, comment, user.username, audit
+        )
 
         if release_request.status != RequestStatus.PENDING:
             updates = [
@@ -1295,7 +1297,7 @@ class BusinessLogicLayer:
         workspace: str | None = None,
         request: str | None = None,
     ) -> list[AuditEvent]:
-        return bll._dal.get_audit_log(
+        return self._dal.get_audit_log(
             user=user,
             workspace=workspace,
             request=request,
@@ -1310,7 +1312,7 @@ class BusinessLogicLayer:
             workspace=workspace.name,
             path=path,
         )
-        bll._dal.audit_event(audit)
+        self._dal.audit_event(audit)
 
     def audit_request_file_access(
         self, request: ReleaseRequest, path: UrlPath, user: User
@@ -1322,7 +1324,7 @@ class BusinessLogicLayer:
             path=path,
             group=path.parts[0],
         )
-        bll._dal.audit_event(audit)
+        self._dal.audit_event(audit)
 
     def audit_request_file_download(
         self, request: ReleaseRequest, path: UrlPath, user: User
@@ -1334,7 +1336,7 @@ class BusinessLogicLayer:
             path=path,
             group=path.parts[0],
         )
-        bll._dal.audit_event(audit)
+        self._dal.audit_event(audit)
 
     def _get_notification_update_dict(
         self, update_type: NotificationUpdateType, group_name: str, user: User

--- a/airlock/notifications.py
+++ b/airlock/notifications.py
@@ -1,0 +1,33 @@
+import requests
+from django.conf import settings
+
+
+session = requests.Session()
+
+
+def send_notification_event(event_json: str, username: str):
+    """API call to job server to create a release."""
+    if not settings.AIRLOCK_API_TOKEN:
+        # Skip attempting to send notifications when we're running a
+        # local dev server in isolation
+        return {"status": "ok"}
+    response = session.post(
+        url=f"{settings.AIRLOCK_API_ENDPOINT}/airlock/events/",
+        data=event_json,
+        headers={
+            "OS-User": username,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "Authorization": settings.AIRLOCK_API_TOKEN,
+        },
+    )
+
+    # We expect to get a 201 back from job-server, even if it encountered an error in
+    # processing the notification. If we get anything else, return it in the expected
+    # format so it can be logged
+    if response.status_code != 201:
+        return {
+            "status": "error",
+            "message": f"Error sending notification: {response.status_code} {response.reason}",
+        }
+    return response.json()

--- a/airlock/notifications.py
+++ b/airlock/notifications.py
@@ -1,6 +1,10 @@
+import logging
+
 import requests
 from django.conf import settings
 
+
+logger = logging.getLogger(__name__)
 
 session = requests.Session()
 
@@ -10,6 +14,7 @@ def send_notification_event(event_json: str, username: str):
     if not settings.AIRLOCK_API_TOKEN:
         # Skip attempting to send notifications when we're running a
         # local dev server in isolation
+        logger.info("Would send notification: %s", event_json)
         return {"status": "ok"}
     response = session.post(
         url=f"{settings.AIRLOCK_API_ENDPOINT}/airlock/events/",

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -369,14 +369,19 @@ class MissingVariableErrorFilter(logging.Filter):
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
+    "formatters": {
+        "default": {
+            "format": "[{asctime}] {levelname} {message}",
+            "datefmt": "%d/%b/%Y %H:%M:%S",
+            "style": "{",
         },
+    },
+    "handlers": {
+        "console": {"class": "logging.StreamHandler", "formatter": "default"},
     },
     "root": {
         "handlers": ["console"],
-        "level": "WARNING",
+        "level": os.environ.get("LOG_LEVEL", "WARNING"),
     },
     "filters": {
         "missing_variable_error": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,7 @@ def release_files_stubber(responses):
 @pytest.fixture
 def notifications_stubber(responses, settings):
     settings.AIRLOCK_API_TOKEN = "token"
+    responses.assert_all_requests_are_fired = False
 
     def send_notification(json=None, exception=None):
         status_code = exception.response.status_code if exception else 201
@@ -98,3 +99,8 @@ def notifications_stubber(responses, settings):
         return responses
 
     return send_notification
+
+
+@pytest.fixture
+def mock_notifications(notifications_stubber):
+    return notifications_stubber()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,3 +80,21 @@ def release_files_stubber(responses):
         return responses
 
     return release_files
+
+
+@pytest.fixture
+def notifications_stubber(responses, settings):
+    settings.AIRLOCK_API_TOKEN = "token"
+
+    def send_notification(json=None, exception=None):
+        status_code = exception.response.status_code if exception else 201
+        json = json or {"status": "ok"}
+        responses.post(
+            f"{settings.AIRLOCK_API_ENDPOINT}/airlock/events/",
+            status=status_code,
+            json=json,
+        )
+
+        return responses
+
+    return send_notification

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1407,9 +1407,10 @@ def test_group_edit_bad_group(bll):
 @pytest.mark.parametrize(
     "status,notification_count",
     [
-        # In pending, no notifications are sent
         (RequestStatus.PENDING, 0),
-        (RequestStatus.SUBMITTED, 3),
+        # Currently no notifications are sent for comments. The only notification
+        # sent in this test is for adding a file to the submitted request
+        (RequestStatus.SUBMITTED, 1),
     ],
 )
 def test_group_comment_success(bll, mock_notifications, status, notification_count):
@@ -1433,19 +1434,9 @@ def test_group_comment_success(bll, mock_notifications, status, notification_cou
     notification_responses = parse_notification_responses(mock_notifications)
     assert notification_responses["count"] == notification_count
     if notification_count > 0:
-        file_added, other_user_comment, author_comment = notification_responses[
-            "request_json"
-        ]
+        file_added = notification_responses["request_json"][0]
         assert file_added["event_type"] == "request_updated"
         assert file_added["updates"][0]["update_type"] == "file added"
-        assert other_user_comment["event_type"] == "request_updated"
-        assert other_user_comment["updates"] == [
-            {"update_type": "comment added", "group": "group", "user": "other"}
-        ]
-        assert author_comment["event_type"] == "request_updated"
-        assert author_comment["updates"] == [
-            {"update_type": "comment added", "group": "group", "user": "author"}
-        ]
 
     release_request = factories.refresh_release_request(release_request)
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,0 +1,37 @@
+import json
+
+import requests
+
+from airlock.notifications import send_notification_event
+
+
+def test_notification_no_api_endpoint(settings):
+    settings.AIRLOCK_API_TOKEN = None
+    assert send_notification_event({}, "") == {"status": "ok"}
+
+
+def test_send_notification(notifications_stubber):
+    mock_notifications = notifications_stubber()
+    event_json = json.dumps({"event_type": "request_submitted"})
+    assert send_notification_event(event_json=event_json, username="test-user") == {
+        "status": "ok"
+    }
+    assert len(mock_notifications.calls) == 1
+    call = mock_notifications.calls[0]
+
+    assert call.request.headers["OS-User"] == "test-user"
+    assert call.request.headers["Authorization"] == "token"
+    assert call.request.body == event_json
+
+
+def test_send_notification_error(notifications_stubber):
+    response = requests.Response()
+    response.status_code = 403
+    api403 = requests.HTTPError(response=response)
+
+    notifications_stubber(exception=api403)
+    event_json = json.dumps({"event_type": "request_submitted"})
+    assert send_notification_event(event_json=event_json, username="test-user") == {
+        "status": "error",
+        "message": "Error sending notification: 403 Forbidden",
+    }


### PR DESCRIPTION
Fixes #256 

Sends notifications  on:
- set status (on moving to any status except pending)
- edit group (editing context/controls)
- add file
- withdraw file
- add comment
For updates (i.e. the last 4 above), notifications are only sent for requests in non-pending state.

Currently update events are not batched, with the exception of context and controls editing (because those are part of the same form). The DAL now returns a list of NotificationUpdateTypes on group_edit to indicate which fields have changed and need to be notified.