### PR TITLE
Prevent form labels wrapping

### DIFF
--- a/airlock/templates/add_files.html
+++ b/airlock/templates/add_files.html
@@ -25,7 +25,7 @@
             <div class="flex items-center gap-2 justify-between">
               <span>{{ formset_form.file.value }}</span>
               {{ formset_form.file }}
-              {% form_radios field=formset_form.filetype class="flex flex-row" %}
+              {% form_radios field=formset_form.filetype class="flex flex-row whitespace-nowrap" %}
             </div>
           {% /list_group_item %}
         {% endfor %}


### PR DESCRIPTION
This happened in the presence of long filenames and looked silly.

Before:
![Screenshot from 2024-07-12 15-21-10](https://github.com/user-attachments/assets/6997e3eb-44a7-498c-b2d0-5895192d9a06)

After:
![image](https://github.com/user-attachments/assets/285c3331-a261-4744-bfee-b55c3342bab0)



Closes #465