### PR TITLE
Add code browser links

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -451,7 +451,7 @@ def get_code_tree(
 
     leaf_directories = set()
 
-    if selected_only:
+    if selected_only and selected_path != ROOT_PATH:
         # we only want the selected path, and its immediate children if it has any
         pathlist = [selected_path]
 

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -97,7 +97,8 @@ class PathItem:
         return self.name()
 
     def url(self):
-        suffix = "/" if self.is_directory() else ""
+        url = self.container.get_url(self.relpath)
+        suffix = "/" if (self.is_directory() and not url.endswith("/")) else ""
         return self.container.get_url(self.relpath) + suffix
 
     def contents_url(self, download: bool = False):

--- a/airlock/templates/_components/header.html
+++ b/airlock/templates/_components/header.html
@@ -11,6 +11,22 @@
     <a class="header__link header__nav-link" href="{{ current_request.get_url }}" id="current-request-button">
       View current release request &rarr;
     </a>
+  {% elif context == "repo" %}
+    {% if return_url %}
+      <a class="header__link header__nav-link" href="{{ return_url }}" id="return-button">
+        &larr; Back
+      </a>
+    {% else %}
+      {% if current_request.get_url %}
+        <a class="header__link header__nav-link" href="{{ current_request.get_url }}" id="current-request-button">
+          View current release request &rarr;
+        </a>
+      {% elif workspace.get_url %}
+        <a class="header__link header__nav-link" href="{{ workspace.get_url }}" id="workspace-home-button">
+          View workspace &rarr;
+        </a>
+      {% endif %}
+    {% endif %}
   {% endif %}
 
   {% if context == "request" or context == "workspace" %}

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -65,6 +65,9 @@
       {% endif %}
     {% endif %}
     {% #button variant="primary" type="link" href=path_item.contents_url external=True id="view-button" %}View ↗{% /button %}
+    {% if code_url %}
+      {% #button type="link" variant="primary" id="file-code-button" href=code_url %}View code{% /button %}
+    {% endif %}
   </div>
 
 {% endfragment %}

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -66,7 +66,7 @@
     {% endif %}
     {% #button variant="primary" type="link" href=path_item.contents_url external=True id="view-button" %}View ↗{% /button %}
     {% if code_url %}
-      {% #button type="link" variant="primary" id="file-code-button" href=code_url %}View code{% /button %}
+      {% #button type="link" variant="primary" id="file-code-button" href=code_url external=True %}View code{% /button %}
     {% endif %}
   </div>
 

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -64,7 +64,7 @@
       {% endif %}
     {% /airlock_header %}
   {% else %}
-    {% #airlock_header context=context current_request=current_request title=title workspace=workspace %}
+    {% #airlock_header context=context current_request=current_request title=title workspace=workspace return_url=return_url %}
     {% /airlock_header %}
   {% endif %}
 

--- a/airlock/views/code.py
+++ b/airlock/views/code.py
@@ -24,11 +24,18 @@ def get_repo_or_raise(workspace: Workspace, commit: str):
         raise Http404()
 
 
+def validate_return_url(url):
+    "Ensure a user-provided return url is an internal absolute url path"
+    if url is not None and url[0] != "/":
+        return
+    return url
+
+
 # we return different content if it is a HTMX request.
 @vary_on_headers("HX-Request")
 @instrument(func_attributes={"workspace": "workspace_name", "commit": "commit"})
 def view(request, workspace_name: str, commit: str, path: str = ""):
-    return_url = request.GET.get("return_url")
+    return_url = validate_return_url(request.GET.get("return_url"))
     workspace = get_workspace_or_raise(request.user, workspace_name)
 
     try:

--- a/airlock/views/code.py
+++ b/airlock/views/code.py
@@ -32,6 +32,7 @@ def view(request, workspace_name: str, commit: str, path: str = ""):
     template = "file_browser/index.html"
     selected_only = False
 
+    return_url = request.GET.get("return_url")
     if request.htmx:
         template = "file_browser/contents.html"
         selected_only = True
@@ -60,6 +61,8 @@ def view(request, workspace_name: str, commit: str, path: str = ""):
             "context": "repo",
             "title": f"{repo.repo}@{commit[:7]}",
             "current_request": current_request,
+            "return_url": return_url,
+            "code_url": "",
         },
     )
 

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -89,12 +89,17 @@ def request_view(request, request_id: str, path: str = ""):
             "file_withdraw",
             kwargs={"request_id": request_id, "path": path},
         )
-        code_url = reverse(
-            "code_view",
-            kwargs={
-                "workspace_name": release_request.workspace,
-                "commit": release_request.get_request_file_from_urlpath(path).commit,
-            },
+        code_url = (
+            reverse(
+                "code_view",
+                kwargs={
+                    "workspace_name": release_request.workspace,
+                    "commit": release_request.get_request_file_from_urlpath(
+                        path
+                    ).commit,
+                },
+            )
+            + f"?return_url={release_request.get_url(path)}"
         )
 
     group_edit_form = None
@@ -213,6 +218,7 @@ def request_view(request, request_id: str, path: str = ""):
         # TODO, but for now stops template variable errors
         "multiselect_url": "",
         "code_url": code_url,
+        "return_url": "",
     }
 
     return TemplateResponse(request, template, context)

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -83,10 +83,18 @@ def request_view(request, request_id: str, path: str = ""):
 
     if is_directory_url or release_request.status == RequestStatus.WITHDRAWN:
         file_withdraw_url = None
+        code_url = None
     else:
         file_withdraw_url = reverse(
             "file_withdraw",
             kwargs={"request_id": request_id, "path": path},
+        )
+        code_url = reverse(
+            "code_view",
+            kwargs={
+                "workspace_name": release_request.workspace,
+                "commit": release_request.get_request_file_from_urlpath(path).commit,
+            },
         )
 
     group_edit_form = None
@@ -204,6 +212,7 @@ def request_view(request, request_id: str, path: str = ""):
         "show_c3": settings.SHOW_C3,
         # TODO, but for now stops template variable errors
         "multiselect_url": "",
+        "code_url": code_url,
     }
 
     return TemplateResponse(request, template, context)

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -97,12 +97,15 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     if path_item.is_directory() or path not in workspace.manifest["outputs"]:
         code_url = None
     else:
-        code_url = reverse(
-            "code_view",
-            kwargs={
-                "workspace_name": workspace.name,
-                "commit": workspace.get_manifest_for_file(path)["commit"],
-            },
+        code_url = (
+            reverse(
+                "code_view",
+                kwargs={
+                    "workspace_name": workspace.name,
+                    "commit": workspace.get_manifest_for_file(path)["commit"],
+                },
+            )
+            + f"?return_url={workspace.get_url(path)}"
         )
 
     return TemplateResponse(
@@ -131,6 +134,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
             "project": project,
             # for code button
             "code_url": code_url,
+            "return_url": "",
         },
     )
 

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -94,6 +94,17 @@ def workspace_view(request, workspace_name: str, path: str = ""):
             workspace=workspace.name, exclude_readonly=True, size=20
         )
 
+    if path_item.is_directory() or path not in workspace.manifest["outputs"]:
+        code_url = None
+    else:
+        code_url = reverse(
+            "code_view",
+            kwargs={
+                "workspace_name": workspace.name,
+                "commit": workspace.get_manifest_for_file(path)["commit"],
+            },
+        )
+
     return TemplateResponse(
         request,
         template,
@@ -118,6 +129,8 @@ def workspace_view(request, workspace_name: str, path: str = ""):
             # for workspace summary page
             "activity": activity,
             "project": project,
+            # for code button
+            "code_url": code_url,
         },
     )
 

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -102,7 +102,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
                 "code_view",
                 kwargs={
                     "workspace_name": workspace.name,
-                    "commit": workspace.get_manifest_for_file(path)["commit"],
+                    "commit": workspace.get_manifest_for_file(path).get("commit"),
                 },
             )
             + f"?return_url={workspace.get_url(path)}"

--- a/justfile
+++ b/justfile
@@ -205,10 +205,10 @@ load-example-data: devenv && manifests
     # Configure user details for local login
     cp example-data/dev_users.json "${AIRLOCK_WORK_DIR%/}/${AIRLOCK_DEV_USERS_FILE}"
 
-# generate manifests for local test workspaces
+# generate manifests and git repos for local test workspaces
 manifests:
     cat scripts/manifests.py | $BIN/python manage.py shell
-    
+
 
 # Run the documentation server: to configure the port, append: ---dev-addr localhost:<port>
 docs-serve *ARGS: devenv

--- a/scripts/manifests.py
+++ b/scripts/manifests.py
@@ -6,5 +6,5 @@ from tests import factories
 workspaces = [w for w in settings.WORKSPACE_DIR.iterdir() if w.is_dir()]
 
 for workspace in workspaces:
-    factories.update_manifest(workspace.name)
-    print(f"Writing manifest.json for workspace {workspace.name}")
+    print(f"Writing manifest.json and creating repo for workspace {workspace.name}")
+    repo = factories.create_repo(workspace.name, temporary=False)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -249,8 +249,13 @@ def write_request_file(
     user=None,
     filetype=RequestFileType.OUTPUT,
     approved=False,
+    workspace=None,
 ):
-    workspace = ensure_workspace(request.workspace)
+    # if ensure_workspace is passed a string, it will always create a
+    # new workspace. Optionally pass a workspace instance, which will
+    # ensure that adding a file uses the commit from the workspace's
+    # manifest.json
+    workspace = ensure_workspace(workspace or request.workspace)
     try:
         workspace.abspath(path)
     except bll.FileNotFound:

--- a/tests/functional/test_code_pages.py
+++ b/tests/functional/test_code_pages.py
@@ -1,0 +1,92 @@
+from urllib.parse import urlsplit
+
+import pytest
+from playwright.sync_api import expect
+
+from airlock.business_logic import RequestStatus
+from tests import factories
+
+
+@pytest.fixture(autouse=True)
+def release_request(researcher_user):
+    workspace = factories.create_workspace("test-dir1")
+    factories.write_workspace_file(workspace, "foo.txt", "")
+    factories.create_repo(workspace)
+    release_request = factories.create_release_request(
+        workspace, user=researcher_user, status=RequestStatus.SUBMITTED
+    )
+    # Ensure the request file is written using the workspace previously
+    # created (so it's assigned the correct commit from the manifest.json associated
+    # with that workspace)
+    factories.write_request_file(
+        release_request, "group", "foo.txt", workspace=workspace
+    )
+    yield release_request
+
+
+def test_code_from_workspace(live_server, page, researcher_user):
+    code_button = page.locator("#file-code-button")
+    return_button = page.locator("#return-button")
+
+    # At a directory view, the code button is not displayed
+    page.goto(live_server.url + "/workspaces/view/test-dir1/")
+    expect(code_button).not_to_be_visible()
+
+    # manifest.json itself doesn't have a manifest entry, so code button not displayed
+    page.goto(live_server.url + "/workspaces/view/test-dir1/metadata/manifest.json")
+    expect(code_button).not_to_be_visible()
+
+    # output file does display code button
+    file_url = "/workspaces/view/test-dir1/foo.txt"
+    page.goto(live_server.url + file_url)
+    expect(code_button).to_be_visible()
+    code_button.click()
+
+    # return url (the workspace file) is passed to code view as a query param,
+    # and used as the href for the return button
+    url_parts = urlsplit(page.url)
+    assert url_parts.query == f"return_url={file_url}"
+    expect(page.locator("body")).to_contain_text("project.yaml")
+    expect(return_button).to_be_visible()
+    expect(return_button).to_have_attribute("href", file_url)
+
+    file_link = (
+        page.locator("#tree")
+        .get_by_role("link", name="project.yaml")
+        .locator(".file:scope")
+    )
+    file_link.click()
+    expect(return_button).to_be_visible()
+    expect(return_button).to_have_attribute("href", file_url)
+
+
+def test_code_from_request(live_server, page, release_request, output_checker_user):
+    code_button = page.locator("#file-code-button")
+    return_button = page.locator("#return-button")
+
+    # At a directory view, the code button is not displayed
+    page.goto(live_server.url + f"/requests/view/{release_request.id}/group/")
+    expect(code_button).not_to_be_visible()
+
+    # file view displays code button
+    file_url = f"/requests/view/{release_request.id}/group/foo.txt"
+    page.goto(live_server.url + file_url)
+    expect(code_button).to_be_visible()
+    code_button.click()
+
+    # return url (the release_request file) is passed to code view as a query param,
+    # and used as the href for the return button
+    url_parts = urlsplit(page.url)
+    assert url_parts.query == f"return_url={file_url}"
+    expect(page.locator("body")).to_contain_text("project.yaml")
+    expect(return_button).to_be_visible()
+    expect(return_button).to_have_attribute("href", file_url)
+
+    file_link = (
+        page.locator("#tree")
+        .get_by_role("link", name="project.yaml")
+        .locator(".file:scope")
+    )
+    file_link.click()
+    expect(return_button).to_be_visible()
+    expect(return_button).to_have_attribute("href", file_url)

--- a/tests/integration/views/test_code.py
+++ b/tests/integration/views/test_code.py
@@ -15,6 +15,39 @@ def test_code_view_index(airlock_client):
     assert "project.yaml" in response.rendered_content
 
 
+def test_code_view_index_return_url(airlock_client):
+    airlock_client.login(output_checker=True)
+    workspace = factories.create_workspace("workspace")
+    repo = factories.create_repo(workspace)
+
+    response = airlock_client.get(
+        f"/code/view/workspace/{repo.commit}/?return_url={workspace.get_url()}"
+    )
+    assert "project.yaml" in response.rendered_content
+    assert "return-button" in response.rendered_content
+
+
+def test_code_view_index_request_author(airlock_client):
+    airlock_client.login(output_checker=False, workspaces=["workspace"])
+    workspace = factories.create_workspace("workspace")
+    factories.create_release_request(workspace, user=airlock_client.user)
+    repo = factories.create_repo(workspace)
+
+    response = airlock_client.get(f"/code/view/workspace/{repo.commit}/")
+    assert "project.yaml" in response.rendered_content
+    assert "current-request-button" in response.rendered_content
+
+
+def test_code_view_index_user_has_workspace_access(airlock_client):
+    airlock_client.login(output_checker=False, workspaces=["workspace"])
+    workspace = factories.create_workspace("workspace")
+    repo = factories.create_repo(workspace)
+
+    response = airlock_client.get(f"/code/view/workspace/{repo.commit}/")
+    assert "project.yaml" in response.rendered_content
+    assert "workspace-home-button" in response.rendered_content
+
+
 def test_code_view_file(airlock_client):
     airlock_client.login(output_checker=True)
     repo = factories.create_repo("workspace")

--- a/tests/integration/views/test_code.py
+++ b/tests/integration/views/test_code.py
@@ -109,6 +109,10 @@ def test_code_view_no_repo(airlock_client, code_url, redirected_url):
             "/code/view/workspace/abcdefg/?return_url=/workspaces/view/workspace/foo.txt",
             "/workspaces/view/workspace/foo.txt",
         ),
+        (
+            "/code/view/workspace/abcdefg/?return_url=http://example.com",
+            "/workspaces/view/workspace/",
+        ),
     ],
 )
 def test_code_view_no_commit(airlock_client, code_url, redirected_url):

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -539,3 +539,47 @@ def test_get_code_tree(workspace):
     )
 
     assert str(tree).strip() == expected.strip()
+
+
+def test_get_code_tree_root(workspace):
+    repo = factories.create_repo(
+        workspace,
+        [
+            ("bar/1.txt", ""),
+            ("foo/1.txt", ""),
+            ("foo/2.txt", ""),
+            ("foo/baz/3.txt", ""),
+        ],
+    )
+
+    tree = get_code_tree(repo, UrlPath("."), selected_only=False)
+
+    expected = textwrap.dedent(
+        f"""
+        {repo.get_id()}***
+          bar
+            1.txt
+          foo
+            baz
+              3.txt
+            1.txt
+            2.txt
+        """
+    )
+    assert str(tree).strip() == expected.strip()
+
+    tree = get_code_tree(repo, UrlPath("."), selected_only=True)
+
+    expected = textwrap.dedent(
+        f"""
+        {repo.get_id()}***
+          bar
+            1.txt
+          foo
+            baz
+              3.txt
+            1.txt
+            2.txt
+        """
+    )
+    assert str(tree).strip() == expected.strip()


### PR DESCRIPTION
Adds a link to view code from workspace or request files.
Uses a return_url query param so user can go back to whichever file they came from.

I've also updated `just manifests` to create a local git repo for test workspaces as well as the manifest.json, which mean that code links from workspaces will work. 

However, any existing test request files will have been created with old dummy commits from the manifest.json, so you also need to run `just manage backpopulate_file_manifest_data` to fix them. (If you see "Could not update manifest.json data..." messages, it's probably because you have requests with files that no longer exist in the workspace folder) 