### PR TITLE
Handle invalid UTF-8 in plain text view

### DIFF
--- a/airlock/renderers.py
+++ b/airlock/renderers.py
@@ -53,12 +53,13 @@ class Renderer:
         if cache_id is None:
             cache_id = filesystem_key(stat)
 
+        if cls.is_text:
+            stream: IO[Any] = abspath.open("r", errors="replace")
+        else:
+            stream = abspath.open("rb")
+
         return cls(
-            stream=(
-                abspath.open("r", errors="replace")
-                if cls.is_text
-                else abspath.open("rb")
-            ),
+            stream=stream,
             file_cache_id=cache_id,
             last_modified=formatdate(stat.st_mtime, usegmt=True),
             filename=path.name,
@@ -68,12 +69,13 @@ class Renderer:
     def from_contents(
         cls, contents: bytes, relpath: UrlPath, cache_id: str
     ) -> Renderer:
+        if cls.is_text:
+            stream: IO[Any] = StringIO(contents.decode("utf8", errors="replace"))
+        else:
+            stream = BytesIO(contents)
+
         return cls(
-            stream=(
-                StringIO(contents.decode("utf8", errors="replace"))
-                if cls.is_text
-                else BytesIO(contents)
-            ),
+            stream=stream,
             file_cache_id=cache_id,
             filename=relpath.name,
         )

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -131,3 +131,15 @@ def test_csv_renderer_handles_uneven_columns(tmp_path):
     response.render()
     assert response.status_code == 200
     assert response.context_data["use_datatables"] is False
+
+
+def test_plaintext_renderer_handles_invalid_utf8(tmp_path):
+    invalid_file = tmp_path / "invalid.txt"
+    invalid_file.write_bytes(b"invalid \xf0\xa4\xad continuation byte")
+    relpath = invalid_file.relative_to(tmp_path)
+    Renderer = renderers.get_renderer(relpath, plaintext=True)
+    renderer = Renderer.from_file(invalid_file, relpath)
+    response = renderer.get_response()
+    response.render()
+    assert response.status_code == 200
+    assert "invalid � continuation byte" in response.rendered_content


### PR DESCRIPTION
This involves a bit of refactoring as there is now more than one argument to `open()` which we need to modify depending on whether we're in text or binary mode.

Closes #473