### PR TITLE
Update login form label

### DIFF
--- a/airlock/templates/login.html
+++ b/airlock/templates/login.html
@@ -18,7 +18,7 @@
       <form class="gap-2 flex-wrap md:flex-nowrap" method="POST" action="{% url 'login' %}" onsubmit="showSpinner()" >
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next_url }}" />
-        {% form_input type="text" field=token_login_form.user required=True label="GitHub username or Email address" class="mb-3" placeholder="opensafely" input_class="max-w-md" %}
+        {% form_input type="text" field=token_login_form.user required=True label="GitHub username or OpenSAFELY email address" class="mb-3" placeholder="opensafely" input_class="max-w-md" %}
         {% form_input type="text" field=token_login_form.token required=True label="Single Use Token" placeholder="three random words" show_placeholder=True class="mb-3" input_class="max-w-md" %}
 
         {% #button type="submit" variant="primary-outline" id="login-button" %}


### PR DESCRIPTION
Fixes #269 

The form previously asked for "GitHub username or email address". GitHub email address is not always the email address that will work for login. Logging in to job-server with GitHub will populate the user's job-server account with their primary GitHub email. However, they can then change it, and if they do, the new email address will be valid for login, not the primary GitHub one.

We don't want to restrict users to ONLY logging in with GitHub username, as some users may not be very familiar with GitHub and may not know their GitHub username.