### PR TITLE
Remove hx attributes from return button

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -45,7 +45,7 @@
               {% csrf_token %}
               {% #button type="submit" variant="danger" class="action-button btn-sm" id="reject-request-button" %}Reject request{% /button %}
             </form>
-            <form action="{{ request_return_url }}" method="POST" hx-post="{{ request_return_url }}" hx-disabled-elt="button">
+            <form action="{{ request_return_url }}" method="POST">
               {% csrf_token %}
               {% #button type="submit" class="btn-sm" tooltip="Return request for changes/clarification" variant="secondary" id="return-request-button" %}Return request{% /button %}
             </form>

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -227,7 +227,7 @@ def test_request_returnable(
     if can_return:
         expect(return_request_button).to_be_enabled()
         return_request_button.click()
-        expect(return_request_button).to_be_disabled()
+        expect(return_request_button).not_to_be_visible()
     elif login_as == "author":
         expect(return_request_button).not_to_be_visible()
     else:


### PR DESCRIPTION
The return request isn't an htmx one, so these attributes - probably a copy/paste error - were causing it to load the response into the button element.