### PR TITLE
Alerts on the request pages when something needs to be actioned

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -141,6 +141,15 @@
         {% endif %}
       {% endif %}
     {% /airlock_header %}
+
+    {% if request_action_required %}
+      <div class="mt-4">
+        {% #alert variant="warning" title="Action required" dismissible=True %}
+          {{ request_action_required }}
+        {% /alert %}
+      </div>
+    {% endif %}
+
   {% else %}
     {% #airlock_header context=context current_request=current_request title=title workspace=workspace return_url=return_url %}
     {% /airlock_header %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -199,22 +199,6 @@ def request_view(request, request_id: str, path: str = ""):
         user_has_completed_review = False
         user_has_reviewed_all_files = False
 
-    if (
-        user_has_reviewed_all_files
-        and not user_has_completed_review
-        # Only show the reminder if the request is under review. A request
-        # could have been reviewed by 3 checkers, completed by 2 and returned.
-        # We don't want to show the message to the incomplete reviewer who can't
-        # act on it.
-        and release_request.is_under_review()
-        # HTMX doesn't currently consume these messages so we shouldn't set them
-        # for HTMX requests
-        and not request.htmx
-    ):
-        messages.success(
-            request, "All files reviewed. Your review can now be completed."
-        )
-
     request_submit_url = reverse(
         "request_submit",
         kwargs={"request_id": request_id},

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -268,6 +268,13 @@ def request_view(request, request_id: str, path: str = ""):
         request_action_required = (
             "You have reviewed all files. You can now complete your review."
         )
+    elif release_request.status.name == "REVIEWED" and release_request.user_can_review(
+        request.user
+    ):
+        if release_request.can_be_released():
+            request_action_required = "Two independent reviews have been completed. You can now return, reject or release this request."
+        else:
+            request_action_required = "Two independent reviews have been completed. You can now return or reject this request."
     else:
         request_action_required = None
 

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -260,6 +260,17 @@ def request_view(request, request_id: str, path: str = ""):
         else:
             file_reset_review_url = None
 
+    if (
+        release_request.is_under_review()
+        and user_has_reviewed_all_files
+        and not user_has_completed_review
+    ):
+        request_action_required = (
+            "You have reviewed all files. You can now complete your review."
+        )
+    else:
+        request_action_required = None
+
     context = {
         "workspace": bll.get_workspace(release_request.workspace, request.user),
         "release_request": release_request,
@@ -292,6 +303,7 @@ def request_view(request, request_id: str, path: str = ""):
         "can_comment": can_comment,
         "group_activity": group_activity,
         "show_c3": settings.SHOW_C3,
+        "request_action_required": request_action_required,
         # TODO, but for now stops template variable errors
         "multiselect_url": "",
         "code_url": code_url,


### PR DESCRIPTION
Adds a new component for showing an alert message when an action is required on a request.

Currently these are:
1) Output checker has reviewed all files and needs to complete their review
![Screenshot from 2024-07-17 10-58-01](https://github.com/user-attachments/assets/42692330-c193-47d8-90d0-015bb5996901)

2) Output checker completes the second review for a request and the request now needs to be progressed by returning, rejecting or releasing.

Releasing is available (all files approved twice):
![Screenshot from 2024-07-17 10-57-21](https://github.com/user-attachments/assets/fc82b695-6d60-49b1-84e6-e45401cb75a2)

Releasing not available (some files rejected by at one or both reviewers):
![Screenshot from 2024-07-17 11-35-16](https://github.com/user-attachments/assets/2e0d7915-970d-494b-b67a-e64e3b5e8302)

Fixes #503 