### PR TITLE
Reuse CSV datatable delayed loading for activity log

### DIFF
--- a/airlock/static/assets/datatable-loader.js
+++ b/airlock/static/assets/datatable-loader.js
@@ -3,8 +3,8 @@ const observer = new MutationObserver((mutations, obs) => {
     "button.datatable-sorter"
   );
   if (sorterButton) {
-    document.querySelector("#csvtable p.spinner").style.display = "none";
-    document.querySelector("#csvtable table.datatable").style.display = "table";
+    document.querySelector("#airlock-table p.spinner").style.display = "none";
+    document.querySelector("#airlock-table table.datatable").style.display = "table";
     obs.disconnect();
     clearTimeout();
     return;
@@ -25,8 +25,8 @@ setTimeout(() => {
     "button.datatable-sorter"
   );
   if (!sorterButton) {
-    document.querySelector("#csvtable p.spinner").style.display = "none";
-    document.querySelector("#csvtable table.datatable").style.display = "table";
+    document.querySelector("#airlock-table p.spinner").style.display = "none";
+    document.querySelector("#airlock-table table.datatable").style.display = "table";
     const sortIcons = document.getElementsByClassName("sort-icon");
     for (let i = 0; i < sortIcons.length; i++) {
       sortIcons.item(i).style.display = "none";;

--- a/airlock/templates/activity.html
+++ b/airlock/templates/activity.html
@@ -6,33 +6,36 @@
 
 {% #card title="Recent activity" %}
   {% if activity %}
-    <table class="datatable" id="customTable">
-      <thead>
-        <tr>
-          <th><div class="flex flex-row gap-2">Time{% datatable_sort_icon %}</div></th>
-          <th><div class="flex flex-row gap-2">User{% datatable_sort_icon %}</div></th>
-          <th><div class="flex flex-row gap-2">Action{% datatable_sort_icon %}</div></th>
-          <th><div class="flex flex-row gap-2">Details{% datatable_sort_icon %}</div></th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for log in activity %}
+    <div id="airlock-table">
+      <p class="spinner">Loading table data...</p>
+      <table class="datatable" style="display: none"  id="customTable">
+        <thead>
           <tr>
-            <td>{{ log.created_at|date:'Y-m-d H:i' }}</td>
-            <td>{{ log.user }}</td>
-            <td>{{ log.description }}</td>
-            <td>
-              <ul>
-                {% if log.path %}<li><b>path:</b> {{ log.path }}</li>{% endif %}
-                {% for k,v in log.extra.items %}
-                  <li><b>{{ k }}:</b> {{ v }}</li>
-                {% endfor %}
-              </ul>
-            </td>
+            <th><div class="flex flex-row gap-2">Time{% datatable_sort_icon %}</div></th>
+            <th><div class="flex flex-row gap-2">User{% datatable_sort_icon %}</div></th>
+            <th><div class="flex flex-row gap-2">Action{% datatable_sort_icon %}</div></th>
+            <th><div class="flex flex-row gap-2">Details{% datatable_sort_icon %}</div></th>
           </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {% for log in activity %}
+            <tr>
+              <td>{{ log.created_at|date:'Y-m-d H:i' }}</td>
+              <td>{{ log.user }}</td>
+              <td>{{ log.description }}</td>
+              <td>
+                <ul>
+                  {% if log.path %}<li><b>path:</b> {{ log.path }}</li>{% endif %}
+                  {% for k,v in log.extra.items %}
+                    <li><b>{{ k }}:</b> {{ v }}</li>
+                  {% endfor %}
+                </ul>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
   {% else %}
     {% #list_group %}
       {% list_group_empty title="No activity" description="There has been no recent activity on this workspace" %}
@@ -42,3 +45,4 @@
 
 {% vite_asset "assets/src/scripts/components.js" %}
 <script defer src="{% static 'assets/activity.js' %}"></script>
+<script defer src="{% static 'assets/datatable-loader.js' %}"></script>

--- a/airlock/templates/file_browser/csv.html
+++ b/airlock/templates/file_browser/csv.html
@@ -14,7 +14,7 @@
 
   <body>
 
-    <div id="csvtable">
+    <div id="airlock-table">
       {% if use_datatables %}
         <p class="spinner">Loading table data...</p>
         <table class="datatable" style="display: none" id="customTable">
@@ -48,7 +48,7 @@
 
   </div>
 
-  <script src="{% static 'assets/file_browser/csv.js' %}"></script>
+  <script src="{% static 'assets/datatable-loader.js' %}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Makes the datatable loading script for hiding the raw table before a datatable loads more generic, and reuse it for the activity log datatable.

Fixes #478 