### PR TITLE
Prevent extraneous alerts stacking up

### DIFF
--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -179,7 +179,13 @@ def request_view(request, request_id: str, path: str = ""):
         user_has_completed_review = False
         user_has_reviewed_all_files = False
 
-    if user_has_reviewed_all_files and not user_has_completed_review:
+    if (
+        user_has_reviewed_all_files
+        and not user_has_completed_review
+        # HTMX doesn't currently consume these messages so we shouldn't set them
+        # for HTMX requests
+        and not request.htmx
+    ):
         messages.success(
             request, "All files reviewed. Your review can now be completed."
         )


### PR DESCRIPTION
To reproduce the original issue:

 * As an output checker, approve/reject all files in a release request so that the confirmation message "All files reviewed. Your review can now be completed." is displayed.

 * In the left-hand tree view, click back and forward between two files which updates the page contents without reloading the page.

 * Do something to reload the page (pressing F5 will do).

 * Note the stack of confirmation messages, whose count corresponds to the number of times you clicked in the left-hand tree view.

To my mind it's a slightly unusual use of the messages framework to set messages repeatedly on GET, based on the current state of the system. Normally, messages are set in response the changes of state, usually via a POST. But in any case, preventing this messages being set when the page is requested via HTMX solves the immediate issue.

Closes #464