### PR TITLE
Add a resubmitted notification type

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -116,6 +116,7 @@ class NotificationEventType(Enum):
     REQUEST_RELEASED = "request_released"
     REQUEST_REJECTED = "request_rejected"
     REQUEST_RETURNED = "request_returned"
+    REQUEST_RESUBMITTED = "request_resubmitted"
     REQUEST_UPDATED = "request_updated"
 
 
@@ -1404,8 +1405,15 @@ class BusinessLogicLayer:
             user=user,
         )
         self._dal.set_status(release_request.id, to_status, audit)
+        if (release_request.status, to_status) == (
+            RequestStatus.RETURNED,
+            RequestStatus.SUBMITTED,
+        ):
+            notification_event = NotificationEventType.REQUEST_RESUBMITTED
+        else:
+            notification_event = self.STATUS_EVENT_NOTIFICATION.get(to_status)
+
         release_request.status = to_status
-        notification_event = self.STATUS_EVENT_NOTIFICATION.get(to_status)
         if notification_event:  # pragma: no cover
             self.send_notification(release_request, notification_event, user)
 

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1411,11 +1411,10 @@ class BusinessLogicLayer:
         ):
             notification_event = NotificationEventType.REQUEST_RESUBMITTED
         else:
-            notification_event = self.STATUS_EVENT_NOTIFICATION.get(to_status)
+            notification_event = self.STATUS_EVENT_NOTIFICATION[to_status]
 
         release_request.status = to_status
-        if notification_event:  # pragma: no cover
-            self.send_notification(release_request, notification_event, user)
+        self.send_notification(release_request, notification_event, user)
 
     def _validate_editable(self, release_request, user):
         if user.username != release_request.author:

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -797,7 +797,7 @@ def test_set_status(current, future, valid_author, valid_checker, bll):
             RequestStatus.RETURNED,
             RequestStatus.SUBMITTED,
             "author",
-            "request_submitted",
+            "request_resubmitted",
         ),
         (RequestStatus.APPROVED, RequestStatus.RELEASED, "checker", "request_released"),
     ],
@@ -979,7 +979,7 @@ def test_resubmit_request(bll, mock_notifications):
     bll.submit_request(release_request, author)
     release_request = factories.refresh_release_request(release_request)
     assert release_request.status == RequestStatus.SUBMITTED
-    assert_last_notification(mock_notifications, "request_submitted")
+    assert_last_notification(mock_notifications, "request_resubmitted")
 
     for i in range(2):
         user = factories.create_user(f"output-checker-{i}", output_checker=True)

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from airlock.business_logic import BusinessLogicLayer, RequestStatus
 from airlock.notifications import send_notification_event
 
 
@@ -35,3 +36,13 @@ def test_send_notification_error(notifications_stubber):
         "status": "error",
         "message": "Error sending notification: 403 Forbidden",
     }
+
+
+def test_all_expected_status_changes_notify():
+    """
+    For every possible request status that a request can move
+    to (i.e. all except PENDING), assert that there is a corresponding
+    notification event that will be sent.
+    """
+    to_statuses = set(RequestStatus) - {RequestStatus.PENDING}
+    assert set(BusinessLogicLayer.STATUS_EVENT_NOTIFICATION) == to_statuses


### PR DESCRIPTION
When a request is re-submitted, it's useful to send that to job-server so it can differentiate between and inital submission (which creates and issue) and a re-submission (which updates an issue).