### PR TITLE
Disable CSV pagination

### DIFF
--- a/airlock/static/assets/file_browser/csv.js
+++ b/airlock/static/assets/file_browser/csv.js
@@ -1,11 +1,10 @@
 const observer = new MutationObserver((mutations, obs) => {
-  const pageNumberEl = document.querySelector(
-    `[data-table-pagination="page-number"]`
+  const sorterButton = document.querySelector(
+    "button.datatable-sorter"
   );
-  if (pageNumberEl.innerText !== "#") {
+  if (sorterButton) {
     document.querySelector("#csvtable p.spinner").style.display = "none";
     document.querySelector("#csvtable table.datatable").style.display = "table";
-    document.querySelector("#pagination-nav").classList.remove("hidden");
     obs.disconnect();
     return;
   }

--- a/airlock/templates/file_browser/csv.html
+++ b/airlock/templates/file_browser/csv.html
@@ -40,44 +40,6 @@
         </tbody>
       </table>
 
-      <nav id="pagination-nav" class="hidden flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3" aria-label="Pagination">
-        <div class="sm:block">
-          <p class="text-sm text-gray-700">
-            Page
-            <strong data-table-pagination="page-number">#</strong>
-            of
-            <strong data-table-pagination="total-pages">#</strong>
-          </p>
-        </div>
-        <div class="flex flex-1 justify-between gap-4 sm:justify-end">
-          <button
-            data-table-pagination="previous-page"
-            class="
-                   px-4 py-2 text-sm font-medium
-                   inline-flex items-center justify-center border rounded-md shadow-sm transition-buttons duration-200
-                   border border-slate-400/75 text-slate-700 !shadow-none
-                   hover:bg-slate-200
-                   focus:bg-slate-200 focus:ring-slate-500 focus:ring-offset-white
-                   hover:shadow-lg
-                   focus:outline-none focus:ring-2 focus:ring-offset-2"
-          >
-            Previous
-          </button>
-          <button
-            data-table-pagination="next-page"
-            class="
-                   px-4 py-2 text-sm font-medium
-                   inline-flex items-center justify-center border rounded-md shadow-sm transition-buttons duration-200
-                   border border-slate-400/75 text-slate-700 !shadow-none
-                   hover:bg-slate-200
-                   focus:bg-slate-200 focus:ring-slate-500 focus:ring-offset-white
-                   hover:shadow-lg
-                   focus:outline-none focus:ring-2 focus:ring-offset-2"
-          >
-            Next
-          </button>
-        </div>
-      </nav>
     </div>
 
     <script src="{% static 'assets/file_browser/csv.js' %}"></script>


### PR DESCRIPTION
Remove pagination, which doesn't affect load times since it was all being done on the frontend in datatables anyway.

JS updated to wait until an element of the loaded datatable is present before hiding the loading spinner (avoids displaying the unformatted table before the datatable has loaded).