### PR TITLE
Rework directory view to use datatable

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -207,6 +207,12 @@ class AirlockContainer(Protocol):
     def get_renderer(self, relpath: UrlPath) -> renderers.Renderer:
         """Create and return the correct renderer for this path."""
 
+    def get_size(self, relpath: UrlPath) -> int:
+        """Get the size of a file"""
+
+    def get_modified_time(self, relpath: UrlPath) -> datetime | None:
+        """Get modified time of a file"""
+
 
 @dataclass(order=True)
 class Workspace:
@@ -304,6 +310,16 @@ class Workspace:
             raise BusinessLogicLayer.ManifestFileError(
                 f"Could not parse data for {relpath} from manifest.json file"
             )
+
+    def get_size(self, relpath: UrlPath) -> int:
+        return int(self.get_manifest_for_file(relpath).get("size", 0))
+
+    def get_modified_time(self, relpath: UrlPath) -> datetime | None:
+        ts = self.get_manifest_for_file(relpath).get("timestamp")
+        if ts:
+            return datetime.utcfromtimestamp(ts)
+        else:  # pragma: no cover
+            return None
 
     def abspath(self, relpath):
         """Get absolute path for file
@@ -412,6 +428,14 @@ class CodeRepo:
             relpath=relpath,
             cache_id="",
         )
+
+    def get_size(self, relpath: UrlPath) -> int:
+        """Get the size of a file"""
+        return 0  # pragma: no cover
+
+    def get_modified_time(self, relpath: UrlPath) -> datetime | None:
+        """Get modified time of a file"""
+        return None  # pragma: no cover
 
     def request_filetype(self, relpath: UrlPath) -> RequestFileType | None:
         return RequestFileType.CODE
@@ -593,6 +617,12 @@ class ReleaseRequest:
             relpath=request_file.relpath,
             cache_id=request_file.file_id,
         )
+
+    def get_size(self, relpath: UrlPath) -> int:
+        return int(self.get_request_file(relpath).size)
+
+    def get_modified_time(self, relpath: UrlPath) -> datetime | None:
+        return datetime.utcfromtimestamp(self.get_request_file(relpath).timestamp)
 
     def get_request_file(self, relpath: UrlPath | str):
         relpath = UrlPath(relpath)

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -333,7 +333,7 @@ class Workspace:
         except BusinessLogicLayer.ManifestFileError:
             pass
 
-        # not in manifest, check disk
+        # not in manifest, e.g. log file. Check disk
         try:
             abspath = self.abspath(relpath)
         except BusinessLogicLayer.FileNotFound:

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -133,13 +133,15 @@ class PathItem:
         else:
             return 0
 
-    def size_kb(self) -> str:
+    def size_mb(self) -> str:
         size = self.size()
         if size == 0:
-            return ""
+            return "0 Mb"
+        mb = to_mb(size)
+        i     elif size < 10240:
+            return "<0.01 Mb"
 
-        kb = to_kb(size)
-        return f"{kb} Kb"
+        return f"{mb} Mb"
 
     def modified(self) -> datetime | None:
         if self.type == PathType.FILE:
@@ -533,6 +535,6 @@ def children_sort_key(node: PathItem):
     return (name != "metadata", node.type == PathType.FILE, name)
 
 
-def to_kb(value_in_bytes):
+def to_mb(value_in_bytes):
     """Convert given value to Mb"""
-    return round(value_in_bytes / 1024, 2)
+    return round(value_in_bytes / (1024 * 1024), 2)

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
@@ -125,6 +126,26 @@ class PathItem:
 
     def file_type(self):
         return self.suffix().lstrip(".")
+
+    def size(self) -> int:
+        if self.type == PathType.FILE:
+            return self.container.get_size(self.relpath)
+        else:
+            return 0
+
+    def size_kb(self) -> str:
+        size = self.size()
+        if size == 0:
+            return ""
+
+        kb = to_kb(size)
+        return f"{kb} Kb"
+
+    def modified(self) -> datetime | None:
+        if self.type == PathType.FILE:
+            return self.container.get_modified_time(self.relpath)
+        else:
+            return None
 
     def breadcrumbs(self):
         item = self
@@ -510,3 +531,8 @@ def children_sort_key(node: PathItem):
     # this works because True == 1 and False == 0
     name = node.name()
     return (name != "metadata", node.type == PathType.FILE, name)
+
+
+def to_kb(value_in_bytes):
+    """Convert given value to Mb"""
+    return round(value_in_bytes / 1024, 2)

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -137,11 +137,11 @@ class PathItem:
         size = self.size()
         if size == 0:
             return "0 Mb"
-        mb = to_mb(size)
-        i     elif size < 10240:
+        elif size < 10240:
             return "<0.01 Mb"
-
-        return f"{mb} Mb"
+        # all our test files are small
+        else:  # pragma: no cover
+            return f"{to_mb(size)} Mb"
 
     def modified(self) -> datetime | None:
         if self.type == PathType.FILE:
@@ -535,6 +535,6 @@ def children_sort_key(node: PathItem):
     return (name != "metadata", node.type == PathType.FILE, name)
 
 
-def to_mb(value_in_bytes):
+def to_mb(value_in_bytes):  # pragma: no cover
     """Convert given value to Mb"""
     return round(value_in_bytes / (1024 * 1024), 2)

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -1,16 +1,61 @@
-{% #card title=path_item.name %}
-  {% #list_group %}
-    {% if not path_item.children %}
-      {% list_group_empty icon=True title="This directory is empty" %}
-    {% else %}
-      {% for entry in path_item.children %}
-        {% #list_group_item href=entry.url %}
-          {{ entry.name}}
-          {% if entry.is_directory %}
-            {% icon_folder_outline class="h-6 w-6 text-slate-600 inline" %}
-          {% endif %}
-        {% /list_group_item %}
-      {% endfor %}
-    {% endif %}
-  {% /list_group %}
+{% load django_vite %}
+{% load airlock %}
+{% load static %}
+
+<style>
+  #customTable thead {
+    position: sticky;
+    top: 0;
+    text-align: left;
+    background-color: rgba(248,250,252);
+  }
+
+  #customTable td.name a.directory {
+    background-image: url(/static/folder.png);
+    background-repeat: no-repeat;
+    background-size: 1.4rem;
+    background-position: left -0.2rem top 0;
+    padding-left: 1.1rem;
+  }
+
+</style>
+
+{% #card title=path_item.name container=True %}
+  {% if not path_item.children %}
+    This directory is empty
+  {% else %}
+    {% #table class="dir_table" id="customTable" %}
+      {% #table_head %}
+        <tr>
+          <th>
+            <div class="flex flex-row gap-2">File{% datatable_sort_icon %}</div>
+          </th>
+          <th>
+            <div class="flex flex-row gap-2">Size{% datatable_sort_icon %}</div>
+          </th>
+          <th>
+            <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
+          </th>
+        </tr>
+      {% /table_head %}
+      <tbody>
+        {% for path in path_item.children %}
+          <tr>
+            <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
+            <td data-order="{{ path.size }}">{{ path.size_kb }}</td>
+            <td>{{ path.modified|date:"Y-m-d H:i" }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    {% /table %}
+    </form>
+
+    {% vite_asset "assets/src/scripts/components.js" %}
+
+    <script type="text/javascript">
+      // ensure datatable is initialised when loading over HTMX
+      window.initCustomTable ? window.initCustomTable() : null;
+    </script>
+
+  {% endif %}
 {% /card %}

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -42,7 +42,7 @@
         {% for path in path_item.children %}
           <tr>
             <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
-            <td data-order="{{ path.size }}">{{ path.size_kb }}</td>
+            <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
             <td>{{ path.modified|date:"Y-m-d H:i" }}</td>
           </tr>
         {% endfor %}

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -104,7 +104,7 @@ def update_manifest(workspace: Workspace | str, files=None):
 
     manifest_path = root / "metadata/manifest.json"
 
-    skip_paths = [root / "logs", root / "metadata"]
+    skip_paths = [root / "metadata"]
 
     repo = "http://example.com/org/repo"
 

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -219,7 +219,11 @@ def test_e2e_release_files(page, live_server, dev_users, release_files_stubber):
 
     # Locate the link by its name, because later when we're looking at
     # the request, there will be 2 files that match .locator(".file:scope")
-    file_link = page.get_by_role("link", name="file.txt").locator(".file:scope")
+    file_link = (
+        page.locator("#tree")
+        .get_by_role("link", name="file.txt")
+        .locator(".file:scope")
+    )
 
     # Click to open the filegroup tree
     filegroup_link.click()

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+from datetime import datetime
 from hashlib import file_digest
 from io import BytesIO
 from pathlib import Path
@@ -109,6 +110,26 @@ def test_workspace_manifest_for_file_not_found(bll):
     )
     with pytest.raises(BusinessLogicLayer.ManifestFileError):
         workspace.get_manifest_for_file(UrlPath("foo/bar.txt"))
+
+
+def test_get_size():
+    workspace = factories.create_workspace("workspace")
+    assert workspace.get_size(UrlPath("metadata/foo.log")) == 0
+    factories.write_workspace_file(
+        workspace, "metadata/foo.log", contents="foo", manifest=False
+    )
+    assert workspace.get_size(UrlPath("metadata/foo.log")) == 3
+
+
+def test_get_modified_time():
+    workspace = factories.create_workspace("workspace")
+    assert workspace.get_modified_time(UrlPath("metadata/foo.log")) is None
+    factories.write_workspace_file(
+        workspace, "metadata/foo.log", contents="foo", manifest=False
+    )
+    assert isinstance(
+        workspace.get_modified_time(UrlPath("metadata/foo.log")), datetime
+    )
 
 
 def test_request_container(mock_notifications):


### PR DESCRIPTION
This uses a datatable to list the contents in a directory. It was spun
out of the multiselect work.

This means we can sort and order on columns, and so I also add size and
modified times for this too, to provide a use case.

There will be other columns coming soon, one for current file state
(unreleased/in-request/released for workspace files,
approved/rejected/withdrawn for request files), as well as a checkbox
column for the multiselect.
