### PR TITLE
Update the manifests.py script for real repos

### DIFF
--- a/justfile
+++ b/justfile
@@ -206,9 +206,10 @@ load-example-data: devenv && manifests
     # Configure user details for local login
     cp example-data/dev_users.json "${AIRLOCK_WORK_DIR%/}/${AIRLOCK_DEV_USERS_FILE}"
 
-# generate manifests and git repos for local test workspaces
+# generate or update manifests and git repos for local test workspaces
 manifests:
     cat scripts/manifests.py | $BIN/python manage.py shell
+
 
 # generate the automated state diagrams from code
 state-diagram file="docs/request-states.md":

--- a/scripts/manifests.py
+++ b/scripts/manifests.py
@@ -1,10 +1,27 @@
 from django.conf import settings
 
+from airlock.business_logic import Workspace
 from tests import factories
 
 
 workspaces = [w for w in settings.WORKSPACE_DIR.iterdir() if w.is_dir()]
 
 for workspace in workspaces:
-    print(f"Writing manifest.json and creating repo for workspace {workspace.name}")
-    repo = factories.create_repo(workspace.name, temporary=False)
+    try:
+        workspace = Workspace.from_directory(workspace.name)
+        first_output = next(
+            (output for output in workspace.manifest["outputs"].values()), None
+        )
+        is_real_repo = first_output and first_output["repo"].startswith(
+            "https://github.com"
+        )
+    except Exception:
+        is_real_repo = False
+
+    if is_real_repo:
+        # If it's a real github repo, just update the manifest
+        print(f"Updating manifest.json for workspace {workspace.name}")
+        factories.update_manifest(workspace.name)
+    else:
+        print(f"Writing manifest.json and creating repo for workspace {workspace.name}")
+        repo = factories.create_repo(workspace.name, temporary=False)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -107,11 +107,16 @@ def update_manifest(workspace: Workspace | str, files=None):
     skip_paths = [root / "metadata"]
 
     repo = "http://example.com/org/repo"
+    commit = "abcdefgh" * 5  # 40 characters
 
     if manifest_path.exists():
         manifest = json.loads(manifest_path.read_text())
         manifest["workspace"] = name
-        repo = manifest["repo"] or repo
+        if manifest["outputs"]:
+            first_output = list(manifest["outputs"].values())[0]
+            repo = first_output["repo"]
+            if repo.startswith("https://github.com"):  # pragma: no cover
+                commit = first_output["commit"]
         manifest.setdefault("outputs", {})
     else:
         manifest = {"workspace": name, "repo": repo, "outputs": {}}
@@ -132,7 +137,7 @@ def update_manifest(workspace: Workspace | str, files=None):
             job_id=f"job_{i}",
             job_request=f"job_request_{i}",
             action=f"action_{i}",
-            commit="abcdefgh" * 5,  # 40 characters,
+            commit=commit,
             repo=repo,
             excluded=False,
         )


### PR DESCRIPTION
Avoid re-creating dummy github repos and commits for workspaces with real github repo urls in their manifest.json. This means we can mimic a real github repo locally and update manifests when we edit local files without borking the valid repo/commit info.