### PR TITLE
Add workspace file state detection

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -606,7 +606,7 @@ class ReleaseRequest:
         return url
 
     def get_renderer(self, relpath: UrlPath) -> renderers.Renderer:
-        request_file = self.get_request_file(relpath)
+        request_file = self.get_request_file_from_urlpath(relpath)
         renderer_class = renderers.get_renderer(relpath)
         return renderer_class.from_file(
             self.abspath(relpath),
@@ -615,14 +615,15 @@ class ReleaseRequest:
         )
 
     def get_file_metadata(self, relpath: UrlPath) -> FileMetadata:
-        rfile = self.get_request_file(relpath)
+        rfile = self.get_request_file_from_urlpath(relpath)
         return FileMetadata(
             rfile.size,
             rfile.timestamp,
             _content_hash=rfile.file_id,
         )
 
-    def get_request_file(self, relpath: UrlPath | str):
+    def get_request_file_from_urlpath(self, relpath: UrlPath | str):
+        """Get the request file from the url, which includes the group."""
         relpath = UrlPath(relpath)
         group = relpath.parts[0]
         file_relpath = UrlPath(*relpath.parts[1:])
@@ -640,7 +641,7 @@ class ReleaseRequest:
 
         The first part of the relpath is the group, so we parse and validate that first.
         """
-        request_file = self.get_request_file(relpath)
+        request_file = self.get_request_file_from_urlpath(relpath)
         return self.root() / request_file.file_id
 
     def all_files_set(self):
@@ -672,7 +673,7 @@ class ReleaseRequest:
         return next(
             (
                 r
-                for r in self.get_request_file(urlpath).reviews
+                for r in self.get_request_file_from_urlpath(urlpath).reviews
                 if r.reviewer == reviewer
             ),
             None,
@@ -680,7 +681,7 @@ class ReleaseRequest:
 
     def request_filetype(self, urlpath: UrlPath):
         try:
-            return self.get_request_file(urlpath).filetype
+            return self.get_request_file_from_urlpath(urlpath).filetype
         except BusinessLogicLayer.FileNotFound:
             return None
 

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -281,6 +281,7 @@ class Workspace:
         return reverse("workspace_view", kwargs=kwargs)
 
     def get_workspace_state(self, relpath: UrlPath) -> WorkspaceFileState | None:
+        # defence in depth, we've been given a bad file path
         try:
             self.abspath(relpath)
         except BusinessLogicLayer.FileNotFound:

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -13,7 +13,7 @@ from airlock.business_logic import (
     RequestFileType,
     Workspace,
 )
-from airlock.types import FileMetadata, UrlPath
+from airlock.types import FileMetadata, UrlPath, WorkspaceFileState
 from airlock.utils import is_valid_file_type
 from services.tracing import instrument
 
@@ -50,6 +50,7 @@ class PathItem:
     relpath: UrlPath
 
     type: PathType | None = None
+    workspace_state: WorkspaceFileState | None = None
     children: list[PathItem] = field(default_factory=list)
     parent: PathItem | None = None
 
@@ -168,6 +169,9 @@ class PathItem:
         need to.
         """
         classes = [self.type.value.lower()] if self.type else []
+
+        if self.workspace_state:
+            classes.append(self.workspace_state.value.lower())
 
         if self.request_filetype:
             classes.append(self.request_filetype.value.lower())
@@ -499,6 +503,7 @@ def get_path_tree(
                     node.expanded = selected or (path in (selected_path.parents or []))
             else:
                 node.type = PathType.FILE
+                node.workspace_state = container.get_workspace_state(path)
 
             tree.append(node)
 

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
@@ -127,11 +128,39 @@ class PathItem:
     def file_type(self):
         return self.suffix().lstrip(".")
 
-    def metadata(self) -> FileMetadata:
+    def metadata(self) -> FileMetadata | None:
         if self.type == PathType.FILE:
             return self.container.get_file_metadata(self.relpath)
         else:
-            return FileMetadata.empty()
+            return None
+
+    def size(self) -> int | None:
+        metadata = self.metadata()
+        if metadata is None:
+            return None
+
+        return metadata.size
+
+    def size_mb(self) -> str:
+        size = self.size()
+        if size is None:
+            return ""
+
+        if size == 0:
+            return "0 Mb"
+        elif size < 10240:
+            return "<0.01 Mb"
+        # out test files are small
+        else:  # pragma: no cover
+            mb = round(size / (1024 * 1024), 2)
+            return f"{mb} Mb"
+
+    def modified_at(self) -> datetime | None:
+        metadata = self.metadata()
+        if metadata is None:
+            return None
+
+        return datetime.utcfromtimestamp(metadata.timestamp)
 
     def breadcrumbs(self):
         item = self

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -42,8 +42,8 @@
         {% for path in path_item.children %}
           <tr>
             <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
-            <td data-order="{{ path.metadata.size }}">{{ path.metadata.size_mb }}</td>
-            <td>{{ path.metadata.modified_at|date:"Y-m-d H:i" }}</td>
+            <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
+            <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -42,8 +42,8 @@
         {% for path in path_item.children %}
           <tr>
             <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
-            <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
-            <td>{{ path.modified|date:"Y-m-d H:i" }}</td>
+            <td data-order="{{ path.metadata.size }}">{{ path.metadata.size_mb }}</td>
+            <td>{{ path.metadata.modified_at|date:"Y-m-d H:i" }}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -14,7 +14,7 @@
           {% csrf_token %}
         </form>
         <div id="multiselect_modal"></div>
-      {% elif file_in_request %}
+      {% elif path_item.workspace_state.value == "UNDER_REVIEW" %}
         {% #button type="button" disabled=True tooltip="This file has already been added to the current request" id="add-file-modal-button-disabled" %}
           Add File to Request
         {% /button %}

--- a/airlock/types.py
+++ b/airlock/types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime
 from enum import Enum
 from functools import cached_property
 from pathlib import Path, PurePosixPath
@@ -39,8 +38,8 @@ class FileMetadata:
     sometimes they are not, so need reading from the filesystem.
     """
 
-    size: int | None
-    timestamp: int | None
+    size: int
+    timestamp: int
     _content_hash: str | None = None
     path: Path | None = None
 
@@ -54,9 +53,7 @@ class FileMetadata:
 
     @classmethod
     def from_path(cls, path: Path) -> FileMetadata:
-        if path.is_dir():
-            return cls.empty()
-
+        assert path.is_file()
         stat = path.stat()
         return cls(
             size=stat.st_size,
@@ -64,35 +61,13 @@ class FileMetadata:
             path=path,
         )
 
-    @classmethod
-    def empty(cls) -> FileMetadata:
-        return cls(size=None, timestamp=None)
-
     @cached_property
-    def content_hash(self):
+    def content_hash(self) -> str:
         if self._content_hash is not None:
             return self._content_hash
         elif self.path is not None:
             assert self.path.is_file()
             return hashlib.file_digest(self.path.open("rb"), "sha256").hexdigest()
-        else:
-            return None
-
-    @property
-    def size_mb(self) -> str:
-        if self.size is None:
-            return ""
-        elif self.size == 0:
-            return "0 Mb"
-        elif self.size < 10240:
-            return "<0.01 Mb"
-        else:
-            mb = round(self.size / (1024 * 1024), 2)
-            return f"{mb} Mb"
-
-    @property
-    def modified_at(self) -> datetime | None:
-        if self.timestamp is None:
-            return None
-
-        return datetime.utcfromtimestamp(self.timestamp)
+        else:  # pragma: no cover
+            # should never get here due to constructor's validation
+            raise Exception("no content_hash available. FileMetadata.path: {self.path}")

--- a/airlock/types.py
+++ b/airlock/types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 from functools import cached_property
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
@@ -18,6 +19,16 @@ if TYPE_CHECKING:  # pragma: no cover
     class UrlPath(PurePosixPath): ...
 else:
     UrlPath = PurePosixPath
+
+
+class WorkspaceFileState(Enum):
+    """Possible states of a workspace file."""
+
+    # Workspace path states
+    UNRELEASED = "UNRELEASED"
+    UNDER_REVIEW = "UNDER_REVIEW"
+    RELEASED = "RELEASED"
+    CONTENT_UPDATED = "UPDATED"
 
 
 @dataclass

--- a/airlock/types.py
+++ b/airlock/types.py
@@ -1,5 +1,11 @@
-from pathlib import PurePosixPath
-from typing import TYPE_CHECKING
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from functools import cached_property
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any
 
 
 # We use PurePosixPath as a convenient URL path representation. In theory we could use
@@ -12,3 +18,70 @@ if TYPE_CHECKING:  # pragma: no cover
     class UrlPath(PurePosixPath): ...
 else:
     UrlPath = PurePosixPath
+
+
+@dataclass
+class FileMetadata:
+    """Represents the base properties of file metadata.
+
+    Often these are in the manifest.json, so can be read from there. But
+    sometimes they are not, so need reading from the filesystem.
+    """
+
+    size: int | None
+    timestamp: int | None
+    _content_hash: str | None = None
+    path: Path | None = None
+
+    @classmethod
+    def from_manifest(cls, metadata: dict[str, Any]) -> FileMetadata:
+        return cls(
+            size=int(metadata["size"]),
+            timestamp=int(metadata["timestamp"]),
+            _content_hash=str(metadata["content_hash"]),
+        )
+
+    @classmethod
+    def from_path(cls, path: Path) -> FileMetadata:
+        if path.is_dir():
+            return cls.empty()
+
+        stat = path.stat()
+        return cls(
+            size=stat.st_size,
+            timestamp=int(stat.st_mtime),
+            path=path,
+        )
+
+    @classmethod
+    def empty(cls) -> FileMetadata:
+        return cls(size=None, timestamp=None)
+
+    @cached_property
+    def content_hash(self):
+        if self._content_hash is not None:
+            return self._content_hash
+        elif self.path is not None:
+            assert self.path.is_file()
+            return hashlib.file_digest(self.path.open("rb"), "sha256").hexdigest()
+        else:
+            return None
+
+    @property
+    def size_mb(self) -> str:
+        if self.size is None:
+            return ""
+        elif self.size == 0:
+            return "0 Mb"
+        elif self.size < 10240:
+            return "<0.01 Mb"
+        else:
+            mb = round(self.size / (1024 * 1024), 2)
+            return f"{mb} Mb"
+
+    @property
+    def modified_at(self) -> datetime | None:
+        if self.timestamp is None:
+            return None
+
+        return datetime.utcfromtimestamp(self.timestamp)

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -287,7 +287,7 @@ def file_withdraw(request, request_id, path: str):
     grouppath = UrlPath(path)
 
     try:
-        release_request.get_request_file(grouppath)
+        release_request.get_request_file_from_urlpath(grouppath)
     except bll.FileNotFound:
         raise Http404()
 
@@ -297,7 +297,7 @@ def file_withdraw(request, request_id, path: str):
         raise PermissionDenied(str(exc))
 
     try:
-        release_request.get_request_file(grouppath)
+        release_request.get_request_file_from_urlpath(grouppath)
     except bll.FileNotFound:
         # its been removed - redirect to group that contained
         redirect_url = release_request.get_url(grouppath.parts[0])
@@ -331,7 +331,7 @@ def file_approve(request, request_id, path: str):
     release_request = get_release_request_or_raise(request.user, request_id)
 
     try:
-        relpath = release_request.get_request_file(path).relpath
+        relpath = release_request.get_request_file_from_urlpath(path).relpath
     except bll.FileNotFound:
         raise Http404()
 
@@ -350,7 +350,7 @@ def file_reject(request, request_id, path: str):
     release_request = get_release_request_or_raise(request.user, request_id)
 
     try:
-        relpath = release_request.get_request_file(path).relpath
+        relpath = release_request.get_request_file_from_urlpath(path).relpath
     except bll.FileNotFound:
         raise Http404()
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -150,8 +150,9 @@ def create_workspace(name, user=None):
         user = create_user("author", workspaces=[name])
 
     workspace_dir = settings.WORKSPACE_DIR / name
-    workspace_dir.mkdir(exist_ok=True, parents=True)
-    update_manifest(name)
+    if not workspace_dir.exists():
+        workspace_dir.mkdir(exist_ok=True, parents=True)
+        update_manifest(name)
     return bll.get_workspace(name, user)
 
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -731,7 +731,7 @@ def test_file_withdraw_file_pending(airlock_client):
     release_request = factories.refresh_release_request(release_request)
 
     # ensure it does exist
-    release_request.get_request_file("group/path/test.txt")
+    release_request.get_request_file_from_urlpath("group/path/test.txt")
 
     response = airlock_client.post(
         f"/requests/withdraw/{release_request.id}/group/path/test.txt",
@@ -742,7 +742,7 @@ def test_file_withdraw_file_pending(airlock_client):
     persisted_request = factories.bll.get_release_request(release_request.id, author)
 
     with pytest.raises(factories.bll.FileNotFound):
-        persisted_request.get_request_file("group/path/test.txt")
+        persisted_request.get_request_file_from_urlpath("group/path/test.txt")
 
 
 def test_file_withdraw_file_submitted(airlock_client):
@@ -757,7 +757,7 @@ def test_file_withdraw_file_submitted(airlock_client):
     release_request = factories.refresh_release_request(release_request)
 
     # ensure it does exist
-    release_request.get_request_file("group/path/test.txt")
+    release_request.get_request_file_from_urlpath("group/path/test.txt")
 
     response = airlock_client.post(
         f"/requests/withdraw/{release_request.id}/group/path/test.txt",
@@ -769,7 +769,9 @@ def test_file_withdraw_file_submitted(airlock_client):
     assert "This file has been withdrawn" in response.rendered_content
 
     persisted_request = factories.bll.get_release_request(release_request.id, author)
-    request_file = persisted_request.get_request_file("group/path/test.txt")
+    request_file = persisted_request.get_request_file_from_urlpath(
+        "group/path/test.txt"
+    )
     assert request_file.filetype == RequestFileType.WITHDRAWN
 
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -117,12 +117,12 @@ def test_get_file_metadata():
     workspace = factories.create_workspace("workspace")
 
     # non existant file
-    empty = workspace.get_file_metadata(UrlPath("metadata/foo.log"))
-    assert empty.size is None
-    assert empty.size_mb == ""
-    assert empty.timestamp is None
-    assert empty.modified_at is None
-    assert empty.content_hash is None
+    assert workspace.get_file_metadata(UrlPath("metadata/foo.log")) is None
+
+    # directory
+    (workspace.root() / "directory").mkdir()
+    with pytest.raises(AssertionError):
+        workspace.get_file_metadata(UrlPath("directory")) is None
 
     # small log file
     factories.write_workspace_file(
@@ -131,7 +131,6 @@ def test_get_file_metadata():
 
     from_file = workspace.get_file_metadata(UrlPath("metadata/foo.log"))
     assert from_file.size == 3
-    assert from_file.size_mb == "<0.01 Mb"
     assert from_file.timestamp is not None
     assert from_file.content_hash == hashlib.sha256(b"foo").hexdigest()
 
@@ -143,19 +142,11 @@ def test_get_file_metadata():
 
     from_metadata = workspace.get_file_metadata(UrlPath("output/bar.csv"))
     assert from_metadata.size == len(contents)
-    assert from_metadata.size_mb == "2.0 Mb"
     assert from_metadata.timestamp is not None
     assert (
         from_metadata.content_hash
         == hashlib.sha256(contents.encode("utf8")).hexdigest()
     )
-
-    (workspace.root() / "directory").mkdir()
-    directory = workspace.get_file_metadata(UrlPath("directory"))
-    assert directory.size is None
-    assert directory.size_mb == ""
-    assert directory.timestamp is None
-    assert directory.content_hash is None
 
 
 def test_workspace_get_workspace_state(bll):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1022,7 +1022,7 @@ def test_request_all_files_set(bll):
     assert len(filegroup.supporting_files) == 1
 
 
-def test_request_release_get_request_file(bll):
+def test_request_release_get_request_file_from_urlpath(bll):
     path = UrlPath("foo/bar.txt")
     supporting_path = UrlPath("foo/bar1.txt")
     release_request = factories.create_release_request("id")
@@ -1032,12 +1032,12 @@ def test_request_release_get_request_file(bll):
     )
 
     with pytest.raises(bll.FileNotFound):
-        release_request.get_request_file("badgroup" / path)
+        release_request.get_request_file_from_urlpath("badgroup" / path)
 
     with pytest.raises(bll.FileNotFound):
-        release_request.get_request_file("default/does/not/exist")
+        release_request.get_request_file_from_urlpath("default/does/not/exist")
 
-    request_file = release_request.get_request_file("default" / path)
+    request_file = release_request.get_request_file_from_urlpath("default" / path)
     assert request_file.relpath == path
 
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1020,7 +1020,7 @@ def test_withdraw_file_from_request_not_author(bll, state):
         bll.withdraw_file_from_request(release_request, UrlPath("bad/path"), user=other)
 
 
-def test_request_all_files_set(bll):
+def test_request_all_files_by_name(bll):
     author = factories.create_user(username="author", workspaces=["workspace"])
     path = Path("path/file.txt")
     supporting_path = Path("path/supporting_file.txt")
@@ -1038,8 +1038,9 @@ def test_request_all_files_set(bll):
         release_request, supporting_path, author, filetype=RequestFileType.SUPPORTING
     )
 
-    # all_files_set consists of output files and supporting files
-    assert release_request.all_files_set() == {path, supporting_path}
+    release_request = factories.refresh_release_request(release_request)
+    # all_files_by_name consists of output files and supporting files
+    assert release_request.all_files_by_name.keys() == {path, supporting_path}
 
     filegroup = release_request.filegroups["default"]
     assert len(filegroup.files) == 2

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -115,6 +115,8 @@ def test_workspace_manifest_for_file_not_found(bll):
 
 def test_get_file_metadata():
     workspace = factories.create_workspace("workspace")
+
+    # non existant file
     empty = workspace.get_file_metadata(UrlPath("metadata/foo.log"))
     assert empty.size is None
     assert empty.size_mb == ""

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -62,7 +62,7 @@ def test_renderers_get_renderer_request(tmp_path, rf, suffix, mimetype, template
     time = 1709652904  # date this test was written
     abspath = request.abspath(grouppath)
     os.utime(abspath, (time, time))
-    request_file = request.get_request_file(grouppath)
+    request_file = request.get_request_file_from_urlpath(grouppath)
 
     renderer_class = renderers.get_renderer(request_file.relpath)
     renderer = renderer_class.from_file(


### PR DESCRIPTION
This adds a core capability - knowing whether a file is part of the current reqeust and if it has been updated since added.

It uses this new capability to a) decorate the tree with classes for later styling and b) decide if a file can be added to a request or not.

fixes #343 

