### PR TITLE
Track and expose request file state in tree

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -349,7 +349,7 @@ class Workspace:
     def get_user_request_state(
         self, relpath: UrlPath, user: User
     ) -> UserFileReviewStatus | None:
-        return None
+        return None  # pragma: nocover
 
     def get_requests_url(self):
         return reverse(
@@ -524,7 +524,7 @@ class CodeRepo:
     def get_user_request_state(
         self, relpath: UrlPath, user: User
     ) -> UserFileReviewStatus | None:
-        return None
+        return None  # pragma: no cover
 
 
 @dataclass(frozen=True)

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -58,7 +58,7 @@ class RequestFileType(Enum):
     CODE = "code"
 
 
-class FileReviewStatus(Enum):
+class UserFileReviewStatus(Enum):
     APPROVED = "APPROVED"
     REJECTED = "REJECTED"
     UNDECIDED = (
@@ -499,7 +499,7 @@ class FileReview:
     """
 
     reviewer: str
-    status: FileReviewStatus
+    status: UserFileReviewStatus
     created_at: datetime
     updated_at: datetime
 
@@ -545,7 +545,7 @@ class RequestFile:
                 [
                     review
                     for review in self.reviews
-                    if review.status == FileReviewStatus.APPROVED
+                    if review.status == UserFileReviewStatus.APPROVED
                 ]
             )
             >= 2
@@ -555,7 +555,7 @@ class RequestFile:
         return [
             review
             for review in self.reviews
-            if review.status == FileReviewStatus.REJECTED
+            if review.status == UserFileReviewStatus.REJECTED
         ]
 
     def reviewed(self):
@@ -568,7 +568,7 @@ class RequestFile:
                     review
                     for review in self.reviews
                     if review.status
-                    in [FileReviewStatus.APPROVED, FileReviewStatus.REJECTED]
+                    in [UserFileReviewStatus.APPROVED, UserFileReviewStatus.REJECTED]
                 ]
             )
             >= 2
@@ -1587,12 +1587,12 @@ class BusinessLogicLayer:
         """Change an existing rejected file in a returned request to undecided before re-submitting"""
         if release_request.status != RequestStatus.RETURNED:
             raise self.ApprovalPermissionDenied(
-                f"cannot change file review to {FileReviewStatus.UNDECIDED.name} from request in state {release_request.status.name}"
+                f"cannot change file review to {UserFileReviewStatus.UNDECIDED.name} from request in state {release_request.status.name}"
             )
 
-        if review.status != FileReviewStatus.REJECTED:
+        if review.status != UserFileReviewStatus.REJECTED:
             raise self.ApprovalPermissionDenied(
-                f"cannot change file review from {review.status.name} to {FileReviewStatus.UNDECIDED.name} from request in state {release_request.status.name}"
+                f"cannot change file review from {review.status.name} to {UserFileReviewStatus.UNDECIDED.name} from request in state {release_request.status.name}"
             )
 
         audit = AuditEvent.from_request(

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -183,17 +183,13 @@ class PathItem:
         return crumbs
 
     def is_output(self):
-        return self.container.request_filetype(self.relpath) == RequestFileType.OUTPUT
+        return self.request_filetype == RequestFileType.OUTPUT
 
     def is_supporting(self):
-        return (
-            self.container.request_filetype(self.relpath) == RequestFileType.SUPPORTING
-        )
+        return self.request_filetype == RequestFileType.SUPPORTING
 
     def is_withdrawn(self):
-        return (
-            self.container.request_filetype(self.relpath) == RequestFileType.WITHDRAWN
-        )
+        return self.request_filetype == RequestFileType.WITHDRAWN
 
     def is_valid(self):
         return is_valid_file_type(Path(self.relpath))

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -16,7 +16,7 @@ from airlock.business_logic import (
     UserFileReviewStatus,
     Workspace,
 )
-from airlock.types import FileMetadata, UrlPath, WorkspaceFileState
+from airlock.types import FileMetadata, UrlPath, WorkspaceFileStatus
 from airlock.users import User
 from airlock.utils import is_valid_file_type
 from services.tracing import instrument
@@ -54,9 +54,9 @@ class PathItem:
     relpath: UrlPath
 
     type: PathType | None = None
-    workspace_state: WorkspaceFileState | None = None
-    request_state: RequestFileReviewStatus | None = None
-    user_request_state: UserFileReviewStatus | None = None
+    workspace_status: WorkspaceFileStatus | None = None
+    request_status: RequestFileReviewStatus | None = None
+    user_request_status: UserFileReviewStatus | None = None
     children: list[PathItem] = field(default_factory=list)
     parent: PathItem | None = None
 
@@ -103,8 +103,8 @@ class PathItem:
 
     def display_status(self):
         """Status of this path."""
-        if isinstance(self.container, Workspace) and self.workspace_state:
-            return self.workspace_state.formatted()
+        if isinstance(self.container, Workspace) and self.workspace_status:
+            return self.workspace_status.formatted()
         # TODO request states
         return ""
 
@@ -208,14 +208,14 @@ class PathItem:
         """
         classes = [self.type.value.lower()] if self.type else []
 
-        if self.workspace_state:
-            classes.append(f"workspace_{self.workspace_state.value.lower()}")
+        if self.workspace_status:
+            classes.append(f"workspace_{self.workspace_status.value.lower()}")
 
-        if self.request_state:
-            classes.append(f"request_{self.request_state.value.lower()}")
+        if self.request_status:
+            classes.append(f"request_{self.request_status.value.lower()}")
 
-        if self.user_request_state:
-            classes.append(f"user_{self.user_request_state.value.lower()}")
+        if self.user_request_status:
+            classes.append(f"user_{self.user_request_status.value.lower()}")
         else:
             classes.append("user_incomplete")
 
@@ -555,10 +555,10 @@ def get_path_tree(
                 # get_path_tree needs to work with both Workspace and
                 # ReleaseRequest containers, so we have these container specfic
                 # calls
-                node.workspace_state = container.get_workspace_state(path)
-                node.request_state = container.get_request_state(path)
+                node.workspace_status = container.get_workspace_status(path)
+                node.request_status = container.get_request_status(path)
                 if user:
-                    node.user_request_state = container.get_user_request_state(
+                    node.user_request_status = container.get_user_request_status(
                         path, user
                     )
 

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -14,7 +14,7 @@
           {% csrf_token %}
         </form>
         <div id="multiselect_modal"></div>
-      {% elif path_item.workspace_state.value == "UNDER_REVIEW" %}
+      {% elif path_item.workspace_status.value == "UNDER_REVIEW" %}
         {% #button type="button" disabled=True tooltip="This file has already been added to the current request" id="add-file-modal-button-disabled" %}
           Add File to Request
         {% /button %}

--- a/airlock/templates/file_browser/request.html
+++ b/airlock/templates/file_browser/request.html
@@ -4,7 +4,7 @@
       {{ release_request.status.name }}
     {% /description_item %}
     {% #description_item title="Files requested for release" %}
-      {{ release_request.output_files_set|length }}
+      {{ release_request.output_files|length }}
     {% /description_item %}
     {% #description_item title="Supporting files not for release" %}
       {{ release_request.supporting_files_count }}

--- a/airlock/types.py
+++ b/airlock/types.py
@@ -20,7 +20,7 @@ else:
     UrlPath = PurePosixPath
 
 
-class WorkspaceFileState(Enum):
+class WorkspaceFileStatus(Enum):
     """Possible states of a workspace file."""
 
     # Workspace path states

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -195,9 +195,9 @@ def request_view(request, request_id: str, path: str = ""):
             kwargs={"request_id": request_id, "path": path},
         )
 
-        existing_review = release_request.get_file_review_for_reviewer(
-            path, request.user.username
-        )
+        request_file = release_request.get_request_file_from_urlpath(relpath)
+        existing_review = request_file.reviews.get(request.user.username)
+
         if existing_review and existing_review.status != UserFileReviewStatus.UNDECIDED:
             if existing_review.status == UserFileReviewStatus.APPROVED:
                 file_approve_url = None

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -13,9 +13,9 @@ from opentelemetry import trace
 
 from airlock.business_logic import (
     ROOT_PATH,
-    FileReviewStatus,
     RequestFileType,
     RequestStatus,
+    UserFileReviewStatus,
     bll,
 )
 from airlock.file_browser_api import get_request_tree
@@ -198,13 +198,13 @@ def request_view(request, request_id: str, path: str = ""):
         existing_review = release_request.get_file_review_for_reviewer(
             path, request.user.username
         )
-        if existing_review and existing_review.status != FileReviewStatus.UNDECIDED:
-            if existing_review.status == FileReviewStatus.APPROVED:
+        if existing_review and existing_review.status != UserFileReviewStatus.UNDECIDED:
+            if existing_review.status == UserFileReviewStatus.APPROVED:
                 file_approve_url = None
-            elif existing_review.status == FileReviewStatus.REJECTED:
+            elif existing_review.status == UserFileReviewStatus.REJECTED:
                 file_reject_url = None
             else:
-                assert False, "Invalid FileReviewStatus value"
+                assert False, "Invalid UserFileReviewStatus value"
         else:
             file_reset_review_url = None
 

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -12,7 +12,7 @@ from opentelemetry import trace
 from airlock.business_logic import RequestFileType, bll
 from airlock.file_browser_api import get_workspace_tree
 from airlock.forms import AddFileForm, FileTypeFormSet, MultiselectForm
-from airlock.types import UrlPath, WorkspaceFileState
+from airlock.types import UrlPath, WorkspaceFileStatus
 from airlock.views.helpers import (
     display_form_errors,
     display_multiple_messages,
@@ -73,14 +73,14 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     # check file metadata to allow updating a file if the original has
     # changed.
     valid_states_to_add = [
-        WorkspaceFileState.UNRELEASED,
-        # TODO WorkspaceFileState.CONTENT_UPDATED,
+        WorkspaceFileStatus.UNRELEASED,
+        # TODO WorkspaceFileStatus.CONTENT_UPDATED,
     ]
 
     add_file = (
         path_item.is_valid()
         and request.user.can_create_request(workspace_name)
-        and workspace.get_workspace_state(path_item.relpath) in valid_states_to_add
+        and workspace.get_workspace_status(path_item.relpath) in valid_states_to_add
     )
 
     activity = []
@@ -205,8 +205,8 @@ def multiselect_add_files(request, multiform, workspace):
     for f in multiform.cleaned_data["selected"]:
         workspace.abspath(f)  # validate path
 
-        state = workspace.get_workspace_state(UrlPath(f))
-        if state == WorkspaceFileState.UNRELEASED:
+        state = workspace.get_workspace_status(UrlPath(f))
+        if state == WorkspaceFileStatus.UNRELEASED:
             files_to_add.append(f)
         else:
             rfile = workspace.current_request.get_request_file_from_output_path(f)

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -6,10 +6,10 @@ from airlock.business_logic import (
     AuditEventType,
     BusinessLogicLayer,
     DataAccessLayerProtocol,
-    FileReviewStatus,
     NotificationUpdateType,
     RequestFileType,
     RequestStatus,
+    UserFileReviewStatus,
 )
 from airlock.types import UrlPath
 from local_db.models import (
@@ -252,7 +252,7 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
             review, _ = FileReview.objects.get_or_create(
                 file=request_file, reviewer=username
             )
-            review.status = FileReviewStatus.APPROVED
+            review.status = UserFileReviewStatus.APPROVED
             review.save()
 
             self._create_audit_log(audit)
@@ -268,7 +268,7 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
             review, _ = FileReview.objects.get_or_create(
                 file=request_file, reviewer=username
             )
-            review.status = FileReviewStatus.REJECTED
+            review.status = UserFileReviewStatus.REJECTED
             review.save()
 
             self._create_audit_log(audit)
@@ -297,7 +297,7 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
                 request_id=request_id, relpath=relpath
             )
             review = FileReview.objects.get(file=request_file, reviewer=reviewer)
-            review.status = FileReviewStatus.UNDECIDED
+            review.status = UserFileReviewStatus.UNDECIDED
             review.save()
 
             self._create_audit_log(audit)

--- a/local_db/migrations/0006_filereview.py
+++ b/local_db/migrations/0006_filereview.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 (
                     "status",
                     local_db.models.EnumField(
-                        default=airlock.business_logic.FileReviewStatus["REJECTED"]
+                        default=airlock.business_logic.UserFileReviewStatus["REJECTED"]
                     ),
                 ),
                 ("created_at", models.DateTimeField(default=django.utils.timezone.now)),

--- a/local_db/migrations/0009_alter_auditlog_type_alter_filereview_status_and_more.py
+++ b/local_db/migrations/0009_alter_auditlog_type_alter_filereview_status_and_more.py
@@ -21,8 +21,8 @@ class Migration(migrations.Migration):
             model_name="filereview",
             name="status",
             field=local_db.models.EnumField(
-                default=airlock.business_logic.FileReviewStatus["REJECTED"],
-                enum=airlock.business_logic.FileReviewStatus,
+                default=airlock.business_logic.UserFileReviewStatus["REJECTED"],
+                enum=airlock.business_logic.UserFileReviewStatus,
             ),
         ),
         migrations.AlterField(

--- a/local_db/models.py
+++ b/local_db/models.py
@@ -11,9 +11,9 @@ from ulid import ulid  # type: ignore
 
 from airlock.business_logic import (
     AuditEventType,
-    FileReviewStatus,
     RequestFileType,
     RequestStatus,
+    UserFileReviewStatus,
 )
 
 
@@ -215,7 +215,7 @@ class FileReview(models.Model):
         RequestFileMetadata, related_name="reviews", on_delete=models.RESTRICT
     )
     reviewer = models.TextField()
-    status = EnumField(default=FileReviewStatus.REJECTED, enum=FileReviewStatus)
+    status = EnumField(default=UserFileReviewStatus.REJECTED, enum=UserFileReviewStatus)
     created_at = models.DateTimeField(default=timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -5,10 +5,10 @@ import requests
 
 from airlock.business_logic import (
     AuditEventType,
-    FileReviewStatus,
     RequestFileType,
     RequestStatus,
     UrlPath,
+    UserFileReviewStatus,
     bll,
 )
 from tests import factories
@@ -705,7 +705,7 @@ def test_file_approve(airlock_client):
         .files[relpath]
         .reviews[0]
     )
-    assert review.status == FileReviewStatus.APPROVED
+    assert review.status == UserFileReviewStatus.APPROVED
     assert review.reviewer == "testuser"
 
 
@@ -731,7 +731,7 @@ def test_file_reject(airlock_client):
         .files[relpath]
         .reviews[0]
     )
-    assert review.status == FileReviewStatus.REJECTED
+    assert review.status == UserFileReviewStatus.REJECTED
     assert review.reviewer == "testuser"
 
 
@@ -758,7 +758,7 @@ def test_file_reset_review(airlock_client):
         .files[relpath]
         .reviews[0]
     )
-    assert review.status == FileReviewStatus.REJECTED
+    assert review.status == UserFileReviewStatus.REJECTED
     assert review.reviewer == "testuser"
 
     # then reset it to have no review

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -701,9 +701,8 @@ def test_file_approve(airlock_client):
     relpath = UrlPath(path)
     review = (
         factories.bll.get_release_request(release_request.id, author)
-        .filegroups["group"]
-        .files[relpath]
-        .reviews[0]
+        .get_request_file_from_output_path(relpath)
+        .reviews[airlock_client.user.username]
     )
     assert review.status == UserFileReviewStatus.APPROVED
     assert review.reviewer == "testuser"
@@ -727,9 +726,8 @@ def test_file_reject(airlock_client):
     relpath = UrlPath(path)
     review = (
         factories.bll.get_release_request(release_request.id, author)
-        .filegroups["group"]
-        .files[relpath]
-        .reviews[0]
+        .get_request_file_from_output_path(relpath)
+        .reviews[airlock_client.user.username]
     )
     assert review.status == UserFileReviewStatus.REJECTED
     assert review.reviewer == "testuser"
@@ -754,9 +752,8 @@ def test_file_reset_review(airlock_client):
     relpath = UrlPath(path)
     review = (
         factories.bll.get_release_request(release_request.id, author)
-        .filegroups["group"]
-        .files[relpath]
-        .reviews[0]
+        .get_request_file_from_output_path(relpath)
+        .reviews[airlock_client.user.username]
     )
     assert review.status == UserFileReviewStatus.REJECTED
     assert review.reviewer == "testuser"

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -3,6 +3,11 @@ import textwrap
 import pytest
 from django.template.loader import render_to_string
 
+from airlock.business_logic import (
+    RequestFileReviewStatus,
+    RequestStatus,
+    UserFileReviewStatus,
+)
 from airlock.file_browser_api import (
     PathType,
     UrlPath,
@@ -35,7 +40,7 @@ def release_request(workspace):
     factories.write_request_file(rr, "group1", "some_dir/file_a.txt")
     factories.write_request_file(rr, "group1", "some_dir/file_c.txt")
     factories.write_request_file(rr, "group2", "some_dir/file_b.txt")
-    return rr
+    return factories.refresh_release_request(rr)
 
 
 def test_get_workspace_tree_general(release_request):
@@ -96,6 +101,16 @@ def test_get_workspace_tree_general(release_request):
         == WorkspaceFileState.UNRELEASED
     )
 
+    # html classes
+    assert (
+        "workspace_under_review" in tree.get_path("some_dir/file_a.txt").html_classes()
+    )
+    assert "workspace_updated" in tree.get_path("some_dir/file_c.txt").html_classes()
+    assert "workspace_unreleased" in tree.get_path("some_dir/file_d.txt").html_classes()
+
+    assert tree.get_path("some_dir/file_a.txt").request_state is None
+    assert tree.get_path("some_dir/file_a.txt").user_request_state is None
+
     # selected
     assert tree.get_path("some_dir/file_a.txt") == tree.get_selected()
 
@@ -150,6 +165,58 @@ def test_get_request_tree_general(release_request):
 
     # check that the tree works with the recursive template
     render_to_string("file_browser/tree.html", {"path": tree})
+
+
+def test_get_request_tree_status(release_request, bll):
+    bll.set_status(
+        release_request,
+        RequestStatus.SUBMITTED,
+        factories.create_user("author", workspaces=[release_request.workspace]),
+    )
+    checker1 = factories.create_user("checker1", [], True)
+    checker2 = factories.create_user("checker2", [], True)
+    path = UrlPath("some_dir/file_a.txt")
+    group_path = "group1" / path
+
+    def set_status(status, user):
+        if status == UserFileReviewStatus.APPROVED:
+            bll.approve_file(release_request, path, user)
+        elif status == UserFileReviewStatus.REJECTED:
+            bll.reject_file(release_request, path, user)
+
+        rr = bll.get_release_request(release_request, user)
+        tree = get_request_tree(rr, user=user)
+        return tree.get_path(group_path)
+
+    item = set_status(None, checker1)
+    assert item.request_state == RequestFileReviewStatus.INCOMPLETE
+    assert item.user_request_state is None
+    assert "request_incomplete" in item.html_classes()
+    assert "user_incomplete" in item.html_classes()
+
+    item = set_status(UserFileReviewStatus.APPROVED, checker1)
+    assert item.request_state == RequestFileReviewStatus.INCOMPLETE
+    assert item.user_request_state == UserFileReviewStatus.APPROVED
+    assert "request_incomplete" in item.html_classes()
+    assert "user_approved" in item.html_classes()
+
+    item = set_status(UserFileReviewStatus.APPROVED, checker2)
+    assert item.request_state == RequestFileReviewStatus.APPROVED
+    assert item.user_request_state == UserFileReviewStatus.APPROVED
+    assert "request_approved" in item.html_classes()
+    assert "user_approved" in item.html_classes()
+
+    item = set_status(UserFileReviewStatus.REJECTED, checker2)
+    assert item.request_state == RequestFileReviewStatus.CONFLICTED
+    assert item.user_request_state == UserFileReviewStatus.REJECTED
+    assert "request_conflicted" in item.html_classes()
+    assert "user_rejected" in item.html_classes()
+
+    item = set_status(UserFileReviewStatus.REJECTED, checker1)
+    assert item.request_state == RequestFileReviewStatus.REJECTED
+    assert item.user_request_state == UserFileReviewStatus.REJECTED
+    assert "request_rejected" in item.html_classes()
+    assert "user_rejected" in item.html_classes()
 
 
 def test_get_workspace_tree_selected_only_file(workspace):

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -15,7 +15,7 @@ from airlock.file_browser_api import (
     get_request_tree,
     get_workspace_tree,
 )
-from airlock.types import WorkspaceFileState
+from airlock.types import WorkspaceFileStatus
 from tests import factories
 from tests.conftest import get_trace
 
@@ -85,20 +85,20 @@ def test_get_workspace_tree_general(release_request):
 
     # state
     assert (
-        tree.get_path("some_dir/file_a.txt").workspace_state
-        == WorkspaceFileState.UNDER_REVIEW
+        tree.get_path("some_dir/file_a.txt").workspace_status
+        == WorkspaceFileStatus.UNDER_REVIEW
     )
     assert (
-        tree.get_path("some_dir/file_b.txt").workspace_state
-        == WorkspaceFileState.UNDER_REVIEW
+        tree.get_path("some_dir/file_b.txt").workspace_status
+        == WorkspaceFileStatus.UNDER_REVIEW
     )
     assert (
-        tree.get_path("some_dir/file_c.txt").workspace_state
-        == WorkspaceFileState.CONTENT_UPDATED
+        tree.get_path("some_dir/file_c.txt").workspace_status
+        == WorkspaceFileStatus.CONTENT_UPDATED
     )
     assert (
-        tree.get_path("some_dir/file_d.txt").workspace_state
-        == WorkspaceFileState.UNRELEASED
+        tree.get_path("some_dir/file_d.txt").workspace_status
+        == WorkspaceFileStatus.UNRELEASED
     )
 
     # html classes
@@ -108,8 +108,8 @@ def test_get_workspace_tree_general(release_request):
     assert "workspace_updated" in tree.get_path("some_dir/file_c.txt").html_classes()
     assert "workspace_unreleased" in tree.get_path("some_dir/file_d.txt").html_classes()
 
-    assert tree.get_path("some_dir/file_a.txt").request_state is None
-    assert tree.get_path("some_dir/file_a.txt").user_request_state is None
+    assert tree.get_path("some_dir/file_a.txt").request_status is None
+    assert tree.get_path("some_dir/file_a.txt").user_request_status is None
 
     # selected
     assert tree.get_path("some_dir/file_a.txt") == tree.get_selected()
@@ -189,32 +189,32 @@ def test_get_request_tree_status(release_request, bll):
         return tree.get_path(group_path)
 
     item = set_status(None, checker1)
-    assert item.request_state == RequestFileReviewStatus.INCOMPLETE
-    assert item.user_request_state is None
+    assert item.request_status == RequestFileReviewStatus.INCOMPLETE
+    assert item.user_request_status is None
     assert "request_incomplete" in item.html_classes()
     assert "user_incomplete" in item.html_classes()
 
     item = set_status(UserFileReviewStatus.APPROVED, checker1)
-    assert item.request_state == RequestFileReviewStatus.INCOMPLETE
-    assert item.user_request_state == UserFileReviewStatus.APPROVED
+    assert item.request_status == RequestFileReviewStatus.INCOMPLETE
+    assert item.user_request_status == UserFileReviewStatus.APPROVED
     assert "request_incomplete" in item.html_classes()
     assert "user_approved" in item.html_classes()
 
     item = set_status(UserFileReviewStatus.APPROVED, checker2)
-    assert item.request_state == RequestFileReviewStatus.APPROVED
-    assert item.user_request_state == UserFileReviewStatus.APPROVED
+    assert item.request_status == RequestFileReviewStatus.APPROVED
+    assert item.user_request_status == UserFileReviewStatus.APPROVED
     assert "request_approved" in item.html_classes()
     assert "user_approved" in item.html_classes()
 
     item = set_status(UserFileReviewStatus.REJECTED, checker2)
-    assert item.request_state == RequestFileReviewStatus.CONFLICTED
-    assert item.user_request_state == UserFileReviewStatus.REJECTED
+    assert item.request_status == RequestFileReviewStatus.CONFLICTED
+    assert item.user_request_status == UserFileReviewStatus.REJECTED
     assert "request_conflicted" in item.html_classes()
     assert "user_rejected" in item.html_classes()
 
     item = set_status(UserFileReviewStatus.REJECTED, checker1)
-    assert item.request_state == RequestFileReviewStatus.REJECTED
-    assert item.user_request_state == UserFileReviewStatus.REJECTED
+    assert item.request_status == RequestFileReviewStatus.REJECTED
+    assert item.user_request_status == UserFileReviewStatus.REJECTED
     assert "request_rejected" in item.html_classes()
     assert "user_rejected" in item.html_classes()
 


### PR DESCRIPTION
- **Rename FileReviewStatus to UserFileReviewStatus**
- **Refactor FileReview.reviews to be a dict with username key**
- **Make request.output_files_set a dictionary**
- **Add RequestFileReviewStatus to capture the full state**
- **Clean up old code still using container.request_filetype**
- **Expose request states in request tree.**
