### PR TITLE
Add confirmation modal before first submission

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -16,10 +16,43 @@
     {% #airlock_header context=context release_request=release_request title=title workspace=workspace %}
       {% if is_author %}
         {% if release_request.status_owner.name == "AUTHOR" %}
-          <form action="{{ request_submit_url }}" method="POST">
-            {% csrf_token %}
-            {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}Submit for review{% /button %}
-          </form>
+          {% if release_request.status.name == "PENDING" %}
+            {% comment %} Initial submission requires confirmation modal {% endcomment %}
+            {% #modal id="submitRequest" button_text="Submit for review" button_variant="success" %}
+              {% #card container=True title="Submit this request for review" %}
+                <form action="{{ request_submit_url }}" method="POST">
+                  {% csrf_token %}
+
+                  <div class="pb-8">
+                    Please confirm that you have read the OpenSAFELY
+                    documentation on data release. In particular note that:
+                    <blockquote style="margin-left: 1rem; margin-top: 1rem">
+                      <p>
+                        All outputs from the NHS England OpenSAFELY COVID-19 service must be
+                        aggregated data with small number suppression applied. The service operates as
+                        a trusted research platform where no patient record level data is permitted to
+                        be extracted from the platform. You MUST NOT request the release of any
+                        information (e.g. name, listsize) that identifies, or could identify, ICBs,
+                        Local Authorities (including MSOA identifiers), Primary Care Networks (PCNs)
+                        and individual GP practices from the Level 4 results server. Please confirm and
+                        that your results are in line with this policy.
+                      </p>
+                    </blockquote>
+                  </div>
+                  {% #button type="submit" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}
+                    I confirm I have read the documentation
+                  {% /button %}
+                  {% #button variant="primary" class="action-button btn-sm" type="cancel" %}Cancel{% /button %}
+                </form>
+              {% /card %}
+            {% /modal %}
+          {% else %}
+            {% comment %} Subsequent re-submission requires just a button press {% endcomment %}
+            <form action="{{ request_submit_url }}" method="POST">
+              {% csrf_token %}
+              {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}Submit for review{% /button %}
+            </form>
+          {% endif %}
           {% #modal id="withdrawRequest" button_text="Withdraw this request" button_variant="warning" %}
             {% #card container=True title="Withdraw this request" %}
               <form action="{{ request_withdraw_url }}" method="POST">

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -20,7 +20,7 @@
             {% csrf_token %}
             {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}Submit for review{% /button %}
           </form>
-          {% #modal id="withdrawRequest" button_text="Withdraw this request" variant="warning" %}
+          {% #modal id="withdrawRequest" button_text="Withdraw this request" button_variant="warning" %}
             {% #card container=True title="Withdraw this request" %}
               <form action="{{ request_withdraw_url }}" method="POST">
                 {% csrf_token %}

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -307,8 +307,10 @@ def test_e2e_release_files(
     )
 
     # Submit request
-    submit_button = page.locator("#submit-for-review-button")
+    submit_button = page.locator("button[data-modal=submitRequest]")
     find_and_click(submit_button)
+    confirm_button = page.locator("#submit-for-review-button")
+    find_and_click(confirm_button)
     expect(page.locator("body")).to_contain_text("SUBMITTED")
     # After the request is submitted, the submit button is no longer visible
     expect(submit_button).not_to_be_visible()


### PR DESCRIPTION
Adds a modal before a request is first submitted (but not when it is resubmitted) which asks the user to confirm that they have read the documentation and will abide by the relevant principles.

Subsequent PRs will add a form to capture more information at this step.

Relates to #403

![Screenshot from 2024-06-27 17-32-53](https://github.com/opensafely-core/airlock/assets/19630/c2cd2f47-aa87-4b8c-a896-0ca9307e8051)

