### PR TITLE
Support managing GitHub issues in different repos per organisation

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1762,9 +1762,14 @@ class BusinessLogicLayer:
             "request_author": request.author,
             "user": user.username,
             "updates": updates,
-            "org": settings.AIRLOCK_OUTPUT_CHECKING_ORG,
-            "repo": settings.AIRLOCK_OUTPUT_CHECKING_REPO,
         }
+        if settings.AIRLOCK_OUTPUT_CHECKING_ORG:
+            event_data.update(
+                {
+                    "org": settings.AIRLOCK_OUTPUT_CHECKING_ORG,
+                    "repo": settings.AIRLOCK_OUTPUT_CHECKING_REPO,
+                }
+            )
 
         data = send_notification_event(json.dumps(event_data), user.username)
         logger.info(

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -309,12 +309,15 @@ else:  # pragma: no cover
         f"variables must be set.\n\n{_missing_env_var_hint}"
     )
 
-AIRLOCK_OUTPUT_CHECKING_ORG = os.environ.get(
-    "AIRLOCK_OUTPUT_CHECKING_ORG", "ebmdatalab"
-)
-AIRLOCK_OUTPUT_CHECKING_REPO = os.environ.get(
-    "AIRLOCK_OUTPUT_CHECKING_REPO", "opensafely-output-review"
-)
+AIRLOCK_OUTPUT_CHECKING_ORG = os.environ.get("AIRLOCK_OUTPUT_CHECKING_ORG")
+AIRLOCK_OUTPUT_CHECKING_REPO = os.environ.get("AIRLOCK_OUTPUT_CHECKING_REPO")
+if bool(AIRLOCK_OUTPUT_CHECKING_ORG) != bool(
+    AIRLOCK_OUTPUT_CHECKING_REPO
+):  # pragma: no cover
+    raise RuntimeError(
+        f"Both or neither of AIRLOCK_OUTPUT_CHECKING_ORG and AIRLOCK_OUTPUT_CHECKING_REPO environment "
+        f"variables must be set.\n\n{_missing_env_var_hint}"
+    )
 
 AIRLOCK_DATA_ACCESS_LAYER = "local_db.data_access.LocalDBDataAccessLayer"
 


### PR DESCRIPTION
Fixes #342

Previously we had a default org/repo that was sent to job-server; now we only send these values if they're explicitly set as env variables, and we let job-server deal with any others. This means that the test backend can set the org/repo that should be used for creating issues (i.e. not a real output-checking repo), and job-server can decide which repo to use based on the organisation that the workspace belongs to (which airlock doesn't have knowledge of).

Depends on job-server PR https://github.com/opensafely-core/job-server/pull/4372