### PR TITLE
Use three-way pill for file status

### DIFF
--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -92,28 +92,35 @@
               </button>
             </form>
           {% elif file_reset_review_url and file_reject_url %}
-            <form action="{{ file_reset_review_url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active" id="file-reset-button" type="submit">
-                Approve file
-              </button>
-            </form>
+            <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active" id="file-approve-button" disabled="true">
+              Approve file
+            </button>
           {% endif %}
 
           {% if file_reject_url %}
             <form action="{{ file_reject_url }}" method="POST">
               {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reject-button" type="submit">
+              <button aria-pressed="false" class="btn-group__btn" id="file-reject-button" type="submit">
                 Request changes
               </button>
             </form>
           {% elif file_reset_review_url and file_approve_url %}
+            <button aria-pressed="true" class="btn-group__btn btn-group__btn--active" id="file-reject-button" disabled="true">
+              Request changes
+            </button>
+          {% endif %}
+
+          {% if file_reset_review_url %}
             <form action="{{ file_reset_review_url }}" method="POST">
               {% csrf_token %}
-              <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" type="submit">
-                Request changes
+              <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reset-button" type="submit">
+                Undecided
               </button>
             </form>
+          {% elif file_approve_url and file_reject_url %}
+            <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
+              Undecided
+            </button>
           {% endif %}
         </div>
       {% endif %}

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -379,19 +379,23 @@ def test_e2e_release_files(
     expect(page.locator("#file-reject-button")).to_have_attribute(
         "aria-pressed", "false"
     )
+    expect(page.locator("#file-reset-button")).to_be_disabled()
     find_and_click(page.locator("#file-reject-button"))
-    expect(page.locator("#file-reset-button")).to_have_attribute("aria-pressed", "true")
+    expect(page.locator("#file-reject-button")).to_have_attribute(
+        "aria-pressed", "true"
+    )
+    expect(page.locator("#file-reset-button")).not_to_be_disabled()
 
     # output checker has now reviewed all output files
     expect(complete_review_button).to_be_visible()
     expect(complete_review_button).to_be_enabled()
 
     # Change our minds & remove the review
-    expect(page.locator("#file-reset-button")).to_have_attribute("aria-pressed", "true")
-    find_and_click(page.locator("#file-reset-button"))
-    expect(page.locator("#file-reject-button")).to_have_attribute(
+    expect(page.locator("#file-reset-button")).to_have_attribute(
         "aria-pressed", "false"
     )
+    find_and_click(page.locator("#file-reset-button"))
+    expect(page.locator("#file-reset-button")).to_have_attribute("aria-pressed", "true")
 
     # complete review button disabled again
     expect(complete_review_button).to_be_visible()
@@ -402,7 +406,9 @@ def test_e2e_release_files(
         "aria-pressed", "false"
     )
     find_and_click(page.locator("#file-approve-button"))
-    expect(page.locator("#file-reset-button")).to_have_attribute("aria-pressed", "true")
+    expect(page.locator("#file-approve-button")).to_have_attribute(
+        "aria-pressed", "true"
+    )
 
     # File is only approved once, so the release files button is still disabled
     expect(release_button).to_be_disabled()


### PR DESCRIPTION
This makes it more obvious how to reset a file's review status to "Undecided".

![Screenshot from 2024-07-12 17-52-26](https://github.com/user-attachments/assets/fd0bf10e-644d-4a85-ac4f-fdfbe4254cf7)
![Screenshot from 2024-07-12 17-52-32](https://github.com/user-attachments/assets/53427bf6-9535-48ab-8dde-5e85775a1ca4)
![Screenshot from 2024-07-12 17-52-39](https://github.com/user-attachments/assets/eb1be309-9f5a-4b58-b2aa-1532f8186841)




Closes #466