### PR TITLE
Fix indentation of files in tree view

### DIFF
--- a/airlock/static/assets/file_browser/tree.css
+++ b/airlock/static/assets/file_browser/tree.css
@@ -123,7 +123,7 @@
   background-size: 100%;
   filter: var(--icon-filter);
   height: 14px;
-  margin-left: 0.25rem;
+  margin-left: 1rem;
   width: 14px;
 }
 


### PR DESCRIPTION
Align file icons with folder icons at the same level

Before:
![Screenshot from 2024-07-16 17-06-13](https://github.com/user-attachments/assets/0a1c8d90-a48e-4806-9d6a-d407abdffde1)

After:
![Screenshot from 2024-07-16 17-05-35](https://github.com/user-attachments/assets/650e5952-d568-444a-af9b-4f8289cc642f)
