### PR TITLE
Hide multiselect checkbox for directories

### DIFF
--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -90,7 +90,11 @@
               {% endif %}
               <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
               <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
-              <td>{% form_checkbox name="selected" value=path.relpath custom_field=True %}</td>
+              <td>
+                {% if not path.is_directory %}
+                  {% form_checkbox name="selected" value=path.relpath custom_field=True %}
+                {% endif %}
+              </td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
* fix #440 

<img width="949" alt="Screenshot 2024-07-05 at 16 06 49" src="https://github.com/opensafely-core/airlock/assets/2082895/0b4b0544-7339-4fe3-b908-9e73d4067449">
