### PR TITLE
Hide "Approved Requests" card if no requests

### DIFF
--- a/airlock/templates/requests.html
+++ b/airlock/templates/requests.html
@@ -37,15 +37,15 @@
         {% /list_group %}
       {% /card %}
 
-      {% #card title="Approved Requests" %}
-        {% #list_group id="returned-requests" %}
-          {% for request in approved_requests %}
-            {% #list_group_item href=request.get_url %}{{ request.workspace }} by {{ request.author }}{% /list_group_item %}
-          {% empty %}
-            {% list_group_empty title="No approved requests" description="There are no approved requests awaiting release" %}
-          {% endfor %}
-        {% /list_group %}
-      {% /card %}
+      {% if approved_requests %}
+        {% #card title="Approved requests awaiting release" %}
+          {% #list_group id="returned-requests" %}
+            {% for request in approved_requests %}
+              {% #list_group_item href=request.get_url %}{{ request.workspace }} by {{ request.author }}{% /list_group_item %}
+            {% endfor %}
+          {% /list_group %}
+        {% /card %}
+      {% endif %}
 
     {% endif %}
   </div>


### PR DESCRIPTION
* this is only for a slightly unusual error state, in which the release process has failed (during the interaction with job server)
* most of the time, most output checkers should not need to worry about this, so hide it from the default view
* fixes #477 