### PR TITLE
Allow easy switching between users in local dev environments

### DIFF
--- a/airlock/nav.py
+++ b/airlock/nav.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from dataclasses import dataclass
 
+from django.conf import settings
 from django.http import HttpRequest
 from django.urls import reverse
 
@@ -36,3 +37,7 @@ def menu(request):
         NavItem(name="Docs", url_name="docs_home"),
     ]
     return {"nav": list(iter_nav(items, request))}
+
+
+def dev_users(request):
+    return {"dev_users": settings.DEV_USERS}

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -144,6 +144,7 @@ TEMPLATES = [
                 # "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "airlock.nav.menu",
+                "airlock.nav.dev_users",
             ],
             "builtins": [
                 "slippers.templatetags.slippers",  # required for assets library
@@ -299,6 +300,7 @@ AIRLOCK_API_ENDPOINT = os.environ.get(
 assert not AIRLOCK_API_ENDPOINT.endswith("/")
 
 AIRLOCK_API_TOKEN = os.environ.get("AIRLOCK_API_TOKEN")
+DEV_USERS = {}
 
 if AIRLOCK_API_TOKEN:  # pragma: no cover
     AIRLOCK_DEV_USERS_FILE = None
@@ -306,6 +308,9 @@ elif dev_user_file := os.environ.get("AIRLOCK_DEV_USERS_FILE"):  # pragma: nocov
     AIRLOCK_DEV_USERS_FILE = WORK_DIR / dev_user_file
     if AIRLOCK_DEV_USERS_FILE.exists():
         dev_users = json.loads(AIRLOCK_DEV_USERS_FILE.read_text())
+        DEV_USERS = {
+            username: details["token"] for username, details in dev_users.items()
+        }
         for dev_user in dev_users.values():
             workspace_keys = set(
                 sum(

--- a/airlock/templates/_includes/header.html
+++ b/airlock/templates/_includes/header.html
@@ -48,6 +48,43 @@
           </a>
         </li>
       {% else %}
+        {% if dev_users %}
+          <li>
+            <details-utils close-click-outside close-esc>
+              <details class="flex group">
+                <summary
+                  class="
+                         flex relative h-full items-center text-oxford transition-colors duration-200 rounded px-2 py-0 cursor-pointer
+                         hover:text-bn-strawberry-700
+                         focus:text-bn-strawberry-700 focus:outline-none focus:ring-2 focus:ring-oxford-500
+                        "
+                  data-testid="switch-user"
+                >
+                  Switch user
+                  <span class="opacity-75 ml-1">
+                    <img height="16" width="16" class="icon inline-block group-open:hidden" src="/static/icons/keyboard_arrow_down.svg" alt="">
+                    <img height="16" width="16" class="icon hidden group-open:inline-block" src="/static/icons/keyboard_arrow_up.svg" alt="">
+                  </span>
+                </summary>
+
+                <div class="absolute border-0 origin-top-right top-full mt-2 right-20 z-10 w-48 rounded-md shadow-lg overflow-hidden bg-white ring-1 ring-black ring-opacity-5 focus:outline-none text-sm">
+                  {% for username, token in dev_users.items %}
+                    <form
+                      {% if username == request.user.username %}style="background-color: var(--color-emerald-50);"{% endif %}
+                      class="border-t block px-4 py-2 text-oxford hover:text-bn-strawberry-700 hover:bg-oxford-50 focus:text-bn-strawberry-700 focus:outline-none focus:ring-2 focus:ring-oxford-500 focus:ring-inset w-full text-left"
+                      method="POST" action="{% url 'login' %}">
+                      {% csrf_token %}
+                      <input type="hidden" name="next" value="{{ request.path }}" />
+                      <input type="hidden" name="user" value="{{ username }}" />
+                      <input type="hidden" name="token" value="{{ token }}" />
+                      <button type="submit">{{ username }}</button>
+                    </form>
+                  {% endfor %}
+                </div>
+              </details>
+            </details-utils>
+          </li>
+        {% endif %}
         <li>
           <details-utils close-click-outside close-esc>
             <details class="flex group">
@@ -84,6 +121,8 @@
             </details>
           </details-utils>
         </li>
+
+
       {% endif %}
     </ul>
   </nav>

--- a/airlock/views/auth.py
+++ b/airlock/views/auth.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib import messages
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -25,6 +26,7 @@ def login(request):
         # If `user_data` is None then the form object will have the relevant errors
         if user_data is not None:
             request.session["user"] = user_data
+            messages.success(request, f"Logged in as {user_data['username']}")
             return redirect(next_url)
 
     return TemplateResponse(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import sys
@@ -93,4 +94,53 @@ def researcher_user(live_server, context):
             },
             "output_checker": False,
         },
+    )
+
+
+@pytest.fixture
+def dev_users(tmp_path, settings):
+    settings.AIRLOCK_DEV_USERS_FILE = tmp_path / "dev_users.json"
+    settings.AIRLOCK_DEV_USERS_FILE.write_text(
+        json.dumps(
+            {
+                "output_checker": {
+                    "token": "output_checker",
+                    "details": {
+                        "username": "output_checker",
+                        "fullname": "Output Checker",
+                        "output_checker": True,
+                        "staff": True,
+                        "workspaces": {},
+                    },
+                },
+                "output_checker_1": {
+                    "token": "output_checker_1",
+                    "details": {
+                        "username": "output_checker_1",
+                        "fullname": "Output Checker 1",
+                        "output_checker": True,
+                        "staff": True,
+                        "workspaces": {},
+                    },
+                },
+                "researcher": {
+                    "token": "researcher",
+                    "details": {
+                        "username": "researcher",
+                        "fullname": "Researcher",
+                        "output_checker": False,
+                        "staff": False,
+                        "workspaces": {
+                            "test-workspace": {
+                                "project_details": {
+                                    "name": "Project 1",
+                                    "ongoing": True,
+                                },
+                                "archived": False,
+                            }
+                        },
+                    },
+                },
+            }
+        )
     )

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -1,7 +1,5 @@
-import json
 import re
 
-import pytest
 from playwright.sync_api import expect
 
 from airlock.business_logic import RequestStatus, bll
@@ -10,55 +8,6 @@ from tests import factories
 
 
 admin_user = factories.create_user("admin", output_checker=True)
-
-
-@pytest.fixture
-def dev_users(tmp_path, settings):
-    settings.AIRLOCK_DEV_USERS_FILE = tmp_path / "dev_users.json"
-    settings.AIRLOCK_DEV_USERS_FILE.write_text(
-        json.dumps(
-            {
-                "output_checker": {
-                    "token": "output_checker",
-                    "details": {
-                        "username": "output_checker",
-                        "fullname": "Output Checker",
-                        "output_checker": True,
-                        "staff": True,
-                        "workspaces": {},
-                    },
-                },
-                "output_checker_1": {
-                    "token": "output_checker_1",
-                    "details": {
-                        "username": "output_checker_1",
-                        "fullname": "Output Checker 1",
-                        "output_checker": True,
-                        "staff": True,
-                        "workspaces": {},
-                    },
-                },
-                "researcher": {
-                    "token": "researcher",
-                    "details": {
-                        "username": "researcher",
-                        "fullname": "Researcher",
-                        "output_checker": False,
-                        "staff": False,
-                        "workspaces": {
-                            "test-workspace": {
-                                "project_details": {
-                                    "name": "Project 1",
-                                    "ongoing": True,
-                                },
-                                "archived": False,
-                            }
-                        },
-                    },
-                },
-            }
-        )
-    )
 
 
 def find_and_click(locator):


### PR DESCRIPTION
Gives us a menu option to switch between any of the available users in a `dev_users.json` file.

If `AIRLOCK_API_TOKEN` is set (i.e. in prod or prod-like envs - anything with a connected job-server), `AIRLOCK_DEV_USERS_FILE` is always None, there will be no DEV_USERS, and the menu item won't be visible.

No AIRLOCK_API_TOKEN in .env:
![Screenshot from 2024-07-12 15-17-26](https://github.com/user-attachments/assets/98ff08a3-a94a-4865-93b3-8620a4b47375)

With AIRLOCK_API_TOKEN in .env:
![image](https://github.com/user-attachments/assets/57bb186e-0de0-4af7-8204-cc0d6c62334e)
