### PR TITLE
Option to view any allowed file as plain text

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -113,10 +113,15 @@ class PathItem:
         suffix = "/" if (self.is_directory() and not url.endswith("/")) else ""
         return self.container.get_url(self.relpath) + suffix
 
-    def contents_url(self, download: bool = False):
+    def contents_url(self, download: bool = False, plaintext: bool = False):
         if self.type != PathType.FILE:
             raise Exception(f"contents_url called on non-file path {self.relpath}")
-        return self.container.get_contents_url(self.relpath, download=download)
+        return self.container.get_contents_url(
+            self.relpath, download=download, plaintext=plaintext
+        )
+
+    def contents_plaintext_url(self):
+        return self.contents_url(plaintext=True)
 
     def iframe_sandbox(self):
         # we allow csv files to use scripts, as we render those ourselves

--- a/airlock/renderers.py
+++ b/airlock/renderers.py
@@ -136,6 +136,10 @@ class TextRenderer(Renderer):
         }
 
 
+class PlainTextRenderer(TextRenderer):
+    template = RendererTemplate.from_name("file_browser/plaintext.html")
+
+
 class InvalidFileRenderer(Renderer):
     template = RendererTemplate.from_name("file_browser/text.html")
 
@@ -155,16 +159,18 @@ FILE_RENDERERS = {
 }
 
 
-def get_renderer(relpath: UrlPath) -> type[Renderer]:
+def get_renderer(relpath: UrlPath, plaintext=False) -> type[Renderer]:
     if is_valid_file_type(UrlPath(relpath)):
-        renderer_class = FILE_RENDERERS.get(relpath.suffix, Renderer)
-    else:
-        renderer_class = InvalidFileRenderer
-    return renderer_class
+        if plaintext:
+            return PlainTextRenderer
+        return FILE_RENDERERS.get(relpath.suffix, Renderer)
+    return InvalidFileRenderer
 
 
-def get_code_renderer(relpath: UrlPath) -> type[Renderer]:
+def get_code_renderer(relpath: UrlPath, plaintext=False) -> type[Renderer]:
     """Guess correct renderer for code file."""
+    if plaintext:
+        return PlainTextRenderer
 
     if relpath.suffix in FILE_RENDERERS:
         return FILE_RENDERERS[relpath.suffix]

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -113,6 +113,12 @@
               Open in new tab
             </a>
           </li>
+          <li class="more-dropdown__item">
+            <a href="{{ path_item.contents_plaintext_url }}" class="more-dropdown__link" id="plain-text-button" target="_blank" rel="noopener noreferrer">
+              <img class="more-dropdown__icon" src="/static/icons/open_in_new.svg" alt="">
+              Open as plain text
+            </a>
+          </li>
           {% if code_url %}
             <li class="more-dropdown__item">
               <a href="{{ code_url }}" class="more-dropdown__link" id="file-code-button" target="_blank" rel="noopener noreferrer">

--- a/airlock/templates/file_browser/plaintext.html
+++ b/airlock/templates/file_browser/plaintext.html
@@ -1,0 +1,2 @@
+<plaintext>
+  {{ text }}

--- a/airlock/views/code.py
+++ b/airlock/views/code.py
@@ -88,8 +88,9 @@ def contents(request, workspace_name: str, commit: str, path: str):
     workspace = get_workspace_or_raise(request.user, workspace_name)
     repo = get_repo_or_raise(workspace, commit)
 
+    plaintext = request.GET.get("plaintext", False)
     try:
-        renderer = repo.get_renderer(UrlPath(path))
+        renderer = repo.get_renderer(UrlPath(path), plaintext=plaintext)
     except bll.FileNotFound:
         raise Http404()
 

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -275,7 +275,8 @@ def request_contents(request, request_id: str, path: str):
         return download_file(abspath, filename=path)
 
     bll.audit_request_file_access(release_request, UrlPath(path), request.user)
-    renderer = release_request.get_renderer(UrlPath(path))
+    plaintext = request.GET.get("plaintext", False)
+    renderer = release_request.get_renderer(UrlPath(path), plaintext=plaintext)
     return serve_file(request, renderer)
 
 

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -157,7 +157,8 @@ def workspace_contents(request, workspace_name: str, path: str):
 
     bll.audit_workspace_file_access(workspace, UrlPath(path), request.user)
 
-    renderer = workspace.get_renderer(UrlPath(path))
+    plaintext = request.GET.get("plaintext", False)
+    renderer = workspace.get_renderer(UrlPath(path), plaintext=plaintext)
     return serve_file(request, renderer)
 
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -65,6 +65,13 @@ def test_workspace_container():
         "/workspaces/content/workspace/foo/bar.html?cache_id="
         in workspace.get_contents_url(UrlPath("foo/bar.html"))
     )
+    plaintext_contents_url = workspace.get_contents_url(
+        UrlPath("foo/bar.html"), plaintext=True
+    )
+    assert (
+        "/workspaces/content/workspace/foo/bar.html?cache_id=" in plaintext_contents_url
+    )
+    assert "&plaintext=true" in plaintext_contents_url
 
     assert workspace.request_filetype("path") is None
 
@@ -187,6 +194,12 @@ def test_request_container(mock_notifications):
         "/requests/content/id/group/bar.html?cache_id="
         in release_request.get_contents_url(UrlPath("group/bar.html"))
     )
+    plaintext_contents_url = release_request.get_contents_url(
+        UrlPath("group/bar.html"), plaintext=True
+    )
+    assert "/requests/content/id/group/bar.html?cache_id=" in plaintext_contents_url
+    assert "&plaintext=true" in plaintext_contents_url
+
     assert_no_notifications(mock_notifications)
 
 
@@ -256,6 +269,15 @@ def test_code_repo_container():
         f"/code/contents/workspace/{repo.commit}/project.yaml?cache_id="
         in repo.get_contents_url(UrlPath("project.yaml"))
     )
+
+    plaintext_contents_url = repo.get_contents_url(
+        UrlPath("project.yaml"), plaintext=True
+    )
+    assert (
+        f"/code/contents/workspace/{repo.commit}/project.yaml?cache_id="
+        in plaintext_contents_url
+    )
+    assert "&plaintext=true" in plaintext_contents_url
 
     assert repo.request_filetype("path") == RequestFileType.CODE
 


### PR DESCRIPTION
Fixes #408, which wasn't really a problem with CSV rendering, but a problem with the file that had been labelled as CSV. This will give users the option to view files in plain text, which should make badly formatted CSVs more readable without downloading.