### PR TITLE
Use context var rather than removed method

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -113,7 +113,7 @@
           {% if release_request.status.name %}
             data-request-status="{{ release_request.status.name }}"
           {% endif %}
-          {% if release_request.all_files_reviewed %}
+          {% if user_has_reviewed_all_files %}
             data-all-files-reviewed="true"
           {% endif %}
           {% if release_request.all_files_approved %}


### PR DESCRIPTION
The method was removed here:
https://github.com/opensafely-core/airlock/commit/8be977883a16afd8

But the template code which used it was added in a separate PR here:
https://github.com/opensafely-core/airlock/commit/88eb7d5537a4b49d

So while each PR's tests passed, their merge didn't.