### PR TITLE
Only show the complete-review reminder where there are files to review

### DIFF
--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -157,12 +157,17 @@ def request_view(request, request_id: str, path: str = ""):
             request=release_request.id, group=group, exclude_readonly=True, size=20
         )
 
-    user_has_completed_review = (
-        request.user.username in release_request.completed_reviews
-    )
-    user_has_reviewed_all_files = release_request.all_files_reviewed_by_reviewer(
-        request.user
-    )
+    if not is_author:
+        user_has_completed_review = (
+            request.user.username in release_request.completed_reviews
+        )
+        user_has_reviewed_all_files = (
+            release_request.output_files()
+            and release_request.all_files_reviewed_by_reviewer(request.user)
+        )
+    else:
+        user_has_completed_review = False
+        user_has_reviewed_all_files = False
 
     if user_has_reviewed_all_files and not user_has_completed_review:
         messages.success(


### PR DESCRIPTION
If there are no output files on a request, there's nothing to be reviewed. The method for all_files_reviewed_for_user returns True, but we don't want to remind users to complete their review when there was nothing to review.

We also don't want to show this to authors at all.