### PR TITLE
Hide required asterisk for comment field

### DIFF
--- a/airlock/templates/file_browser/group.html
+++ b/airlock/templates/file_browser/group.html
@@ -63,7 +63,7 @@
               {% /alert %}
             {% endif %}
 
-            {% form_textarea field=group_comment_form.comment placeholder=" " label="Add Comment" show_placeholder=True class="w-full max-w-lg" rows=6 required=True %}
+            {% form_textarea field=group_comment_form.comment placeholder=" " label="Add Comment" show_placeholder=True class="w-full max-w-lg" rows=6 required=False %}
             {% if group_comment_form.visibility.field.choices|length == 1 %}
               <input type="hidden" name="visibility" value="{{ group_comment_form.visibility.field.choices.0.0 }}"/>
             {% else %}


### PR DESCRIPTION
This removes the client side validation and means that if you click the comment button without entering any text, it'll hit the form validation. I think this is OK, since it shouldb't be that common to try to add comments without putting something in the box first.