### PR TITLE
Send notifications for status changes only

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -188,15 +188,6 @@ class NotificationEventType(Enum):
     REQUEST_RESUBMITTED = "request_resubmitted"
 
 
-class NotificationUpdateType(Enum):
-    FILE_ADDED = "file added"
-    FILE_UPDATED = "file updated"
-    FILE_WITHDRAWN = "file withdrawn"
-    CONTEXT_EDITIED = "context edited"
-    CONTROLS_EDITED = "controls edited"
-    COMMENT_ADDED = "comment added"
-
-
 READONLY_EVENTS = {
     AuditEventType.WORKSPACE_FILE_VIEW,
     AuditEventType.REQUEST_FILE_VIEW,
@@ -1218,7 +1209,7 @@ class DataAccessLayerProtocol(Protocol):
         context: str,
         controls: str,
         audit: AuditEvent,
-    ) -> list[NotificationUpdateType]:
+    ):
         raise NotImplementedError()
 
     def group_comment_create(
@@ -2241,15 +2232,6 @@ class BusinessLogicLayer:
             group=path.parts[0],
         )
         self._dal.audit_event(audit)
-
-    def _get_notification_update_dict(
-        self, update_type: NotificationUpdateType, group_name: str, user: User
-    ):
-        return {
-            "update_type": update_type.value,
-            "group": group_name,
-            "user": user.username,
-        }
 
     def send_notification(
         self,

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -7,7 +7,6 @@ from airlock.business_logic import (
     BusinessLogicLayer,
     CommentVisibility,
     DataAccessLayerProtocol,
-    NotificationUpdateType,
     RequestFileType,
     RequestFileVote,
     RequestStatus,
@@ -398,19 +397,13 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
         context: str,
         controls: str,
         audit: AuditEvent,
-    ) -> list[NotificationUpdateType]:
-        changed = []
+    ):
         with transaction.atomic():
             filegroup = self._get_filegroup(request_id, group)
-            if filegroup.context != context:
-                changed.append(NotificationUpdateType.CONTEXT_EDITIED)
-            if filegroup.controls != controls:
-                changed.append(NotificationUpdateType.CONTROLS_EDITED)
             filegroup.context = context
             filegroup.controls = controls
             filegroup.save()
             self._create_audit_log(audit)
-        return changed
 
     def group_comment_create(
         self,


### PR DESCRIPTION
fixes #461 
Remove notifications for updates. We now only send notification for status changes. I've kept the option to send updates with a notification but reworked it a little, so in future we can send additional update messages along with a status change notification. Job-server handles these in [this PR](https://github.com/opensafely-core/job-server/pull/4443).