### PR TITLE
Update definition of active requests and prevent adding/withdrawing in submitted status

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1459,11 +1459,7 @@ class BusinessLogicLayer:
                 f"only author {release_request.author} can modify the files in this request"
             )
 
-        if release_request.status not in [
-            RequestStatus.PENDING,
-            RequestStatus.SUBMITTED,
-            RequestStatus.RETURNED,
-        ]:
+        if release_request.status_owner() != RequestStatusOwner.AUTHOR:
             raise self.RequestPermissionDenied(
                 f"cannot modify files in request that is in state {release_request.status.name}"
             )

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1567,8 +1567,8 @@ class BusinessLogicLayer:
                 relpath=relpath,
                 audit=audit,
             )
-        elif release_request.status == RequestStatus.SUBMITTED:
-            # the request has been submitted, set the file type to WITHDRAWN
+        elif release_request.status == RequestStatus.RETURNED:
+            # the request has been returned, set the file type to WITHDRAWN
             filegroup_data = self._dal.withdraw_file_from_request(
                 request_id=release_request.id,
                 relpath=relpath,

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1311,9 +1311,6 @@ class BusinessLogicLayer:
         RequestStatus.APPROVED: [
             RequestStatus.RELEASED,
         ],
-        RequestStatus.REJECTED: [
-            RequestStatus.APPROVED,  # allow mind changed
-        ],
     }
 
     # The following lists should a) include every status and b) be disjoint

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -16,6 +16,7 @@ from airlock.business_logic import (
     ROOT_PATH,
     RequestFileType,
     RequestStatus,
+    RequestStatusOwner,
     UserFileReviewStatus,
     bll,
 )
@@ -88,14 +89,21 @@ def request_view(request, request_id: str, path: str = ""):
     if "is_author" in request.GET:  # pragma: nocover
         is_author = request.GET["is_author"].lower() == "true"
 
-    if is_directory_url or release_request.status == RequestStatus.WITHDRAWN:
-        file_withdraw_url = None
-        code_url = None
-    else:
+    file_withdraw_url = None
+    code_url = None
+
+    if (
+        release_request.status_owner() == RequestStatusOwner.AUTHOR
+        and not is_directory_url
+    ):
+        # A file can only be withdrawn from a request that is currently
+        # editable by the author
         file_withdraw_url = reverse(
             "file_withdraw",
             kwargs={"request_id": request_id, "path": path},
         )
+
+    if not is_directory_url:
         code_url = (
             reverse(
                 "code_view",

--- a/docs/request-states.md
+++ b/docs/request-states.md
@@ -16,6 +16,5 @@ stateDiagram-v2
     RETURNED --> SUBMITTED
     RETURNED --> WITHDRAWN
     APPROVED --> RELEASED
-    REJECTED --> APPROVED
 ```
 

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -218,9 +218,9 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
         audit: AuditEvent,
     ):
         with transaction.atomic():
-            # defense in depth, we can only withdraw from active submitted requests
+            # defense in depth, we can only withdraw from active returned requests
             request = self._find_metadata(request_id)
-            assert request.status == RequestStatus.SUBMITTED
+            assert request.status == RequestStatus.RETURNED
 
             try:
                 request_file = RequestFileMetadata.objects.get(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -10,7 +10,7 @@ from playwright.sync_api import expect
 from tests import factories
 
 
-expect.set_options(timeout=10_000)
+expect.set_options(timeout=15_000)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/functional/test_code_pages.py
+++ b/tests/functional/test_code_pages.py
@@ -13,13 +13,15 @@ def release_request(researcher_user):
     factories.write_workspace_file(workspace, "foo.txt", "")
     factories.create_repo(workspace)
     release_request = factories.create_request_at_status(
-        workspace, author=researcher_user, status=RequestStatus.SUBMITTED
-    )
-    # Ensure the request file is written using the workspace previously
-    # created (so it's assigned the correct commit from the manifest.json associated
-    # with that workspace)
-    factories.write_request_file(
-        release_request, "group", "foo.txt", workspace=workspace
+        workspace,
+        author=researcher_user,
+        status=RequestStatus.SUBMITTED,
+        # Ensure the request file is written using the workspace previously
+        # created (so it's assigned the correct commit from the manifest.json associated
+        # with that workspace)
+        files=[
+            factories.request_file(group="group", path="foo.txt", workspace=workspace)
+        ],
     )
     yield release_request
 

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -46,10 +46,7 @@ def test_request_file_withdraw(live_server, context, page, bll):
     file2_locator.click()
 
     expect(file2_locator).not_to_have_class("withdrawn")
-
-    page.locator("#withdraw-file-button").click()
-
-    expect(file2_locator).to_have_class(re.compile("withdrawn"))
+    expect(page.locator("#withdraw-file-button")).not_to_be_visible()
 
 
 def test_request_group_edit_comment(live_server, context, page, bll, settings):

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 from playwright.sync_api import expect
 
@@ -44,8 +42,6 @@ def test_request_file_withdraw(live_server, context, page, bll):
 
     file2_locator = page.locator("#tree").get_by_role("link", name="file2.txt")
     file2_locator.click()
-
-    expect(file2_locator).not_to_have_class("withdrawn")
     expect(page.locator("#withdraw-file-button")).not_to_be_visible()
 
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -1039,6 +1039,26 @@ def test_file_withdraw_file_submitted(airlock_client):
         f"/requests/withdraw/{release_request.id}/group/path/test.txt",
         follow=True,
     )
+    assert response.status_code == 403
+
+
+def test_file_withdraw_file_returned(airlock_client):
+    airlock_client.login("author", ["test1"], False)
+    release_request = factories.create_request_at_status(
+        "test1",
+        author=airlock_client.user,
+        status=RequestStatus.RETURNED,
+        files=[
+            factories.request_file("group", "path/test.txt", rejected=True),
+        ],
+    )
+    # ensure it does exist
+    release_request.get_request_file_from_urlpath("group/path/test.txt")
+
+    response = airlock_client.post(
+        f"/requests/withdraw/{release_request.id}/group/path/test.txt",
+        follow=True,
+    )
     # ensure template is rendered to force template coverage
     response.render()
     assert response.status_code == 200

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -839,7 +839,7 @@ def test_provider_get_current_request_for_user_output_checker(bll):
         (RequestStatus.REJECTED, RequestStatus.SUBMITTED, False, False, None),
         (RequestStatus.REJECTED, RequestStatus.PARTIALLY_REVIEWED, False, False, None),
         (RequestStatus.REJECTED, RequestStatus.REVIEWED, False, False, None),
-        (RequestStatus.REJECTED, RequestStatus.APPROVED, False, True, None),
+        (RequestStatus.REJECTED, RequestStatus.APPROVED, False, False, None),
         (RequestStatus.REJECTED, RequestStatus.WITHDRAWN, False, False, None),
         (RequestStatus.RELEASED, RequestStatus.PENDING, False, False, None),
         (RequestStatus.RELEASED, RequestStatus.SUBMITTED, False, False, None),
@@ -1050,7 +1050,6 @@ def test_request_status_ownership(bll):
             "request_withdrawn",
         ),
         (RequestStatus.APPROVED, RequestStatus.RELEASED, "checker", "request_released"),
-        (RequestStatus.REJECTED, RequestStatus.APPROVED, "checker", "request_approved"),
     ],
 )
 def test_set_status_notifications(


### PR DESCRIPTION
Fixes #424 

- Update the definition of active request to include all author and reviewer owned statuses
- Hide withdraw file button if request is not author-editable
- Update BLL and DAL so that adding and withdrawing files are only allowed in author-owned statuses
- Remove state transition from REJECTED to APPROVED