### PR TITLE
Temporarily remove c3 form fields

### DIFF
--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -402,3 +402,5 @@ LOGGING = {
         },
     },
 }
+
+SHOW_C3 = os.environ.get("AIRLOCK_SHOW_C3", "false") == "True"

--- a/airlock/templates/file_browser/group.html
+++ b/airlock/templates/file_browser/group.html
@@ -1,40 +1,41 @@
 {% #card title=path_item.name container=True %}
-  <form action="{{ group_edit_url }}" method="POST" aria-label="group-edit-form">
-    {% csrf_token %}
-    <div style="display: flex; flex-direction: row; width: 100%; flex-wrap: wrap; gap: 1rem;">
-      <div style="display: flex: flex-direction: column; flex-basis: 100%; flex: 1;">
-        {% form_textarea field=group_edit_form.context show_placeholder=True resize=True placeholder="Describe the data to be released in this group of files" class="w-full max-w-lg mx-auto" rows=6 disabled=group_readonly readonly=group_readonly %}
+  {% if show_c3 %}
+    <form action="{{ group_edit_url }}" method="POST" aria-label="group-edit-form">
+      {% csrf_token %}
+      <div style="display: flex; flex-direction: row; width: 100%; flex-wrap: wrap; gap: 1rem;">
+        <div style="display: flex: flex-direction: column; flex-basis: 100%; flex: 1;">
+          {% form_textarea field=group_edit_form.context show_placeholder=True resize=True placeholder="Describe the data to be released in this group of files" class="w-full max-w-lg mx-auto" rows=6 disabled=group_readonly readonly=group_readonly %}
+        </div>
+        <div style="display: flex: flex-direction: column; flex-basis: 100%; flex: 1; gap: 1rem;">
+          {% form_textarea field=group_edit_form.controls resize=True show_placeholder=True placeholder="Describe the disclosure controls that have been applied to these files" class="w-full max-w-lg mx-auto" rows=6 disabled=group_readonly readonly=group_readonly %}
+        </div>
       </div>
-      <div style="display: flex: flex-direction: column; flex-basis: 100%; flex: 1; gap: 1rem;">
-        {% form_textarea field=group_edit_form.controls resize=True show_placeholder=True placeholder="Describe the disclosure controls that have been applied to these files" class="w-full max-w-lg mx-auto" rows=6 disabled=group_readonly readonly=group_readonly %}
-      </div>
+      {% if not group_readonly %}
+        <div class="mt-2">
+          {% #button type="submit" variant="success" id="edit-group-button" disabled=group_readonly %}Save{% /button %}
+        </div>
+      {% endif %}
+    </form>
+
+    <div class="comments" style="margin-top: 1rem;">
+      {% #list_group %}
+        {% for comment in group_comments %}
+          {% #list_group_rich_item status_text=comment.created_at|date:"Y-m-d H:i"  title=comment.author %}
+            {{ comment.comment }}
+          {% /list_group_rich_item %}
+        {% endfor %}
+        {% #list_group_item %}
+          <form action="{{ group_comment_url }}" method="POST" aria-label="group-comment-form">
+            {% csrf_token %}
+            {% form_textarea field=group_comment_form.comment placeholder=" " label="Add Comment" show_placeholder=True class="w-full max-w-lg" rows=6 required=True %}
+            <div class="mt-2">
+              {% #button type="submit" variant="success" id="edit-comment-button" %}Comment{% /button %}
+            </div>
+          </form>
+        {% /list_group_item %}
+      {% /list_group %}
     </div>
-    {% if not group_readonly %}
-      <div class="mt-2">
-        {% #button type="submit" variant="success" id="edit-group-button" disabled=group_readonly %}Save{% /button %}
-      </div>
-    {% endif %}
-  </form>
-
-  <div class="comments" style="margin-top: 1rem;">
-    {% #list_group %}
-      {% for comment in group_comments %}
-        {% #list_group_rich_item status_text=comment.created_at|date:"Y-m-d H:i"  title=comment.author %}
-          {{ comment.comment }}
-        {% /list_group_rich_item %}
-      {% endfor %}
-      {% #list_group_item %}
-        <form action="{{ group_comment_url }}" method="POST" aria-label="group-comment-form">
-          {% csrf_token %}
-          {% form_textarea field=group_comment_form.comment placeholder=" " label="Add Comment" show_placeholder=True class="w-full max-w-lg" rows=6 required=True %}
-          <div class="mt-2">
-            {% #button type="submit" variant="success" id="edit-comment-button" %}Comment{% /button %}
-          </div>
-        </form>
-      {% /list_group_item %}
-    {% /list_group %}
-  </div>
-
+  {% endif %}
   {% include "activity.html" with activity=group_activity %}
 
 {% /card %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -200,6 +200,7 @@ def request_view(request, request_id: str, path: str = ""):
         "group_comments": comments,
         "group_comment_url": group_comment_url,
         "group_activity": group_activity,
+        "show_c3": settings.SHOW_C3,
     }
 
     return TemplateResponse(request, template, context)

--- a/docs/creating-a-release-request.md
+++ b/docs/creating-a-release-request.md
@@ -25,7 +25,7 @@ File groups allow the researcher to group the various files in a release request
 into logical groups, in order to help the output checker understand the request.
 Supporting files should be placed in the same file group as the Output file they support. 
 
-## Adding context and controls
+<!-- ## Adding context and controls
 
 Context and controls should be added to each file group. These allow researchers to
 provide information about the files requested for release. Files should be organised
@@ -37,7 +37,7 @@ needs to be provided once per group of files.
 
 To add context and controls to a group, the researcher should navigate to the current
 release request and click on the name of the relevant group. This will open a page with
-options to enter context and control information.
+options to enter context and control information. -->
 
 ## Withdrawing files
 

--- a/docs/requesting-a-review.md
+++ b/docs/requesting-a-review.md
@@ -1,3 +1,8 @@
+!!! Note
+This process is under development and currently only applies to release requests
+submitted by internal researchers.
+
+
 ## Submitting a request
 
 Once the researcher has finished working on the release request, the next step is to
@@ -6,10 +11,14 @@ and click "Submit For Review".
 
 The status of the release request will transition to "Submitted".
 
-!!!note "Notifying output checkers"
-    :construction: Work in progress :construction:
+A GitHub issue will be automatically created and output-checkers will be notified
+in Slack of the new release request.
 
-    Currently, the researcher needs to notify output checkers of the submitted request by email or slack.
-    
-    In future, output checkers will be automatically notified when new release requests are submitted
-    for review. 
+
+### Completing the release request form
+
+After submitting their request on Airlock, researchers complete [this form](https://docs.google.com/document/d/1uWRiFps6tDA2SpxSxf0C2G9mOVWMQ6TQ/edit)
+and attach it to the GitHub issue. To find the relevant GitHub issue, go to the
+[opensafely-output-review](https://github.com/ebmdatalab/opensafely-output-review/issues/)
+issues list. Issues created by Airlock are titled with
+the workspace name and Airlock release request ID.

--- a/docs/reviewing.md
+++ b/docs/reviewing.md
@@ -27,9 +27,9 @@ Whilst viewing a file in an Airlock release request, they have the option of:
 
 ## Dealing with discrepancies and rejected files
 
-Output checkers and researchers can add comments on each file group to request
+<!-- Output checkers and researchers can add comments on each file group to request
 information and discuss discrepancies. Comments are recorded and displayed on the
-file group with the user's username and a timestamp.
+file group with the user's username and a timestamp. -->
 
 Researchers should withdraw any files that have been rejected in order for their
 release request to progress. They can add further files, including revised versions

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -58,7 +58,8 @@ def test_request_file_withdraw(live_server, context, page, bll):
     expect(file2_locator).to_have_class(re.compile("withdrawn"))
 
 
-def test_request_group_edit_comment(live_server, context, page, bll):
+def test_request_group_edit_comment(live_server, context, page, bll, settings):
+    settings.SHOW_C3 = True
     author = login_as_user(
         live_server,
         context,


### PR DESCRIPTION
Fixes #324 

Hides the form fields for context, comments and controls based on a new SHOW_C3 env variable and setting.

Also updates docs to be consistent with the (temporary) new process. The [minimally-adapted Word doc form](https://docs.google.com/document/d/1uWRiFps6tDA2SpxSxf0C2G9mOVWMQ6TQ/edit?usp=drive_link&ouid=114747311902500453985&rtpof=true&sd=true) should also be reviewed before this is merged. 

