### PR TITLE
Fallback to fetching repo from first manifest output

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -437,9 +437,7 @@ class CodeRepo:
     @classmethod
     def from_workspace(cls, workspace: Workspace, commit: str):
         try:
-            repo = workspace.manifest.get("repo")
-            if repo is None:
-                repo = list(workspace.manifest["outputs"].values())[0]["repo"]
+            repo = list(workspace.manifest["outputs"].values())[0]["repo"]
         except (BusinessLogicLayer.ManifestFileError, IndexError, KeyError) as exc:
             raise cls.RepoNotFound(
                 f"Could not parse manifest.json file: {workspace.manifest_path()}:\n{exc}"

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -306,6 +306,9 @@ class Workspace:
     def root(self):
         return settings.WORKSPACE_DIR / self.name
 
+    def manifest_path(self):
+        return self.root() / "metadata/manifest.json"
+
     def get_id(self) -> str:
         return self.name
 
@@ -434,10 +437,12 @@ class CodeRepo:
     @classmethod
     def from_workspace(cls, workspace: Workspace, commit: str):
         try:
-            repo = workspace.manifest["repo"]
-        except (BusinessLogicLayer.ManifestFileError, KeyError):
+            repo = workspace.manifest.get("repo")
+            if repo is None:
+                repo = list(workspace.manifest["outputs"].values())[0]["repo"]
+        except (BusinessLogicLayer.ManifestFileError, IndexError, KeyError) as exc:
             raise cls.RepoNotFound(
-                "Could not parse manifest.json file: {manifest_path}:\n{exc}"
+                f"Could not parse manifest.json file: {workspace.manifest_path()}:\n{exc}"
             )
 
         try:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -214,7 +214,10 @@ def create_repo(workspace, files=None, temporary=True):
 
     commit = response.stdout.strip()
     update_manifest(workspace)
-    workspace.manifest["repo"] = str(repo_dir)
+    if not workspace.manifest["outputs"]:
+        write_workspace_file(workspace, "foo.txt")
+
+    workspace.manifest["repo"] = None  # match job-runner output
     for output in workspace.manifest["outputs"].values():
         output["repo"] = str(repo_dir)
         output["commit"] = str(commit)

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -84,7 +84,9 @@ def tree_element_is_selected(page, locator):
     return "selected" in classes
 
 
-def test_e2e_release_files(page, live_server, dev_users, release_files_stubber):
+def test_e2e_release_files(
+    page, live_server, context, dev_users, release_files_stubber
+):
     """
     Test full Airlock process to create, submit and release files
 
@@ -320,7 +322,7 @@ def test_e2e_release_files(page, live_server, dev_users, release_files_stubber):
     # The literal request URL in the html includes the root path (".")
     expect(request_link).to_have_attribute("href", f"/requests/view/{request_id}/")
 
-    # Log out
+    # Log out with buttons
     find_and_click(page.get_by_test_id("nav-account"))
     find_and_click(page.get_by_test_id("nav-logout"))
 
@@ -395,10 +397,9 @@ def test_e2e_release_files(page, live_server, dev_users, release_files_stubber):
     expect(page.locator("#file-reject-button")).not_to_be_visible()
     expect(page.locator("#file-reset-button")).not_to_be_visible()
 
-    # Logout and log in as second output-checker to do second approval and
-    # release
-    find_and_click(page.get_by_test_id("nav-account"))
-    find_and_click(page.get_by_test_id("nav-logout"))
+    # Logout (by clearing cookies) and log in as second output-checker to do second approval
+    # and release
+    context.clear_cookies()
     login_as(live_server, page, "output_checker_1")
     # Approve the file
     page.goto(live_server.url + release_request.get_url("my-new-group/subdir/file.txt"))

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -133,12 +133,18 @@ def test_request_return(live_server, context, page, bll):
         "file2.txt",
         "file 2 content",
     )
-    factories.bll.set_status(release_request, RequestStatus.SUBMITTED, author)
+    bll.set_status(release_request, RequestStatus.SUBMITTED, author)
 
     return_request_button = page.locator("#return-request-button")
+    page.goto(live_server.url + release_request.get_url())
+
+    def _logout():
+        # logout by clearing cookies
+        context.clear_cookies()
 
     def _review_files(username):
-        # login as first output-checker
+        # logout current user, login as username
+        _logout()
         login_as_user(
             live_server,
             context,
@@ -172,7 +178,8 @@ def test_request_return(live_server, context, page, bll):
     # Return the request
     return_request_button.click()
 
-    # login as author again
+    # logout, login as author again
+    _logout()
     login_as_user(
         live_server,
         context,
@@ -186,7 +193,8 @@ def test_request_return(live_server, context, page, bll):
     # Can re-submit a returned request
     page.locator("#submit-for-review-button").click()
 
-    # login as first output-checker
+    # logout, login as first output-checker
+    _logout()
     login_as_user(
         live_server,
         context,

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -2134,9 +2134,27 @@ def test_group_comment_create_invalid_params(bll):
     assert len(release_request.filegroups["group"].comments) == 1
 
 
-def test_coderepo_from_workspace_bad_json(bll):
+@pytest.mark.parametrize(
+    "manifest",
+    [
+        {},
+        {"repo": None, "outputs": {}},
+        {"repo": None, "outputs": {"file.txt": {"commit": "commit"}}},
+    ],
+)
+def test_coderepo_from_workspace_no_repo_in_manifest(bll, manifest):
     workspace = factories.create_workspace("workspace")
-    workspace.manifest = {}
-
+    workspace.manifest = manifest
     with pytest.raises(CodeRepo.RepoNotFound):
         CodeRepo.from_workspace(workspace, "commit")
+
+
+def test_coderepo_from_workspace_no_root_repo(bll):
+    workspace = factories.create_workspace("workspace")
+    factories.write_workspace_file(workspace, "foo.txt")
+    factories.create_repo(workspace)
+    # No root repo, retrieved from first output in manifest instead
+    workspace.manifest["repo"] = None
+    CodeRepo.from_workspace(
+        workspace, workspace.manifest["outputs"]["foo.txt"]["commit"]
+    )

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -243,7 +243,9 @@ def test_request_file_manifest_data_content_hash_mismatch(mock_notifications, bl
 
 
 def test_code_repo_container():
-    repo = factories.create_repo("workspace")
+    workspace = factories.create_workspace("workspace")
+    factories.write_workspace_file(workspace, "foo.txt")
+    repo = factories.create_repo(workspace)
 
     assert repo.get_id() == f"workspace@{repo.commit[:7]}"
     assert (
@@ -2149,9 +2151,8 @@ def test_coderepo_from_workspace_no_repo_in_manifest(bll, manifest):
         CodeRepo.from_workspace(workspace, "commit")
 
 
-def test_coderepo_from_workspace_no_root_repo(bll):
+def test_coderepo_from_workspace(bll):
     workspace = factories.create_workspace("workspace")
-    factories.write_workspace_file(workspace, "foo.txt")
     factories.create_repo(workspace)
     # No root repo, retrieved from first output in manifest instead
     workspace.manifest["repo"] = None


### PR DESCRIPTION
For older manifests, the top level repo may be None, but it can be retrieved from the output file data.