### PR TITLE
Only show "add file(s)" buttons when a request is in pending or returned statuses

### DIFF
--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -24,12 +24,22 @@
 {% fragment as buttons %}
   {% if context == "workspace" %}
     {% if path_item.children %}
-      <div class="div flex flex-col items-start gap-4">
-        <div class="flex items-center gap-2">
-          {% #button type="submit" name="action" value="add_files" variant="success" form="multiselect_form"%}Add Files to Request{% /button %}
+      {% if multiselect_add %}
+        <div class="div flex flex-col items-start gap-4">
+          <div class="flex items-center gap-2">
+            {% #button type="submit" name="action" value="add_files" variant="success" form="multiselect_form"%}Add Files to Request{% /button %}
+          </div>
+          <div id="multiselect_modal"></div>
         </div>
-        <div id="multiselect_modal"></div>
-      </div>
+      {% elif current_request and current_request.status_owner != "AUTHOR"  %}
+        {% #button type="button" disabled=True tooltip="The current request is under review and cannot be modified." id="add-file-modal-button-disabled" %}
+          Add Files to Request
+        {% /button %}
+      {% else %}
+        {% #button type="button" disabled=True tooltip="You do not have permission to add files to a request" id="add-file-modal-button-disabled" %}
+          Add Files to Request
+        {% /button %}
+      {% endif %}
     {% endif %}
   {% endif %}
 {% endfragment %}

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -22,6 +22,10 @@
         {% #button type="button" disabled=True tooltip="This file type cannot be added to a request" id="add-file-modal-button-disabled" %}
           Add File to Request
         {% /button %}
+      {% elif current_request and current_request.status_owner != "AUTHOR" %}
+        {% #button type="button" disabled=True tooltip="The current request is under review and cannot be modified." id="add-file-modal-button-disabled" %}
+          Add File to Request
+        {% /button %}
       {% else %}
         {% #button type="button" disabled=True tooltip="You do not have permission to add this file to a request" id="add-file-modal-button-disabled" %}
           Add File to Request


### PR DESCRIPTION
Fixes #438 

A file can only be added from a workspace with a current request if that request is in pending or returned status (i.e. author-editable ones). We already have appropriate checks and error messages if a file can't be added due to request status, but this disables the button.

Also adds similar checks for the "add files" multiselect and disables it if there is an active request in non-editable status. It doesn't check there are add-able files, since the modal already shows the file state for each selected file.

![image](https://github.com/opensafely-core/airlock/assets/6770950/9be1b76a-1307-48fe-9519-6f01c00ec293)
