### PR TITLE
Restrict actions on archived workspaces and inactive projects

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -344,6 +344,10 @@ class Workspace:
     def is_archived(self):
         return self.metadata.get("archived")
 
+    # helpers for templates
+    def is_active(self):
+        return self.project().is_ongoing and not self.is_archived()
+
     def display_name(self):
         # helper for templates
         if self.is_archived():

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -282,7 +282,7 @@ class Workspace:
 
     name: str
     manifest: dict[str, Any]
-    metadata: dict[str, str]
+    metadata: dict[str, Any]
     current_request: ReleaseRequest | None
 
     @classmethod
@@ -324,6 +324,9 @@ class Workspace:
 
     def project(self):
         return self.metadata.get("project_details", {})
+
+    def is_archived(self):
+        return self.metadata.get("archived")
 
     def root(self):
         return settings.WORKSPACE_DIR / self.name
@@ -1118,6 +1121,20 @@ class BusinessLogicLayer:
         # empty metadata instance.
         # Currently, the only place this metadata is used is in the workspace
         # index, to group by project, so its mostly fine that its not here.
+        #
+        # Metadata also contains information about whether the workspace is
+        # archived, and whether the project is ongoing (note that a project
+        # could be completed/closed and a workspace not archived, so we need
+        # to check for both of these states);
+        # The metadata is extracted as an attribute on the workspace. It is
+        # used in the workspace index, to show/group
+        # workspaces by project and project ongoing status, and within that,
+        # by archived status. It is also used to prevent release
+        # requests being created for archived workspaces or for not-ongoing projects.
+        #
+        # It will be None for output checkers who don't have explicit access to
+        # the workspace; this is OK as they also won't be able to create requests
+        # for the workspace, and they only have access to browse the files.
         metadata = user.workspaces.get(name, {})
 
         return Workspace.from_directory(

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -272,6 +272,18 @@ class AirlockContainer(Protocol):
         """Get user's request status of file."""
 
 
+@dataclass(frozen=True)
+class Project:
+    name: str
+    is_ongoing: bool
+
+    def display_name(self):
+        # helper for templates
+        if not self.is_ongoing:
+            return f"{self.name} (INACTIVE)"
+        return self.name
+
+
 @dataclass(order=True)
 class Workspace:
     """Simple wrapper around a workspace directory on disk.
@@ -322,11 +334,21 @@ class Workspace:
     def __str__(self):
         return self.get_id()
 
-    def project(self):
-        return self.metadata.get("project_details", {})
+    def project(self) -> Project:
+        details = self.metadata.get("project_details", {})
+        return Project(
+            name=details.get("name", "Unknown project"),
+            is_ongoing=details.get("ongoing", True),
+        )
 
     def is_archived(self):
         return self.metadata.get("archived")
+
+    def display_name(self):
+        # helper for templates
+        if self.is_archived():
+            return f"{self.name} (ARCHIVED)"
+        return self.name
 
     def root(self):
         return settings.WORKSPACE_DIR / self.name

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -323,7 +323,7 @@ class Workspace:
         return self.get_id()
 
     def project(self):
-        return self.metadata.get("project", None)
+        return self.metadata.get("project_details", {})
 
     def root(self):
         return settings.WORKSPACE_DIR / self.name

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -22,7 +22,7 @@
 
 
 {% fragment as buttons %}
-  {% if context == "workspace" %}
+  {% if context == "workspace" and workspace.is_active %}
     {% if path_item.children %}
       {% if multiselect_add %}
         <div class="div flex flex-col items-start gap-4">
@@ -76,9 +76,11 @@
             <th>
               <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
             </th>
-            <th data-searchable="false" data-sortable="false">
-              <input class="selectall" type="checkbox" onchange="toggleSelectAll(this)" />
-            </th>
+            {% if context == "workspace" and workspace.is_active %}
+              <th data-searchable="false" data-sortable="false">
+                <input class="selectall" type="checkbox" onchange="toggleSelectAll(this)" />
+              </th>
+            {% endif %}
           </tr>
         {% /table_head %}
         <tbody>
@@ -90,11 +92,13 @@
               {% endif %}
               <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
               <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
-              <td>
-                {% if not path.is_directory %}
-                  {% form_checkbox name="selected" value=path.relpath custom_field=True %}
-                {% endif %}
-              </td>
+              {% if context == "workspace" and workspace.is_active %}
+                <td>
+                  {% if not path.is_directory %}
+                    {% form_checkbox name="selected" value=path.relpath custom_field=True %}
+                  {% endif %}
+                </td>
+              {% endif %}
             </tr>
           {% endfor %}
         </tbody>

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -1,6 +1,6 @@
 {% fragment as buttons %}
   <div class="flex items-center gap-2">
-    {% if context == "workspace" %}
+    {% if context == "workspace" and workspace.is_active %}
       {% if add_file %}
         <form
           method="POST"
@@ -31,7 +31,7 @@
           Add File to Request
         {% /button %}
       {% endif %}
-    {% else %}{# request #}
+    {% elif context == "request" %}
       {% if path_item.is_supporting %}
         <span class="file-status file-status--supporting relative group cursor-pointer">
           <span class="file-status__icon"></span>
@@ -47,12 +47,14 @@
       {% endif %}
 
       {% if is_author %}
-        {% if path_item.is_output and file_withdraw_url %}
-          <form action="{{ file_withdraw_url }}" method="POST">
-            {% csrf_token %}
-            <input type=hidden name="path" value="{{ path_item.relpath }}"/>
-            {% #button type="submit" id="withdraw-file-button" tooltip="Withdraw this file from this request" variant="warning" %}Withdraw from Request{% /button %}
-          </form>
+        {% if workspace.is_active %}
+          {% if path_item.is_output and file_withdraw_url %}
+            <form action="{{ file_withdraw_url }}" method="POST">
+              {% csrf_token %}
+              <input type=hidden name="path" value="{{ path_item.relpath }}"/>
+              {% #button type="submit" id="withdraw-file-button" tooltip="Withdraw this file from this request" variant="warning" %}Withdraw from Request{% /button %}
+            </form>
+          {% endif %}
         {% endif %}
       {% elif is_output_checker %}
         {% if path_item.is_output %}

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -14,116 +14,118 @@
 {% block content %}
   {% if context == "request" %}
     {% #airlock_header context=context release_request=release_request title=title workspace=workspace %}
-      {% if is_author %}
-        {% if release_request.status_owner.name == "AUTHOR" %}
-          {% if release_request.status.name == "PENDING" %}
-            {% comment %} Initial submission requires confirmation modal {% endcomment %}
-            {% #modal id="submitRequest" button_text="Submit for review" button_variant="success" %}
-              {% #card container=True title="Submit this request for review" %}
-                <form action="{{ request_submit_url }}" method="POST">
+      {% if workspace.is_active %}
+        {% if is_author %}
+          {% if release_request.status_owner.name == "AUTHOR" %}
+            {% if release_request.status.name == "PENDING" %}
+              {% comment %} Initial submission requires confirmation modal {% endcomment %}
+              {% #modal id="submitRequest" button_text="Submit for review" button_variant="success" %}
+                {% #card container=True title="Submit this request for review" %}
+                  <form action="{{ request_submit_url }}" method="POST">
+                    {% csrf_token %}
+
+                    <div class="pb-8">
+                      Please confirm that you have read the OpenSAFELY
+                      documentation on data release. In particular note that:
+                      <blockquote style="margin-left: 1rem; margin-top: 1rem">
+                        <p>
+                          All outputs from the NHS England OpenSAFELY COVID-19 service must be
+                          aggregated data with small number suppression applied. The service operates as
+                          a trusted research platform where no patient record level data is permitted to
+                          be extracted from the platform. You MUST NOT request the release of any
+                          information (e.g. name, listsize) that identifies, or could identify, ICBs,
+                          Local Authorities (including MSOA identifiers), Primary Care Networks (PCNs)
+                          and individual GP practices from the Level 4 results server. Please confirm and
+                          that your results are in line with this policy.
+                        </p>
+                      </blockquote>
+                    </div>
+                    {% #button type="submit" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}
+                      I confirm I have read the documentation
+                    {% /button %}
+                    {% #button variant="primary" class="action-button btn-sm" type="cancel" %}Cancel{% /button %}
+                  </form>
+                {% /card %}
+              {% /modal %}
+            {% else %}
+              {% comment %} Subsequent re-submission requires just a button press {% endcomment %}
+              <form action="{{ request_submit_url }}" method="POST">
+                {% csrf_token %}
+                {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}Submit for review{% /button %}
+              </form>
+            {% endif %}
+            {% #modal id="withdrawRequest" button_text="Withdraw this request" button_variant="warning" %}
+              {% #card container=True title="Withdraw this request" %}
+                <form action="{{ request_withdraw_url }}" method="POST">
                   {% csrf_token %}
 
                   <div class="pb-8">
-                    Please confirm that you have read the OpenSAFELY
-                    documentation on data release. In particular note that:
-                    <blockquote style="margin-left: 1rem; margin-top: 1rem">
-                      <p>
-                        All outputs from the NHS England OpenSAFELY COVID-19 service must be
-                        aggregated data with small number suppression applied. The service operates as
-                        a trusted research platform where no patient record level data is permitted to
-                        be extracted from the platform. You MUST NOT request the release of any
-                        information (e.g. name, listsize) that identifies, or could identify, ICBs,
-                        Local Authorities (including MSOA identifiers), Primary Care Networks (PCNs)
-                        and individual GP practices from the Level 4 results server. Please confirm and
-                        that your results are in line with this policy.
-                      </p>
-                    </blockquote>
+                    This will withdraw the entire request.
+                    Once a request is withdrawn, it cannot be resubmitted and must be
+                    recreated from scratch.
+                    Please confirm you wish to withdraw this request.
                   </div>
-                  {% #button type="submit" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}
-                    I confirm I have read the documentation
-                  {% /button %}
-                  {% #button variant="primary" class="action-button btn-sm" type="cancel" %}Cancel{% /button %}
+                  {% #button type="submit" variant="danger" class="action-button btn-sm" id="withdraw-request-confirm" %}Withdraw{% /button %}
+                  {% #button variant="primary" type="cancel" %}Cancel{% /button %}
                 </form>
               {% /card %}
             {% /modal %}
-          {% else %}
-            {% comment %} Subsequent re-submission requires just a button press {% endcomment %}
-            <form action="{{ request_submit_url }}" method="POST">
-              {% csrf_token %}
-              {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button btn-sm" id="submit-for-review-button" %}Submit for review{% /button %}
-            </form>
           {% endif %}
-          {% #modal id="withdrawRequest" button_text="Withdraw this request" button_variant="warning" %}
-            {% #card container=True title="Withdraw this request" %}
-              <form action="{{ request_withdraw_url }}" method="POST">
+        {% elif is_output_checker %}
+          {% if release_request.status_owner.name == "REVIEWER" %}
+            {% comment %} A fully reviewed request can be returned or rejected {% endcomment %}
+            {% if release_request.status.name == "REVIEWED" %}
+              <form action="{{ request_reject_url }}" method="POST">
                 {% csrf_token %}
-
-                <div class="pb-8">
-                  This will withdraw the entire request.
-                  Once a request is withdrawn, it cannot be resubmitted and must be
-                  recreated from scratch.
-                  Please confirm you wish to withdraw this request.
-                </div>
-                {% #button type="submit" variant="danger" class="action-button btn-sm" id="withdraw-request-confirm" %}Withdraw{% /button %}
-                {% #button variant="primary" type="cancel" %}Cancel{% /button %}
+                {% #button type="submit" variant="danger" class="action-button btn-sm" id="reject-request-button" %}Reject request{% /button %}
               </form>
-            {% /card %}
-          {% /modal %}
-        {% endif %}
-      {% elif is_output_checker %}
-        {% if release_request.status_owner.name == "REVIEWER" %}
-          {% comment %} A fully reviewed request can be returned or rejected {% endcomment %}
-          {% if release_request.status.name == "REVIEWED" %}
-            <form action="{{ request_reject_url }}" method="POST">
-              {% csrf_token %}
-              {% #button type="submit" variant="danger" class="action-button btn-sm" id="reject-request-button" %}Reject request{% /button %}
-            </form>
-            <form action="{{ request_return_url }}" method="POST">
-              {% csrf_token %}
-              {% #button type="submit" class="btn-sm" tooltip="Return request for changes/clarification" variant="secondary" id="return-request-button" %}Return request{% /button %}
-            </form>
-          {% else %}
-            {% #button disabled=True class="relative group btn-sm" variant="danger" id="reject-request-button" %}
-              Reject request
-              {% tooltip class="airlock-tooltip" content="Rejecting a request is disabled until review has been completed by two reviewers" %}
-            {% /button %}
-            {% #button disabled=True class="relative group btn-sm" variant="secondary" id="return-request-button" %}
-              Return request
-              {% tooltip class="airlock-tooltip" content="Returning a request is disabled until review has been completed by two reviewers" %}
-            {% /button %}
+              <form action="{{ request_return_url }}" method="POST">
+                {% csrf_token %}
+                {% #button type="submit" class="btn-sm" tooltip="Return request for changes/clarification" variant="secondary" id="return-request-button" %}Return request{% /button %}
+              </form>
+            {% else %}
+              {% #button disabled=True class="relative group btn-sm" variant="danger" id="reject-request-button" %}
+                Reject request
+                {% tooltip class="airlock-tooltip" content="Rejecting a request is disabled until review has been completed by two reviewers" %}
+              {% /button %}
+              {% #button disabled=True class="relative group btn-sm" variant="secondary" id="return-request-button" %}
+                Return request
+                {% tooltip class="airlock-tooltip" content="Returning a request is disabled until review has been completed by two reviewers" %}
+              {% /button %}
+            {% endif %}
+            {% comment %} User can complete review if they haven't already {% endcomment %}
+            {% if user_has_completed_review %}
+              {% #button disabled=True class="relative group btn-sm" variant="secondary" id="complete-review-button" %}
+                Complete review
+                {% tooltip class="airlock-tooltip" content="You have already completed your review" %}
+              {% /button %}
+            {% elif user_has_reviewed_all_files %}
+              <form action="{{ request_review_url }}" method="POST">
+                {% csrf_token %}
+                {% #button type="submit" class="btn-sm" tooltip="Complete Review" variant="secondary" id="complete-review-button" %}Complete review{% /button %}
+              </form>
+            {% else %}
+              {% #button disabled=True class="relative group btn-sm" variant="secondary" id="complete-review-button" %}
+                Complete review
+                {% tooltip class="airlock-tooltip" content="You must review all files before you can complete your review" %}
+              {% /button %}
+            {% endif %}
           {% endif %}
-          {% comment %} User can complete review if they haven't already {% endcomment %}
-          {% if user_has_completed_review %}
-            {% #button disabled=True class="relative group btn-sm" variant="secondary" id="complete-review-button" %}
-              Complete review
-              {% tooltip class="airlock-tooltip" content="You have already completed your review" %}
-            {% /button %}
-          {% elif user_has_reviewed_all_files %}
-            <form action="{{ request_review_url }}" method="POST">
+          {% comment %} A fully reviewed or approved request can be released if all its files are also approved {% endcomment %}
+          {% if release_request.can_be_released %}
+            <form action="{{ release_files_url }}" method="POST" hx-post="{{ release_files_url }}" hx-disabled-elt="button">
               {% csrf_token %}
-              {% #button type="submit" class="btn-sm" tooltip="Complete Review" variant="secondary" id="complete-review-button" %}Complete review{% /button %}
+              {% #button class="btn-sm" type="submit" tooltip="Release files to jobs.opensafely.org" variant="warning" id="release-files-button" %}
+                Release files
+                <img height="16" width="16" class="icon icon--green-700 animate-spin htmx-indicator" src="{% static 'icons/progress_activity.svg' %}" alt="">
+              {% /button %}
             </form>
-          {% else %}
-            {% #button disabled=True class="relative group btn-sm" variant="secondary" id="complete-review-button" %}
-              Complete review
-              {% tooltip class="airlock-tooltip" content="You must review all files before you can complete your review" %}
-            {% /button %}
-          {% endif %}
-        {% endif %}
-        {% comment %} A fully reviewed or approved request can be released if all its files are also approved {% endcomment %}
-        {% if release_request.can_be_released %}
-          <form action="{{ release_files_url }}" method="POST" hx-post="{{ release_files_url }}" hx-disabled-elt="button">
-            {% csrf_token %}
-            {% #button class="btn-sm" type="submit" tooltip="Release files to jobs.opensafely.org" variant="warning" id="release-files-button" %}
+          {% elif release_request.status_owner.name == "REVIEWER" %}
+            {% #button disabled=True class="relative group btn-sm" variant="warning" id="release-files-button" %}
               Release files
-              <img height="16" width="16" class="icon icon--green-700 animate-spin htmx-indicator" src="{% static 'icons/progress_activity.svg' %}" alt="">
+              {% tooltip class="airlock-tooltip" content="Releasing to jobs.opensafely.org is disabled until all files have been approved by by two reviewers" %}
             {% /button %}
-          </form>
-        {% elif release_request.status_owner.name == "REVIEWER" %}
-          {% #button disabled=True class="relative group btn-sm" variant="warning" id="release-files-button" %}
-            Release files
-            {% tooltip class="airlock-tooltip" content="Releasing to jobs.opensafely.org is disabled until all files have been approved by by two reviewers" %}
-          {% /button %}
+          {% endif %}
         {% endif %}
       {% endif %}
     {% /airlock_header %}

--- a/airlock/templates/file_browser/workspace.html
+++ b/airlock/templates/file_browser/workspace.html
@@ -1,7 +1,7 @@
-{% #card title=workspace.name %}
+{% #card title=workspace.display_name %}
   {% #description_list %}
     {% #description_item title="Project" %}
-      {{ project }}
+      {{ project.display_name }}
     {% /description_item %}
   {% /description_list %}
 {% /card %}

--- a/airlock/templates/workspaces.html
+++ b/airlock/templates/workspaces.html
@@ -7,10 +7,10 @@
     {% airlock_header title="Workspaces for "|add:request.user.username %}
 
     {% for project, workspaces in projects.items %}
-      {% #card title=project %}
+      {% #card title=project.display_name %}
         {% #list_group id="workspaces" %}
           {% for workspace in workspaces %}
-            {% #list_group_item href=workspace.get_url %}{{ workspace.name }}{% /list_group_item %}
+            {% #list_group_item href=workspace.get_url %}{{ workspace.display_name }}{% /list_group_item %}
           {% endfor %}
         {% /list_group %}
       {% /card %}

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -1,5 +1,7 @@
 import dataclasses
 import time
+from enum import Enum
+from typing import Any
 
 
 @dataclasses.dataclass(frozen=True)
@@ -11,9 +13,14 @@ class User:
     """
 
     username: str
-    workspaces: dict[str, dict[str, str]] = dataclasses.field(default_factory=dict)
+    workspaces: dict[str, Any] = dataclasses.field(default_factory=dict)
     output_checker: bool = dataclasses.field(default=False)
     last_refresh: float = dataclasses.field(default_factory=time.time)
+
+    class ActionDeniedReason(Enum):
+        NO_PERMISSION = "NO_PERMISSION"
+        WORKSPACE_ARCHIVED = "WORKSPACE_ARCHIVED"
+        PROJECT_INACTIVE = "PROJECT_INACTIVE"
 
     def __post_init__(self):
         assert isinstance(self.workspaces, dict)
@@ -39,13 +46,24 @@ class User:
     def has_permission(self, workspace_name):
         return (
             # Output checkers can view all workspaces
-            self.output_checker or self.can_create_request(workspace_name)
+            # Authors can view all workspaces they have access to (regardless
+            # of archive or project ongoing status)
+            self.output_checker or workspace_name in self.workspaces
         )
 
-    def can_create_request(self, workspace_name):
-        # Only users with explict access to the workspace can create release
+    def can_action_request(self, workspace_name):
+        # Only users with explict access to the workspace can create/modify release
         # requests.
-        return workspace_name in self.workspaces
+        if workspace_name not in self.workspaces:
+            return False, self.ActionDeniedReason.NO_PERMISSION
+        # Requests for archived workspaces cannot be created/modified
+        if self.workspaces[workspace_name]["archived"]:
+            return False, self.ActionDeniedReason.WORKSPACE_ARCHIVED
+        # Requests for workspaces in not-ongoing projects cannot be created/modified
+        if not self.workspaces[workspace_name]["project_details"]["ongoing"]:
+            return False, self.ActionDeniedReason.PROJECT_INACTIVE
+
+        return True, None
 
     def is_authenticated(self):
         return True

--- a/airlock/users.py
+++ b/airlock/users.py
@@ -1,7 +1,9 @@
 import dataclasses
 import time
-from enum import Enum
 from typing import Any
+
+
+class ActionDenied(Exception): ...
 
 
 @dataclasses.dataclass(frozen=True)
@@ -16,11 +18,6 @@ class User:
     workspaces: dict[str, Any] = dataclasses.field(default_factory=dict)
     output_checker: bool = dataclasses.field(default=False)
     last_refresh: float = dataclasses.field(default_factory=time.time)
-
-    class ActionDeniedReason(Enum):
-        NO_PERMISSION = "NO_PERMISSION"
-        WORKSPACE_ARCHIVED = "WORKSPACE_ARCHIVED"
-        PROJECT_INACTIVE = "PROJECT_INACTIVE"
 
     def __post_init__(self):
         assert isinstance(self.workspaces, dict)
@@ -51,19 +48,17 @@ class User:
             self.output_checker or workspace_name in self.workspaces
         )
 
-    def can_action_request(self, workspace_name):
+    def verify_can_action_request(self, workspace_name):
         # Only users with explict access to the workspace can create/modify release
         # requests.
         if workspace_name not in self.workspaces:
-            return False, self.ActionDeniedReason.NO_PERMISSION
+            raise ActionDenied(f"you do not have permission for {workspace_name}")
         # Requests for archived workspaces cannot be created/modified
         if self.workspaces[workspace_name]["archived"]:
-            return False, self.ActionDeniedReason.WORKSPACE_ARCHIVED
+            raise ActionDenied(f"{workspace_name} has been archived")
         # Requests for workspaces in not-ongoing projects cannot be created/modified
         if not self.workspaces[workspace_name]["project_details"]["ongoing"]:
-            return False, self.ActionDeniedReason.PROJECT_INACTIVE
-
-        return True, None
+            raise ActionDenied(f"{workspace_name} is part of an inactive project")
 
     def is_authenticated(self):
         return True

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -17,6 +17,7 @@ from airlock.business_logic import (
 from airlock.file_browser_api import get_workspace_tree
 from airlock.forms import AddFileForm, FileTypeFormSet, MultiselectForm
 from airlock.types import UrlPath, WorkspaceFileStatus
+from airlock.users import ActionDenied
 from airlock.views.helpers import (
     display_form_errors,
     display_multiple_messages,
@@ -84,7 +85,12 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     # the files on the request. In future we'll likely also need to
     # check file metadata to allow updating a file if the original has
     # changed.
-    can_action_request, _ = request.user.can_action_request(workspace_name)
+    try:
+        request.user.verify_can_action_request(workspace_name)
+        can_action_request = True
+    except ActionDenied:
+        can_action_request = False
+
     multiselect_add = can_action_request and (
         workspace.current_request is None
         or workspace.current_request.status_owner() == RequestStatusOwner.AUTHOR

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -82,7 +82,8 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     # the files on the request. In future we'll likely also need to
     # check file metadata to allow updating a file if the original has
     # changed.
-    multiselect_add = request.user.can_create_request(workspace_name) and (
+    can_action_request, _ = request.user.can_action_request(workspace_name)
+    multiselect_add = can_action_request and (
         workspace.current_request is None
         or workspace.current_request.status_owner() == RequestStatusOwner.AUTHOR
     )

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -33,7 +33,7 @@ tracer = trace.get_tracer_provider().get_tracer("airlock")
 def grouped_workspaces(workspaces):
     workspaces_by_project = defaultdict(list)
     for workspace in workspaces:
-        workspaces_by_project[workspace.project()].append(workspace)
+        workspaces_by_project[workspace.project().get("name")].append(workspace)
 
     for project, workspaces in sorted(workspaces_by_project.items()):
         yield project, list(sorted(workspaces))
@@ -97,9 +97,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     )
 
     activity = []
-    project = request.user.workspaces.get(workspace_name, {}).get(
-        "project", "Unknown project"
-    )
+    project = workspace.project().get("name", "Unknown project")
 
     # we are viewing the root, so load workspace audit log
     if path == "":

--- a/example-data/dev_users.json
+++ b/example-data/dev_users.json
@@ -7,7 +7,18 @@
       "output_checker": true,
       "staff": true,
       "workspaces": {
-        "example-workspace": {"project": "Project 1"}
+        "example-workspace": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": false
+        },
+        "example-workspace_1": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": false
+        },
+        "example-workspace_2": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": true
+        }
       }
     }
   },
@@ -19,7 +30,18 @@
       "output_checker": false,
       "staff": false,
       "workspaces": {
-        "example-workspace": {"project": "Project 1"}
+        "example-workspace": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": false
+        },
+        "example-workspace_1": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": false
+        },
+        "example-workspace_2": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": true
+        }
       }
     }
   }

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -37,7 +37,11 @@ def create_user(
         workspaces_dict = workspaces
     else:
         workspaces_dict = {
-            workspace: {"project": "project"} for workspace in workspaces
+            workspace: {
+                "project_details": {"name": "project", "ongoing": True},
+                "archived": False,
+            }
+            for workspace in workspaces
         }
 
     if last_refresh is None:

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -67,7 +67,12 @@ def output_checker_user(live_server, context):
         context,
         {
             "username": "test_output_checker",
-            "workspaces": {"test-dir2": {"project": "Project 2"}},
+            "workspaces": {
+                "test-dir2": {
+                    "project_details": {"name": "Project 2", "ongoing": True},
+                    "archived": False,
+                }
+            },
             "output_checker": True,
         },
     )
@@ -80,7 +85,12 @@ def researcher_user(live_server, context):
         context,
         {
             "username": "test_researcher",
-            "workspaces": {"test-dir1": {"project": "Project 1"}},
+            "workspaces": {
+                "test-dir1": {
+                    "project_details": {"name": "Project 1", "ongoing": True},
+                    "archived": False,
+                }
+            },
             "output_checker": False,
         },
     )

--- a/tests/functional/test_code_pages.py
+++ b/tests/functional/test_code_pages.py
@@ -45,7 +45,7 @@ def test_code_from_workspace(live_server, page, context):
     # output file does display code button
     file_url = "/workspaces/view/test-dir1/foo.txt"
     page.goto(live_server.url + file_url)
-    page.locator("#file-button-more").click()
+    more_button.click()
     expect(code_button).to_be_visible()
 
     with context.expect_page() as new_page_info:

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -45,7 +45,15 @@ def dev_users(tmp_path, settings):
                         "fullname": "Researcher",
                         "output_checker": False,
                         "staff": False,
-                        "workspaces": {"test-workspace": {"project": "Project 1"}},
+                        "workspaces": {
+                            "test-workspace": {
+                                "project_details": {
+                                    "name": "Project 1",
+                                    "ongoing": True,
+                                },
+                                "archived": False,
+                            }
+                        },
                     },
                 },
             }

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -12,7 +12,12 @@ def test_request_file_withdraw(live_server, context, page, bll):
         context,
         user_dict={
             "username": "author",
-            "workspaces": ["workspace"],
+            "workspaces": {
+                "workspace": {
+                    "project_details": {"name": "Project 2", "ongoing": True},
+                    "archived": False,
+                }
+            },
             "output_checker": False,
         },
     )
@@ -52,7 +57,12 @@ def test_request_group_edit_comment(live_server, context, page, bll, settings):
         context,
         user_dict={
             "username": "author",
-            "workspaces": ["workspace"],
+            "workspaces": {
+                "workspace": {
+                    "project_details": {"name": "Project 2", "ongoing": True},
+                    "archived": False,
+                }
+            },
             "output_checker": False,
         },
     )
@@ -95,6 +105,15 @@ def test_request_group_edit_comment(live_server, context, page, bll, settings):
     expect(comments_locator).to_contain_text("test comment")
 
 
+def _workspace_dict():
+    return {
+        "workspace": {
+            "project_details": {"name": "Project 2", "ongoing": True},
+            "archived": False,
+        }
+    }
+
+
 @pytest.mark.parametrize(
     "author,login_as,status,reviewer_buttons_visible,release_button_visible",
     [
@@ -124,10 +143,10 @@ def test_request_buttons(
 ):
     user_data = {
         "researcher": dict(
-            username="researcher", workspaces=["workspace"], output_checker=False
+            username="researcher", workspaces=_workspace_dict(), output_checker=False
         ),
         "checker": dict(
-            username="checker", workspaces=["workspace"], output_checker=True
+            username="checker", workspaces=_workspace_dict(), output_checker=True
         ),
     }
 
@@ -181,13 +200,13 @@ def test_request_returnable(
 ):
     user_data = {
         "author": dict(
-            username="author", workspaces=["workspace"], output_checker=False
+            username="author", workspaces=_workspace_dict(), output_checker=False
         ),
         "checker1": dict(
-            username="checker1", workspaces=["workspace"], output_checker=True
+            username="checker1", workspaces=_workspace_dict(), output_checker=True
         ),
         "checker2": dict(
-            username="checker2", workspaces=["workspace"], output_checker=True
+            username="checker2", workspaces=_workspace_dict(), output_checker=True
         ),
     }
     author = factories.create_user(**user_data["author"])
@@ -230,13 +249,13 @@ def test_request_returnable(
 def test_returned_request(live_server, context, page, bll):
     user_data = {
         "author": dict(
-            username="author", workspaces=["workspace"], output_checker=False
+            username="author", workspaces=_workspace_dict(), output_checker=False
         ),
         "checker1": dict(
-            username="checker1", workspaces=["workspace"], output_checker=True
+            username="checker1", workspaces=_workspace_dict(), output_checker=True
         ),
         "checker2": dict(
-            username="checker2", workspaces=["workspace"], output_checker=True
+            username="checker2", workspaces=_workspace_dict(), output_checker=True
         ),
     }
     author = factories.create_user(**user_data["author"])
@@ -291,7 +310,7 @@ def test_request_releaseable(live_server, context, page, bll):
         context,
         user_dict={
             "username": "output_checker",
-            "workspaces": [],
+            "workspaces": {},
             "output_checker": True,
         },
     )

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -32,7 +32,10 @@ def test_login(requests_post, client, settings):
         "username": "test_user",
         "output_checker": False,
         "workspaces": {
-            "workspace": {"project": "project1"},
+            "workspace": {
+                "project_details": {"name": "project1", "ongoing": True},
+                "archived": False,
+            },
         },
     }
 
@@ -52,7 +55,10 @@ def test_login(requests_post, client, settings):
     assert client.session["user"]["username"] == "test_user"
     assert client.session["user"]["output_checker"] is False
     assert client.session["user"]["workspaces"] == {
-        "workspace": {"project": "project1"},
+        "workspace": {
+            "project_details": {"name": "project1", "ongoing": True},
+            "archived": False,
+        },
     }
 
     assert response.url == "/workspaces/"

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -21,7 +21,9 @@ def test_middleware_expired_user(airlock_client, responses):
     session.save()
 
     new_workspaces = user.workspaces.copy()
-    new_workspaces["new_workspace"] = {"project": "other_project"}
+    new_workspaces["new_workspace"] = {
+        "project_details": {"name": "other_project", "ongoing": True}
+    }
 
     responses.post(
         f"{settings.AIRLOCK_API_ENDPOINT}/releases/authorise",

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -22,7 +22,8 @@ def test_middleware_expired_user(airlock_client, responses):
 
     new_workspaces = user.workspaces.copy()
     new_workspaces["new_workspace"] = {
-        "project_details": {"name": "other_project", "ongoing": True}
+        "project_details": {"name": "other_project", "ongoing": True},
+        "archived": False,
     }
 
     responses.post(

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -20,7 +20,11 @@ def test_home_redirects(airlock_client):
 
 
 def test_workspace_view_summary(airlock_client):
-    airlock_client.login(workspaces={"workspace": {"project": "TESTPROJECT"}})
+    airlock_client.login(
+        workspaces={
+            "workspace": {"project_details": {"name": "TESTPROJECT", "ongoing": True}}
+        }
+    )
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, "file.txt")
     # create audit event to appear on activity
@@ -412,9 +416,9 @@ def test_workspaces_index_no_user(airlock_client):
 def test_workspaces_index_user_permitted_workspaces(airlock_client):
     airlock_client.login(
         workspaces={
-            "test1a": {"project": "Project 1"},
-            "test1b": {"project": "Project 1"},
-            "test2": {"project": "Project 2"},
+            "test1a": {"project_details": {"name": "Project 1", "ongoing": True}},
+            "test1b": {"project_details": {"name": "Project 1", "ongoing": True}},
+            "test2": {"project_details": {"name": "Project 2", "ongoing": True}},
         }
     )
     factories.create_workspace("test1a")

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -22,7 +22,10 @@ def test_home_redirects(airlock_client):
 def test_workspace_view_summary(airlock_client):
     airlock_client.login(
         workspaces={
-            "workspace": {"project_details": {"name": "TESTPROJECT", "ongoing": True}}
+            "workspace": {
+                "project_details": {"name": "TESTPROJECT", "ongoing": True},
+                "archived": False,
+            }
         }
     )
     workspace = factories.create_workspace("workspace")

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -3,7 +3,13 @@ from django.contrib import messages
 from django.contrib.messages.api import get_messages
 from django.urls import reverse
 
-from airlock.business_logic import AuditEventType, RequestFileType, RequestStatus, bll
+from airlock.business_logic import (
+    AuditEventType,
+    Project,
+    RequestFileType,
+    RequestStatus,
+    bll,
+)
 from airlock.types import UrlPath
 from tests import factories
 from tests.conftest import get_trace
@@ -42,6 +48,23 @@ def test_workspace_view_summary(airlock_client):
     assert "Recent activity" in response.rendered_content
     assert "audit_user" in response.rendered_content
     assert "Created request" in response.rendered_content
+
+
+def test_workspace_view_archived_inactive(airlock_client):
+    airlock_client.login(
+        workspaces={
+            "workspace-abc": {
+                "project_details": {"name": "TESTPROJECT", "ongoing": False},
+                "archived": True,
+            }
+        }
+    )
+    workspace = factories.create_workspace("workspace-abc")
+    factories.write_workspace_file(workspace, "file.txt")
+
+    response = airlock_client.get("/workspaces/view/workspace-abc/")
+    assert "workspace-abc (ARCHIVED)" in response.rendered_content
+    assert "TESTPROJECT (INACTIVE)" in response.rendered_content
 
 
 def test_workspace_view_with_existing_request_for_user(airlock_client):
@@ -419,22 +442,61 @@ def test_workspaces_index_no_user(airlock_client):
 def test_workspaces_index_user_permitted_workspaces(airlock_client):
     airlock_client.login(
         workspaces={
-            "test1a": {"project_details": {"name": "Project 1", "ongoing": True}},
-            "test1b": {"project_details": {"name": "Project 1", "ongoing": True}},
-            "test2": {"project_details": {"name": "Project 2", "ongoing": True}},
+            "test1a": {
+                "project_details": {"name": "Project 1", "ongoing": True},
+                "archived": True,
+            },
+            "test1b": {
+                "project_details": {"name": "Project 1", "ongoing": True},
+                "archived": False,
+            },
+            "test1c": {
+                "project_details": {"name": "Project 1", "ongoing": True},
+                "archived": False,
+            },
+            "test2b": {
+                "project_details": {"name": "Project 2", "ongoing": False},
+                "archived": False,
+            },
+            "test2a": {
+                "project_details": {"name": "Project 2", "ongoing": False},
+                "archived": False,
+            },
+            "test3": {
+                "project_details": {"name": "Project 3", "ongoing": True},
+                "archived": False,
+            },
         }
     )
     factories.create_workspace("test1a")
     factories.create_workspace("test1b")
-    factories.create_workspace("test2")
+    factories.create_workspace("test1c")
+    factories.create_workspace("test2b")
+    factories.create_workspace("test2a")
+    factories.create_workspace("test3")
     factories.create_workspace("not-allowed")
     response = airlock_client.get("/workspaces/")
 
     projects = response.context["projects"]
-    assert projects["Project 1"][0].name == "test1a"
-    assert projects["Project 1"][1].name == "test1b"
-    assert projects["Project 2"][0].name == "test2"
-    assert "not-allowed" not in response.rendered_content
+    ongoing_project1 = Project(name="Project 1", is_ongoing=True)
+    inactive_project1 = Project(name="Project 2", is_ongoing=False)
+    ongoing_project2 = Project(name="Project 3", is_ongoing=True)
+
+    # projects are ordered by ongoing first, then by name
+    assert list(projects.keys()) == [
+        ongoing_project1,
+        ongoing_project2,
+        inactive_project1,
+    ]
+
+    # within a project, workspaces are ordered by unarchived first and then by name
+    assert [ws.name for ws in projects[ongoing_project1]] == [
+        "test1b",
+        "test1c",
+        "test1a",
+    ]
+    assert [ws.name for ws in projects[ongoing_project2]] == ["test3"]
+    assert [ws.name for ws in projects[inactive_project1]] == ["test2a", "test2b"]
 
 
 def test_workspace_multiselect_add_files_all_valid(airlock_client, bll):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -287,9 +287,18 @@ def test_provider_get_workspaces_for_user(bll, output_checker):
     factories.create_workspace("bar")
     factories.create_workspace("not-allowed")
     workspaces = {
-        "foo": {"project": "project 1"},
-        "bar": {"project": "project 2"},
-        "not-exists": {"project": "project 3"},
+        "foo": {
+            "project_details": {"name": "project 1", "ongoing": True},
+            "archived": False,
+        },
+        "bar": {
+            "project_details": {"name": "project 2", "ongoing": True},
+            "archived": True,
+        },
+        "not-exists": {
+            "project_details": {"name": "project 2", "ongoing": True},
+            "archived": False,
+        },
     }
     user = factories.create_user(workspaces=workspaces, output_checker=output_checker)
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -182,15 +182,30 @@ def test_workspace_get_workspace_archived_ongoing(bll):
     )
     checker = factories.create_user("checker", output_checker=True)
 
-    assert not bll.get_workspace("workspace", user).is_archived()
-    assert bll.get_workspace("workspace", user).project().get("ongoing")
-    assert bll.get_workspace("archived_workspace", user).is_archived()
-    assert bll.get_workspace("archived_workspace", user).project().get("ongoing")
-    assert not bll.get_workspace("not_ongoing", user).is_archived()
-    assert not bll.get_workspace("not_ongoing", user).project().get("ongoing")
-    for workspace in ["workspace", "archived_workspace", "not_ongoing"]:
-        assert bll.get_workspace(workspace, checker).is_archived() is None
-        assert bll.get_workspace(workspace, checker).project().get("ongoing") is None
+    active_workspace = bll.get_workspace("workspace", user)
+    archived_workspace = bll.get_workspace("archived_workspace", user)
+    inactive_project = bll.get_workspace("not_ongoing", user)
+    assert not active_workspace.is_archived()
+    assert active_workspace.project().is_ongoing
+    assert active_workspace.display_name() == "workspace"
+    assert active_workspace.project().display_name() == "project-1"
+
+    assert archived_workspace.is_archived()
+    assert archived_workspace.project().is_ongoing
+    assert archived_workspace.display_name() == "archived_workspace (ARCHIVED)"
+    assert archived_workspace.project().display_name() == "project-1"
+
+    assert not inactive_project.is_archived()
+    assert not inactive_project.project().is_ongoing
+    assert inactive_project.display_name() == "not_ongoing"
+    assert inactive_project.project().display_name() == "project-2 (INACTIVE)"
+
+    for workspace_name in ["workspace", "archived_workspace", "not_ongoing"]:
+        workspace = bll.get_workspace(workspace_name, checker)
+        assert workspace.is_archived() is None
+        assert bll.get_workspace(workspace_name, checker).project().is_ongoing
+        assert workspace.display_name() == workspace_name
+        assert "INACTIVE" not in workspace.project().display_name()
 
 
 def test_workspace_get_workspace_status(bll):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -156,6 +156,43 @@ def test_get_file_metadata():
     )
 
 
+def test_workspace_get_workspace_archived_ongoing(bll):
+    factories.create_workspace("workspace")
+    factories.create_workspace("archived_workspace")
+    factories.create_workspace("not_ongoing")
+    user = factories.create_user(
+        "user",
+        workspaces={
+            "workspace": {
+                "project": "project-1",
+                "project_details": {"name": "project-1", "ongoing": True},
+                "archived": False,
+            },
+            "archived_workspace": {
+                "project": "project-1",
+                "project_details": {"name": "project-1", "ongoing": True},
+                "archived": True,
+            },
+            "not_ongoing": {
+                "project": "project-2",
+                "project_details": {"name": "project-2", "ongoing": False},
+                "archived": False,
+            },
+        },
+    )
+    checker = factories.create_user("checker", output_checker=True)
+
+    assert not bll.get_workspace("workspace", user).is_archived()
+    assert bll.get_workspace("workspace", user).project().get("ongoing")
+    assert bll.get_workspace("archived_workspace", user).is_archived()
+    assert bll.get_workspace("archived_workspace", user).project().get("ongoing")
+    assert not bll.get_workspace("not_ongoing", user).is_archived()
+    assert not bll.get_workspace("not_ongoing", user).project().get("ongoing")
+    for workspace in ["workspace", "archived_workspace", "not_ongoing"]:
+        assert bll.get_workspace(workspace, checker).is_archived() is None
+        assert bll.get_workspace(workspace, checker).project().get("ongoing") is None
+
+
 def test_workspace_get_workspace_status(bll):
     path = UrlPath("foo/bar.txt")
     workspace = factories.create_workspace("workspace")

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -187,16 +187,19 @@ def test_workspace_get_workspace_archived_ongoing(bll):
     inactive_project = bll.get_workspace("not_ongoing", user)
     assert not active_workspace.is_archived()
     assert active_workspace.project().is_ongoing
+    assert active_workspace.is_active()
     assert active_workspace.display_name() == "workspace"
     assert active_workspace.project().display_name() == "project-1"
 
     assert archived_workspace.is_archived()
     assert archived_workspace.project().is_ongoing
+    assert not archived_workspace.is_active()
     assert archived_workspace.display_name() == "archived_workspace (ARCHIVED)"
     assert archived_workspace.project().display_name() == "project-1"
 
     assert not inactive_project.is_archived()
     assert not inactive_project.project().is_ongoing
+    assert not inactive_project.is_active()
     assert inactive_project.display_name() == "not_ongoing"
     assert inactive_project.project().display_name() == "project-2 (INACTIVE)"
 

--- a/tests/unit/test_login_api.py
+++ b/tests/unit/test_login_api.py
@@ -17,7 +17,13 @@ def test_get_user_data_with_dev_users(settings, tmp_path):
                     "details": {
                         "output_checker": True,
                         "workspaces": {
-                            "test1": {"project": "project1"},
+                            "test1": {
+                                "project_details": {
+                                    "name": "project1",
+                                    "ongoing": True,
+                                },
+                                "archived": False,
+                            },
                         },
                     },
                 },
@@ -28,7 +34,10 @@ def test_get_user_data_with_dev_users(settings, tmp_path):
     dev_data = login_api.get_user_data("test_user", "foo bar baz")
     assert dev_data["output_checker"] is True
     assert dev_data["workspaces"] == {
-        "test1": {"project": "project1"},
+        "test1": {
+            "project_details": {"name": "project1", "ongoing": True},
+            "archived": False,
+        },
     }
     assert "last_refresh" in dev_data
 
@@ -43,7 +52,10 @@ def test_get_user_data_with_dev_users_invalid(settings, tmp_path):
                 "test_user": {"token": "foo bar baz"},
                 "details": {
                     "workspaces": {
-                        "test1": {"project": "project1"},
+                        "test1": {
+                            "project_details": {"name": "project1", "ongoing": True},
+                            "archived": False,
+                        },
                     }
                 },
             }

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -9,8 +9,16 @@ def test_session_user_from_session():
             "id": 1,
             "username": "test",
             "workspaces": {
-                "test-workspace-1": {"project": "Project 1"},
-                "test_workspace2": {"project": "Project 2"},
+                "test-workspace-1": {
+                    "project": "Project 1",
+                    "project_details": {"name": "Project 1", "ongoing": True},
+                    "archived": False,
+                },
+                "test_workspace2": {
+                    "project": "Project 2",
+                    "project_details": {"name": "Project 2", "ongoing": True},
+                    "archived": True,
+                },
             },
             "output_checker": True,
         }
@@ -19,6 +27,16 @@ def test_session_user_from_session():
     assert set(user.workspaces) == {"test-workspace-1", "test_workspace2"}
     assert user.workspaces["test-workspace-1"]["project"] == "Project 1"
     assert user.workspaces["test_workspace2"]["project"] == "Project 2"
+    assert user.workspaces["test-workspace-1"]["project_details"] == {
+        "name": "Project 1",
+        "ongoing": True,
+    }
+    assert user.workspaces["test_workspace2"]["project_details"] == {
+        "name": "Project 2",
+        "ongoing": True,
+    }
+    assert user.workspaces["test-workspace-1"]["archived"] is False
+    assert user.workspaces["test_workspace2"]["archived"] is True
     assert user.output_checker
 
 


### PR DESCRIPTION
Fixes #437 
Prevent requests being created/edited (by authors) for archived workspaces and workspaces for projects.

For now, output-checkers can continue to action requests for archived/inactive workspaces. Currently workspace info is only retrieved for the user's workspaces, so if we wanted to prevent this, we'd need to call a new job-server endpoint to get workspace info. We may well want to do that later, but for now I've limited this PR to the info we have available for a user.

Workspace/project status is shown on the workspace list (with inactive projects last, and archived workspaces last within a project):
![image](https://github.com/opensafely-core/airlock/assets/6770950/e138496b-b517-42b9-85f4-a99c30e41a17)

In the workspace, project/workspace status is also displayed:
![image](https://github.com/opensafely-core/airlock/assets/6770950/a142fc3f-1881-41fe-8e39-f9218b4936e7)

