### PR TITLE
Add confirmation before rejecting request

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -75,16 +75,28 @@
           {% if release_request.status_owner.name == "REVIEWER" %}
             {% comment %} A fully reviewed request can be returned or rejected {% endcomment %}
             {% if release_request.status.name == "REVIEWED" %}
-              <form action="{{ request_reject_url }}" method="POST">
-                {% csrf_token %}
-                {% #button type="submit" variant="danger" class="action-button btn-sm" id="reject-request-button" %}Reject request{% /button %}
-              </form>
+              {% #modal id="rejectRequest" button_text="Reject request" button_variant="danger" %}
+                {% #card container=True title="Reject this request" %}
+                  <form action="{{ request_reject_url }}" method="POST">
+                    {% csrf_token %}
+
+                    <div class="pb-8">
+                      This will reject the entire request. Once a request is
+                      rejected, it cannot be resubmitted and must be recreated
+                      from scratch. Please confirm you wish to reject this
+                      request.
+                    </div>
+                    {% #button type="submit" variant="danger" class="action-button btn-sm" id="reject-request-button" %}Reject request{% /button %}
+                    {% #button variant="primary" type="cancel" %}Cancel{% /button %}
+                  </form>
+                {% /card %}
+              {% /modal %}
               <form action="{{ request_return_url }}" method="POST">
                 {% csrf_token %}
                 {% #button type="submit" class="btn-sm" tooltip="Return request for changes/clarification" variant="secondary" id="return-request-button" %}Return request{% /button %}
               </form>
             {% else %}
-              {% #button disabled=True class="relative group btn-sm" variant="danger" id="reject-request-button" %}
+              {% #button disabled=True class="relative group btn-sm" variant="danger" id="reject-request-button" data-modal="rejectRequest" %}
                 Reject request
                 {% tooltip class="airlock-tooltip" content="Rejecting a request is disabled until review has been completed by two reviewers" %}
               {% /button %}

--- a/example-data/dev_users.json
+++ b/example-data/dev_users.json
@@ -1,9 +1,32 @@
 {
-  "output_checker": {
-    "token": "output_checker",
+  "output_checker_1": {
+    "token": "output_checker_1",
     "details": {
-      "username": "output_checker",
-      "fullname": "Output Checker",
+      "username": "output_checker_1",
+      "fullname": "Output Checker 1",
+      "output_checker": true,
+      "staff": true,
+      "workspaces": {
+        "example-workspace": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": false
+        },
+        "example-workspace_1": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": false
+        },
+        "example-workspace_2": {
+          "project_details": {"name": "Project 1", "ongoing": true},
+          "archived": true
+        }
+      }
+    }
+  },
+  "output_checker_2": {
+    "token": "output_checker_2",
+    "details": {
+      "username": "output_checker_2",
+      "fullname": "Output Checker 2",
       "output_checker": true,
       "staff": true,
       "workspaces": {

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -525,6 +525,7 @@ def test_e2e_reject_request(page, live_server, dev_users):
     page.goto(live_server.url + release_request.get_url())
 
     # Reject request
+    find_and_click(page.locator("button[data-modal=rejectRequest]"))
     find_and_click(page.locator("#reject-request-button"))
     # Page contains rejected message text
     expect(page.locator("body")).to_contain_text("Request has been rejected")

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -169,7 +169,7 @@ def test_request_buttons(
 
     reviewer_buttons = [
         "#return-request-button",
-        "#reject-request-button",
+        "button[data-modal=rejectRequest]",
         "#complete-review-button",
     ]
 
@@ -318,7 +318,7 @@ def test_request_releaseable(live_server, context, page, bll):
     page.goto(live_server.url + release_request.get_url())
 
     release_files_button = page.locator("#release-files-button")
-    reject_request_button = page.locator("#reject-request-button")
+    reject_request_button = page.locator("button[data-modal=rejectRequest]")
     return_request_button = page.locator("#return-request-button")
 
     # Request is currently reviewed twice

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -318,8 +318,8 @@ def test_request_releaseable(live_server, context, page, bll):
     page.goto(live_server.url + release_request.get_url())
 
     release_files_button = page.locator("#release-files-button")
-    return_request_button = page.locator("#reject-request-button")
-    reject_request_button = page.locator("#return-request-button")
+    reject_request_button = page.locator("#reject-request-button")
+    return_request_button = page.locator("#return-request-button")
 
     # Request is currently reviewed twice
     # output checker can release, return or reject


### PR DESCRIPTION
I've adapted the wording from the warning we give when withdrawing a request. Possibly we want to say something different though?

![image](https://github.com/user-attachments/assets/5c79339a-b7dc-49c6-8c7d-6708a5f0e49a)

This suffers from the modal button sizing issue which we already know about and presumably will fix at some point:

![image](https://github.com/user-attachments/assets/bd7f0fc7-74f7-4fbb-8ad2-c925682e4469)


Closes #463