### PR TITLE
Handle bad csvs

### DIFF
--- a/airlock/renderers.py
+++ b/airlock/renderers.py
@@ -122,7 +122,12 @@ class CSVRenderer(Renderer):
     def context(self):
         reader = csv.reader(self.stream)
         headers = next(reader, [])
-        return {"headers": headers, "rows": reader}
+        header_col_count = len(headers)
+        rows = list(reader)
+        ctx = {"headers": headers, "rows": rows, "use_datatables": True}
+        if any(len(row) != header_col_count for row in rows):
+            ctx["use_datatables"] = False
+        return ctx
 
 
 class TextRenderer(Renderer):

--- a/airlock/static/assets/file_browser/csv.js
+++ b/airlock/static/assets/file_browser/csv.js
@@ -6,6 +6,7 @@ const observer = new MutationObserver((mutations, obs) => {
     document.querySelector("#csvtable p.spinner").style.display = "none";
     document.querySelector("#csvtable table.datatable").style.display = "table";
     obs.disconnect();
+    clearTimeout();
     return;
   }
 });
@@ -14,3 +15,21 @@ observer.observe(document, {
   childList: true,
   subtree: true,
 });
+
+// If the datatable hasn't loaded within 5 seconds, it's likely something's gone
+// wrong; unhide the table to show the non-datatable table
+// Also hide the datatable sort icons as they'll be unformatted without the
+// datatable, and they won't work anyway
+setTimeout(() => {
+  const sorterButton = document.querySelector(
+    "button.datatable-sorter"
+  );
+  if (!sorterButton) {
+    document.querySelector("#csvtable p.spinner").style.display = "none";
+    document.querySelector("#csvtable table.datatable").style.display = "table";
+    const sortIcons = document.getElementsByClassName("sort-icon");
+    for (let i = 0; i < sortIcons.length; i++) {
+      sortIcons.item(i).style.display = "none";;
+    }
+  }
+}, 5000);

--- a/airlock/templates/file_browser/csv.html
+++ b/airlock/templates/file_browser/csv.html
@@ -15,35 +15,40 @@
   <body>
 
     <div id="csvtable">
-      <p id="contents-error" style="display: none">Could not load table data. Try opening the file as plain text.</p>
-      <p class="spinner">Loading table data...</p>
-      <table class="datatable" style="display: none" id="customTable">
-        <thead>
-          <tr>
-            {% for header in headers %}
-              <th>
-                <div class="flex flex-row gap-2">
-                  {{ header }}
+      {% if use_datatables %}
+        <p class="spinner">Loading table data...</p>
+        <table class="datatable" style="display: none" id="customTable">
+      {% else %}
+        <table>
+      {% endif %}
+      <thead>
+        <tr>
+          {% for header in headers %}
+            <th>
+              <div class="flex flex-row gap-2">
+                {{ header }}
+                {% if use_datatables %}
                   <span class="sort-icon">{% datatable_sort_icon %}</span>
-                </dir>
-              </th>
+                {% endif %}
+              </dir>
+            </th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for row in rows %}
+          <tr>
+            {% for cell in row %}
+              <td data-order="{{ cell }}">{{ cell }}</td>
             {% endfor %}
           </tr>
-        </thead>
-        <tbody>
-          {% for row in rows %}
-            <tr>
-              {% for cell in row %}
-                <td data-order="{{ cell }}">{{ cell }}</td>
-              {% endfor %}
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+        {% endfor %}
+      </tbody>
+    </table>
 
-    </div>
+  </div>
 
-    <script src="{% static 'assets/file_browser/csv.js' %}"></script>
-  </body>
+  <script src="{% static 'assets/file_browser/csv.js' %}"></script>
+</body>
 
 </html>

--- a/airlock/templates/file_browser/csv.html
+++ b/airlock/templates/file_browser/csv.html
@@ -15,6 +15,7 @@
   <body>
 
     <div id="csvtable">
+      <p id="contents-error" style="display: none">Could not load table data. Try opening the file as plain text.</p>
       <p class="spinner">Loading table data...</p>
       <table class="datatable" style="display: none" id="customTable">
         <thead>
@@ -23,7 +24,7 @@
               <th>
                 <div class="flex flex-row gap-2">
                   {{ header }}
-                  {% datatable_sort_icon %}
+                  <span class="sort-icon">{% datatable_sort_icon %}</span>
                 </dir>
               </th>
             {% endfor %}

--- a/airlock/templates/file_browser/plaintext.html
+++ b/airlock/templates/file_browser/plaintext.html
@@ -1,2 +1,1 @@
-<plaintext>
-  {{ text }}
+<plaintext>{{ text }}

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -117,3 +117,17 @@ def test_csv_renderer_handles_empty_file(tmp_path):
     response = renderer.get_response()
     response.render()
     assert response.status_code == 200
+
+
+def test_csv_renderer_handles_uneven_columns(tmp_path):
+    # CSVs without the equal numbers of columns per row
+    # can be rendered in a plain html table, but not with datatables
+    bad_csv = tmp_path / "empty.csv"
+    bad_csv.write_text("Foo Bar\nfoo,bar")
+    relpath = bad_csv.relative_to(tmp_path)
+    Renderer = renderers.get_renderer(relpath)
+    renderer = Renderer.from_file(bad_csv, relpath)
+    response = renderer.get_response()
+    response.render()
+    assert response.status_code == 200
+    assert response.context_data["use_datatables"] is False


### PR DESCRIPTION
Fixes #416

simple-datatables can only render tables with equal numbers of columns in each row. If a CSV output file has different columns per row (usually because it's not proper tabulated data), the datatable will fail to initialised. This was resulting in the page appearing to hang on the "loading ..." message.

This is addressed in a couple of ways:
1) Adds a `setTimeout` in the JS which waits for 5 seconds, and if the datatable element hasn't been found by then, it just unhides the table element anyway (which will show the plain html table if datatables failed to load).
2) Checks the column counts per row in the CSV renderer, and stops datatables being used at all if the counts aren't the same (which avoids having to wait 5 seconds when we know there's going to be a problem).

This does mean that we're assuming all tables will take at most 5s to load, and we're reading all CSV rows in in the renderer. Given that we've now got a 5000 row limit on L4 CSV files, this shouldn't cause any problems. 