### PR TITLE
Add a small guard rail

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -289,6 +289,10 @@ def create_request_at_status(
         assert (
             withdrawn_after is not None
         ), "pass withdrawn_after to decide when to withdraw"
+        assert withdrawn_after in [
+            RequestStatus.PENDING,
+            RequestStatus.RETURNED,
+        ], f"Invalid state transition with withdrawn_after {withdrawn_after}"
 
     # Get a default checker if one was not provided
     # This is the checker who does the state transitions (approved/released/returned/rejected)


### PR DESCRIPTION
If you call `create_request_at_status` with status `WITHDRAWN` and `withdrawn_after` as an invalid value (in my case `SUBMITTED`), you currently don't get an error, you get a valid request in the withdrawn_after status (i.e. `SUBMITTED`), which can lead to misleading failures in the tests you're working on. 

We could also put a bunch of `bll.set_status()` calls in the relevant places to trigger the actual Exceptions for this stuff, but this is shorter (& I think it only applies to WITHDRAWN). 

