### PR TITLE
Fix bug logging job-server errors

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1607,7 +1607,10 @@ class BusinessLogicLayer:
 
         filelist = old_api.create_filelist(file_paths, release_request)
         jobserver_release_id = old_api.create_release(
-            release_request.workspace, filelist.json(), user.username
+            release_request.workspace,
+            release_request.id,
+            filelist.json(),
+            user.username,
         )
 
         for relpath, abspath in file_paths:

--- a/old_api/__init__.py
+++ b/old_api/__init__.py
@@ -38,7 +38,7 @@ def create_filelist(paths, release_request):
     )
 
 
-def create_release(workspace_name, release_json, username):
+def create_release(workspace_name, release_request_id, release_json, username):
     """API call to job server to create a release."""
     response = session.post(
         url=f"{settings.AIRLOCK_API_ENDPOINT}/releases/workspace/{workspace_name}",
@@ -55,7 +55,7 @@ def create_release(workspace_name, release_json, username):
         logger.error(
             "%s Error creating release - %s - %s",
             response.status_code,
-            release_json["airlock_id"],
+            release_request_id,
             response.content.decode(),
         )
 

--- a/tests/integration/test_old_api.py
+++ b/tests/integration/test_old_api.py
@@ -20,7 +20,7 @@ def test_old_api_create_release(responses):
 
     assert (
         old_api.create_release(
-            "workspace_name", {"airlock_id": "jobserver-id"}, "testuser"
+            "workspace_name", "jobserver-id", {"airlock_id": "jobserver-id"}, "testuser"
         )
         == "jobserver-id"
     )
@@ -39,7 +39,7 @@ def test_old_api_create_release_with_error(responses, caplog):
     )
     with pytest.raises(requests.exceptions.HTTPError):
         old_api.create_release(
-            "workspace_name", {"airlock_id": "jobserver-id"}, "testuser"
+            "workspace_name", "jobserver-id", {"airlock_id": "jobserver-id"}, "testuser"
         )
     assert len(caplog.messages) == 1
     log = caplog.messages[0]

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -402,7 +402,7 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
     }
 
     old_api.create_release.assert_called_once_with(
-        "workspace", json.dumps(expected_json), checker.username
+        "workspace", "request_id", json.dumps(expected_json), checker.username
     )
     old_api.upload_file.assert_called_once_with(
         "jobserver_id", relpath, abspath, checker.username


### PR DESCRIPTION
Pass the request id to `old_api.create_release` so that we can log it. Avoids having to retrieve the request id from the `release_json`, which could be incorrect.

fixes #426