### PR TITLE
Refactor Workspace construction

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Protocol, Self, cast
+from typing import Any, Protocol, Self, cast
 
 from django.conf import settings
 from django.urls import reverse
@@ -217,11 +217,43 @@ class Workspace:
     """
 
     name: str
-    metadata: dict[str, str] = field(default_factory=dict)
+    manifest: dict[str, Any]
+    metadata: dict[str, str]
+    current_request: ReleaseRequest | None
 
-    def __post_init__(self):
-        if not self.root().exists():
-            raise BusinessLogicLayer.WorkspaceNotFound(self.name)
+    @classmethod
+    def from_directory(
+        cls,
+        name: str,
+        metadata: dict[str, str] | None = None,
+        current_request: ReleaseRequest | None = None,
+    ) -> Workspace:
+        root = settings.WORKSPACE_DIR / name
+        if not root.exists():
+            raise BusinessLogicLayer.WorkspaceNotFound(name)
+
+        manifest_path = root / "metadata/manifest.json"
+        if not manifest_path.exists():
+            raise BusinessLogicLayer.ManifestFileError(
+                f"{manifest_path} does not exist"
+            )
+
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise BusinessLogicLayer.ManifestFileError(
+                f"Could not parse manifest.json file: {manifest_path}:\n{exc}"
+            )
+
+        if metadata is None:  # pragma: no cover
+            metadata = {}
+
+        return cls(
+            name,
+            manifest=manifest,
+            metadata=metadata,
+            current_request=current_request,
+        )
 
     def __str__(self):
         return self.get_id()
@@ -265,19 +297,9 @@ class Workspace:
             relpath=relpath,
         )
 
-    def get_manifest_data(self):
-        manifest_path = self.abspath("metadata/manifest.json")
-        try:
-            return json.loads(manifest_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise BusinessLogicLayer.ManifestFileError(
-                f"Could not parse manifest.json file: {manifest_path}:\n{exc}"
-            )
-
     def get_manifest_for_file(self, relpath: UrlPath):
-        manifest_data = self.get_manifest_data()
         try:
-            return manifest_data["outputs"][str(relpath)]
+            return self.manifest["outputs"][str(relpath)]
         except KeyError:
             raise BusinessLogicLayer.ManifestFileError(
                 f"Could not parse data for {relpath} from manifest.json file"
@@ -321,8 +343,7 @@ class CodeRepo:
     @classmethod
     def from_workspace(cls, workspace: Workspace, commit: str):
         try:
-            manifest = workspace.get_manifest_data()
-            repo = manifest["repo"]
+            repo = workspace.manifest["repo"]
         except (BusinessLogicLayer.ManifestFileError, KeyError):
             raise cls.RepoNotFound(
                 "Could not parse manifest.json file: {manifest_path}:\n{exc}"
@@ -828,12 +849,18 @@ class BusinessLogicLayer:
         if user is None or not user.has_permission(name):
             raise self.WorkspacePermissionDenied()
 
-        # this is a bit awkward. IF the user is an output checker, they may not
+        # this is a bit awkward. If the user is an output checker, they may not
         # have the workspace metadata in their User instance, so we provide an
         # empty metadata instance.
         # Currently, the only place this metadata is used is in the workspace
         # index, to group by project, so its mostly fine that its not here.
-        return Workspace(name, user.workspaces.get(name, {}))
+        metadata = user.workspaces.get(name, {})
+
+        return Workspace.from_directory(
+            name,
+            metadata=metadata,
+            current_request=self.get_current_request(name, user),
+        )
 
     def get_workspaces_for_user(self, user: User) -> list[Workspace]:
         """Get all the local workspace directories that a user has permission for."""

--- a/airlock/views/code.py
+++ b/airlock/views/code.py
@@ -22,9 +22,6 @@ def get_repo_or_raise(user: User, workspace_name: str, commit: str):
 
     try:
         return CodeRepo.from_workspace(workspace, commit)
-    except bll.FileNotFound:
-        # cannot find manifest.json
-        raise Http404()
     except (CodeRepo.RepoNotFound, CodeRepo.CommitNotFound):
         raise Http404()
 

--- a/local_db/management/commands/backpopulate_file_manifest_data.py
+++ b/local_db/management/commands/backpopulate_file_manifest_data.py
@@ -1,19 +1,23 @@
 from django.core.management.base import BaseCommand
 
-from airlock.business_logic import BusinessLogicLayer, Workspace
+from airlock.business_logic import bll
 from airlock.types import UrlPath
+from airlock.users import User
 from local_db.models import RequestFileMetadata
 
 
 class Command(BaseCommand):
     def handle(self, **kwargs):
         for request_file in RequestFileMetadata.objects.all():  # pragma: no cover
-            workspace = Workspace(name=request_file.request.workspace)
+            workspace = bll.get_workspace(
+                name=request_file.request.workspace,
+                user=User("backfill", workspaces={}, output_checker=True),
+            )
             try:
                 manifest_data = workspace.get_manifest_for_file(
                     UrlPath(request_file.relpath)
                 )
-            except (BusinessLogicLayer.ManifestFileError, KeyError):
+            except (bll.ManifestFileError, KeyError):
                 print(
                     f"Could not update manifest.json data for {workspace.name}/{request_file.relpath}"
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,12 @@ def clear_all_traces():
     test_exporter.clear()
 
 
+# mark every test iwth django_db
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        item.add_marker(pytest.mark.django_db)
+
+
 # Fail the test run if we see any warnings
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if terminalreporter.stats.get("warnings"):  # pragma: no cover

--- a/tests/integration/management/commands/test_backpopulate_file_manifest_data.py
+++ b/tests/integration/management/commands/test_backpopulate_file_manifest_data.py
@@ -6,7 +6,7 @@ from tests import factories
 
 
 @pytest.mark.django_db
-def test_command():
+def test_command(bll):
     workspace = factories.create_workspace("workspace")
     release_request = factories.create_release_request(workspace)
     factories.write_request_file(
@@ -23,6 +23,9 @@ def test_command():
     file_meta.timestamp = 1
     file_meta.save()
 
+    workspace = bll.get_workspace(
+        "workspace", factories.create_user(workspaces=["workspace"])
+    )
     manifest = workspace.get_manifest_for_file(file_meta.relpath)
     for attr in ["commit", "size", "job_id", "timestamp", "repo"]:
         assert getattr(file_meta, attr) != manifest[attr]


### PR DESCRIPTION
This adds a manifest and current_request property, and a from_directory
contructor, which loads the manifest and any current request, and
creates the Workspace object.

This means any Workspace when created will always have a manifest, as
that is required now. This is more consistent, and uncovered a number of
issues.

It will also have any current_request for the user. This is going to be
very useful in template rendering in a coming PR

The idea is that once a workspace is instantiated, it is complete and
has everything available that it might need to then reference.
