### PR TITLE
Fix missing request.user information

### DIFF
--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -75,7 +75,7 @@ def request_view(request, request_id: str, path: str = ""):
         template = "file_browser/contents.html"
         selected_only = True
 
-    tree = get_request_tree(release_request, relpath, selected_only)
+    tree = get_request_tree(release_request, relpath, selected_only, user=request.user)
     path_item = get_path_item_from_tree_or_404(tree, relpath)
 
     is_directory_url = path.endswith("/") or relpath == ROOT_PATH


### PR DESCRIPTION
Missing `request.user` meant that the `user_approved` class was not being added to approved files in the tree.

This is blocking me from adding icons to show the correct state for a file in the tree.