### PR TITLE
Show request status in request header

### DIFF
--- a/airlock/templates/_components/header.html
+++ b/airlock/templates/_components/header.html
@@ -1,6 +1,6 @@
 <header class="header">
   <h1 class="header__title">
-    {{ title }}
+    {{ title }} {% if context == "request" %}{% pill variant="info" text=release_request.status.name %}{% endif %}
   </h1>
 
   {% if context == "request" and workspace.get_url %}


### PR DESCRIPTION
Fixes #436 

Request status now shown in a pill in the header

![Screenshot from 2024-07-16 16-19-14](https://github.com/user-attachments/assets/8ebff382-c8a6-407f-a2da-99adb937f4ad)
