### PR TITLE
Add support for generating test manifests.

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -504,6 +504,9 @@ def get_path_tree(
 
 
 def children_sort_key(node: PathItem):
-    """Sort children first by directory, then files."""
+    """Sort children first by directory, then files.
+
+    The name metadata is sorted first, as its special."""
     # this works because True == 1 and False == 0
-    return (node.type == PathType.FILE, node.name())
+    name = node.name()
+    return (name != "metadata", node.type == PathType.FILE, name)

--- a/justfile
+++ b/justfile
@@ -162,7 +162,7 @@ test *ARGS: devenv
 
 
 # load example data so there's something to look at in development
-load-example-data: devenv
+load-example-data: devenv && manifests
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -205,6 +205,10 @@ load-example-data: devenv
     # Configure user details for local login
     cp example-data/dev_users.json "${AIRLOCK_WORK_DIR%/}/${AIRLOCK_DEV_USERS_FILE}"
 
+# generate manifests for local test workspaces
+manifests:
+    cat scripts/manifests.py | $BIN/python manage.py shell
+    
 
 # Run the documentation server: to configure the port, append: ---dev-addr localhost:<port>
 docs-serve *ARGS: devenv
@@ -213,3 +217,4 @@ docs-serve *ARGS: devenv
 # Build the documentation
 docs-build *ARGS: devenv
     "$BIN"/mkdocs build --clean {{ ARGS }}
+

--- a/scripts/manifests.py
+++ b/scripts/manifests.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+from tests import factories
+
+
+workspaces = [w for w in settings.WORKSPACE_DIR.iterdir() if w.is_dir()]
+
+for workspace in workspaces:
+    factories.update_manifest(workspace.name)
+    print(f"Writing manifest.json for workspace {workspace.name}")

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1493,7 +1493,9 @@ def test_group_comment_permissions(bll):
 
 def test_coderepo_from_workspace_bad_json():
     workspace = factories.create_workspace("workspace")
-    factories.write_workspace_file("workspace", "metadata/manifest.json", "")
+    bad_manifest = workspace.root() / "metadata/manifest.json"
+    bad_manifest.parent.mkdir()
+    bad_manifest.write_text("")
 
     with pytest.raises(CodeRepo.RepoNotFound):
         CodeRepo.from_workspace(workspace, "commit")

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -46,6 +46,8 @@ def test_get_workspace_tree_general(workspace):
     expected = textwrap.dedent(
         """
         workspace*
+          metadata
+            manifest.json
           empty_dir
           some_dir*
             .file.txt
@@ -145,6 +147,7 @@ def test_get_workspace_tree_selected_only_root(workspace):
     expected = textwrap.dedent(
         """
         workspace***
+          metadata
           empty_dir
           some_dir
         """
@@ -422,6 +425,7 @@ def test_workspace_tree_siblings(workspace):
 
     assert tree.siblings() == []
     assert {s.name() for s in tree.get_path("some_dir").siblings()} == {
+        "metadata",
         "empty_dir",
         "some_dir",
     }


### PR DESCRIPTION
This is used by default in test factories, but also is exposes as `just
manifests` as a dev tool to create manifests for your local test
workspaces.
