### PR TITLE
Increase the global timeout for e2e expect assertions

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -5,8 +5,12 @@ import sys
 import pytest
 from django.conf import settings
 from django.contrib.sessions.models import Session
+from playwright.sync_api import expect
 
 from tests import factories
+
+
+expect.set_options(timeout=10_000)
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
The default is 5s, but we seem to [occasionally hit that,](https://github.com/opensafely-core/airlock/actions/runs/9003575497/job/24734509934#step:6:3596) so increase it to 10s for individual asserts.

Have verified that if the timeout is set to something unreasonably small (like 1s), it gets the same error as the occasionally failing CI tests