### PR TITLE
Refactor factories to use BLL for all state manipulation, rather than the DAL.

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1901,7 +1901,7 @@ class BusinessLogicLayer:
         This currently uses the old api, and is shared amongst provider
         implementations, but that will likely change in future.
 
-        Passing upload=False will just performa the DAL actions, but not
+        Passing upload=False will just perform the DAL actions, but not
         actually attempt to upload the files. This defaults to True, and is
         primarily used for testing.
         """

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1895,11 +1895,15 @@ class BusinessLogicLayer:
         release_request.set_filegroups_from_dict(filegroup_data)
         return release_request
 
-    def release_files(self, release_request: ReleaseRequest, user: User):
+    def release_files(self, release_request: ReleaseRequest, user: User, upload=True):
         """Release all files from a release_request to job-server.
 
         This currently uses the old api, and is shared amongst provider
         implementations, but that will likely change in future.
+
+        Passing upload=False will just performa the DAL actions, but not
+        actually attempt to upload the files. This defaults to True, and is
+        primarily used for testing.
         """
 
         # we check this is valid status transition *before* releasing the files
@@ -1909,12 +1913,16 @@ class BusinessLogicLayer:
         self.validate_file_types(file_paths)
 
         filelist = old_api.create_filelist(file_paths, release_request)
-        jobserver_release_id = old_api.create_release(
-            release_request.workspace,
-            release_request.id,
-            filelist.json(),
-            user.username,
-        )
+
+        if upload:
+            jobserver_release_id = old_api.create_release(
+                release_request.workspace,
+                release_request.id,
+                filelist.json(),
+                user.username,
+            )
+        else:
+            jobserver_release_id = None
 
         for relpath, abspath in file_paths:
             audit = AuditEvent.from_request(
@@ -1924,7 +1932,11 @@ class BusinessLogicLayer:
                 path=relpath,
             )
             self._dal.release_file(release_request.id, relpath, user.username, audit)
-            old_api.upload_file(jobserver_release_id, relpath, abspath, user.username)
+
+            if upload:
+                old_api.upload_file(
+                    jobserver_release_id, relpath, abspath, user.username
+                )
 
         self.set_status(release_request, RequestStatus.RELEASED, user)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -496,7 +496,7 @@ def review_file(request, relpath, status, *users):
 class TestRequestFile:
     """Placeholder containing file metadata.
 
-    Allows us to set up file states declaratively. Use the add() and vote()
+    Allows us to set up file states declaratively. The add() and vote()
     methods can be called with a request in the right state.
     """
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -474,8 +474,6 @@ def review_file(request, relpath, status, *users):
 
     relpath = UrlPath(relpath)
     for user in users:
-        # use the DAL directly means we can add reviews regardless of request
-        # state, which is very useful in test setup.
         if status == RequestFileVote.APPROVED:
             bll.approve_file(
                 request,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -402,16 +402,11 @@ def create_request_at_status(
         return request
 
     if status == RequestStatus.RELEASED:
-        for relpath in request.output_files():
-            bll._dal.release_file(
-                request.id,
-                relpath,
-                checker.username,
-                audit=create_audit_event(
-                    AuditEventType.REQUEST_FILE_APPROVE, user=checker.username
-                ),
-            )
-        bll.set_status(request, RequestStatus.RELEASED, checker)
+        bll.release_files(
+            request,
+            user=checker,
+            upload=False,
+        )
         return refresh_release_request(request)
 
     raise Exception(f"invalid state: {status}")  # pragma: no cover

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -411,14 +411,14 @@ def request_file(
 ):
     def add_file(request):
         request = refresh_release_request(request)
-        write_request_file(
+        add_request_file(
             request, group, path, approved=approved, rejected=rejected, **kwargs
         )
 
     return add_file
 
 
-def write_request_file(
+def add_request_file(
     request,
     group,
     path,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,6 +12,7 @@ from airlock.business_logic import (
     AuditEvent,
     AuditEventType,
     CodeRepo,
+    ReleaseRequest,
     RequestFile,
     RequestFileType,
     RequestFileVote,
@@ -429,7 +430,8 @@ def add_request_file(
     workspace=None,
     rejected=False,
     checkers=None,
-):
+) -> ReleaseRequest:
+    request = refresh_release_request(request)
     # if ensure_workspace is passed a string, it will always create a
     # new workspace. Optionally pass a workspace instance, which will
     # ensure that adding a file uses the commit from the workspace's
@@ -453,6 +455,8 @@ def add_request_file(
         review_file(request, path, RequestFileVote.APPROVED, *checkers)
     elif rejected:
         review_file(request, path, RequestFileVote.REJECTED, *checkers)
+
+    return refresh_release_request(request)
 
 
 def create_request_file_bad_path(request_file, bad_path):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -137,13 +137,15 @@ def update_manifest(workspace: Workspace | str, files=None):
         ]
 
     for i, f in enumerate(files):
-        manifest["outputs"][str(f)] = get_output_metadata(
+        name = str(f)
+        current = manifest.get("outputs", {}).get(name, {})
+        manifest["outputs"][name] = get_output_metadata(
             root / f,
             level="moderately_senstive",
             job_id=f"job_{i}",
             job_request=f"job_request_{i}",
             action=f"action_{i}",
-            commit=commit,
+            commit=current.get("commit", commit),
             repo=repo,
             excluded=False,
         )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,6 +3,8 @@ import json
 import subprocess
 import tempfile
 import time
+import typing
+from dataclasses import dataclass, field
 from hashlib import file_digest
 from pathlib import Path
 
@@ -10,7 +12,6 @@ from django.conf import settings
 
 from airlock.business_logic import (
     AuditEvent,
-    AuditEventType,
     CodeRepo,
     ReleaseRequest,
     RequestFile,
@@ -265,7 +266,7 @@ def create_request_at_status(
     workspace,
     status,
     author=None,
-    files=[],
+    files=None,
     checker=None,
     withdrawn_after=None,
     **kwargs,
@@ -273,8 +274,8 @@ def create_request_at_status(
     """
     Create a valid request at the given status.
 
-    Files must be provided for any status that needs them, in the appropriate reviewed
-    state (e.g. an approved/released status requires at least one fully approved output file).
+    Files must be provided for any status except PENDING. To move to
+    PARTIALLY_REVIEWED and beyond, you will also need to approve or reject.
 
     Files are provided using a factory method for creating them. e.g.
 
@@ -324,17 +325,18 @@ def create_request_at_status(
     )
 
     # add all files
-    for add_file in files:
-        add_file(request)
-
-    request = refresh_release_request(request)
-
-    # if we add files, we should add context & controls
     if files:
+        for testfile in files:
+            testfile.add(request)
+
+        request = refresh_release_request(request)
+
+        # if we add files, we should add context & controls
         for filegroup in request.filegroups:
             dummy_context = "This is some testing context"
             dummy_controls = "I got rid of all the small numbers"
             bll.group_edit(request, filegroup, dummy_context, dummy_controls, author)
+
         request = refresh_release_request(request)
 
     if status == RequestStatus.PENDING:
@@ -346,6 +348,12 @@ def create_request_at_status(
 
     bll.submit_request(request, author)
     request = refresh_release_request(request)
+
+    if files:
+        # apply votes to files.
+        for testfile in files:
+            testfile.vote(request)
+        request = refresh_release_request(request)
 
     if status == RequestStatus.SUBMITTED:
         return request
@@ -409,18 +417,6 @@ def create_request_at_status(
     raise Exception(f"invalid state: {status}")  # pragma: no cover
 
 
-def request_file(
-    group="group", path="test/file.txt", approved=False, rejected=False, **kwargs
-):
-    def add_file(request):
-        request = refresh_release_request(request)
-        add_request_file(
-            request, group, path, approved=approved, rejected=rejected, **kwargs
-        )
-
-    return add_file
-
-
 def add_request_file(
     request,
     group,
@@ -428,10 +424,7 @@ def add_request_file(
     contents="",
     user=None,
     filetype=RequestFileType.OUTPUT,
-    approved=False,
     workspace=None,
-    rejected=False,
-    checkers=None,
 ) -> ReleaseRequest:
     request = refresh_release_request(request)
     # if ensure_workspace is passed a string, it will always create a
@@ -448,15 +441,9 @@ def add_request_file(
     if user is None:  # pragma: nocover
         user = create_user(request.author, workspaces=[workspace.name])
 
-    checkers = checkers or get_default_output_checkers()
-
     bll.add_file_to_request(
         request, relpath=path, user=user, group_name=group, filetype=filetype
     )
-    if approved:
-        review_file(request, path, RequestFileVote.APPROVED, *checkers)
-    elif rejected:
-        review_file(request, path, RequestFileVote.REJECTED, *checkers)
 
     return refresh_release_request(request)
 
@@ -495,25 +482,87 @@ def review_file(request, relpath, status, *users):
         # use the DAL directly means we can add reviews regardless of request
         # state, which is very useful in test setup.
         if status == RequestFileVote.APPROVED:
-            bll._dal.approve_file(
+            bll.approve_file(
                 request,
-                relpath=relpath,
-                username=user.username,
-                audit=create_audit_event(
-                    AuditEventType.REQUEST_FILE_APPROVE, user=user.username
-                ),
+                request.get_request_file_from_output_path(relpath),
+                user=user,
             )
         elif status == RequestFileVote.REJECTED:
-            bll._dal.reject_file(
+            bll.reject_file(
                 request,
-                relpath=relpath,
-                username=user.username,
-                audit=create_audit_event(
-                    AuditEventType.REQUEST_FILE_REJECT, user=user.username
-                ),
+                request.get_request_file_from_output_path(relpath),
+                user=user,
             )
         else:
             raise AssertionError(f"unrecognised status; {status}")  # pragma: no cover
+
+
+@dataclass
+class TestRequestFile:
+    """Placeholder containing file metadata.
+
+    Allows us to set up file states declaratively. Use the add() and vote()
+    methods can be called with a request in the right state.
+    """
+
+    group: str
+    path: UrlPath | str
+    user: User
+    contents: str = ""
+    filetype: RequestFileType = RequestFileType.OUTPUT
+    workspace: str | None = None
+
+    # voting
+    approved: bool = False
+    rejected: bool = False
+    checkers: typing.Sequence[User] = field(default_factory=list)
+
+    def add(self, request):
+        request = refresh_release_request(request)
+        add_request_file(
+            request,
+            group=self.group,
+            path=self.path,
+            contents=self.contents,
+            user=self.user,
+            filetype=self.filetype,
+            workspace=self.workspace,
+        )
+
+    def vote(self, request: ReleaseRequest):
+        if self.approved:
+            review_file(request, self.path, RequestFileVote.APPROVED, *self.checkers)
+        elif self.rejected:
+            review_file(request, self.path, RequestFileVote.REJECTED, *self.checkers)
+
+
+def request_file(
+    group="group",
+    path="test/file.txt",
+    contents="",
+    filetype=RequestFileType.OUTPUT,
+    user=None,
+    approved=False,
+    rejected=False,
+    checkers=None,
+    **kwargs,
+) -> TestRequestFile:
+    """Helper function to define some test file metadata
+
+    At the right points, this metadata will be used to populate and act on
+    a request.
+    """
+    return TestRequestFile(
+        group=group,
+        path=path,
+        contents=contents,
+        filetype=filetype,
+        user=user,
+        # voting
+        approved=approved,
+        rejected=rejected,
+        checkers=checkers or [],
+    )
 
 
 def complete_independent_review(request, *users):

--- a/tests/integration/management/commands/test_backpopulate_file_manifest_data.py
+++ b/tests/integration/management/commands/test_backpopulate_file_manifest_data.py
@@ -9,7 +9,7 @@ from tests import factories
 def test_command(bll):
     workspace = factories.create_workspace("workspace")
     release_request = factories.create_release_request(workspace)
-    factories.write_request_file(
+    factories.add_request_file(
         release_request, "group", "subdir/file.txt", "some content"
     )
 

--- a/tests/integration/test_old_api.py
+++ b/tests/integration/test_old_api.py
@@ -50,7 +50,7 @@ def test_old_api_create_release_with_error(responses, caplog):
 def test_old_api_upload_file(responses):
     release_request = factories.create_release_request("workspace", id="request-id")
     relpath = Path("test/file.txt")
-    factories.write_request_file(release_request, "group", relpath, "test")
+    factories.add_request_file(release_request, "group", relpath, "test")
     abspath = release_request.abspath("group" / relpath)
 
     responses.post(
@@ -68,7 +68,7 @@ def test_old_api_upload_file(responses):
 def test_old_api_upload_file_error(responses, caplog):
     release_request = factories.create_release_request("workspace", id="request-id")
     relpath = Path("test/file.txt")
-    factories.write_request_file(release_request, "group", relpath, "test")
+    factories.add_request_file(release_request, "group", relpath, "test")
     abspath = release_request.abspath("group" / relpath)
 
     responses.post(

--- a/tests/integration/test_old_api.py
+++ b/tests/integration/test_old_api.py
@@ -50,7 +50,9 @@ def test_old_api_create_release_with_error(responses, caplog):
 def test_old_api_upload_file(responses):
     release_request = factories.create_release_request("workspace", id="request-id")
     relpath = Path("test/file.txt")
-    factories.add_request_file(release_request, "group", relpath, "test")
+    release_request = factories.add_request_file(
+        release_request, "group", relpath, "test"
+    )
     abspath = release_request.abspath("group" / relpath)
 
     responses.post(
@@ -68,7 +70,9 @@ def test_old_api_upload_file(responses):
 def test_old_api_upload_file_error(responses, caplog):
     release_request = factories.create_release_request("workspace", id="request-id")
     relpath = Path("test/file.txt")
-    factories.add_request_file(release_request, "group", relpath, "test")
+    release_request = factories.add_request_file(
+        release_request, "group", relpath, "test"
+    )
     abspath = release_request.abspath("group" / relpath)
 
     responses.post(

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -130,7 +130,7 @@ def test_request_view_with_directory(airlock_client):
 def test_request_view_with_file(airlock_client, filetype):
     release_request = factories.create_release_request("workspace")
     airlock_client.login(output_checker=True)
-    factories.add_request_file(
+    release_request = factories.add_request_file(
         release_request, "group", "file.txt", "foobar", filetype=filetype
     )
     response = airlock_client.get(f"/requests/view/{release_request.id}/group/file.txt")
@@ -145,7 +145,9 @@ def test_request_view_with_file(airlock_client, filetype):
 def test_request_view_with_file_htmx(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace")
-    factories.add_request_file(release_request, "group", "file.txt", "foobar")
+    release_request = factories.add_request_file(
+        release_request, "group", "file.txt", "foobar"
+    )
     response = airlock_client.get(
         f"/requests/view/{release_request.id}/group/file.txt",
         headers={"HX-Request": "true"},

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -29,7 +29,7 @@ def test_request_index_no_user(airlock_client):
 def test_request_view_index(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace", airlock_client.user)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
     response = airlock_client.get(f"/requests/view/{release_request.id}/")
     assert "group" in response.rendered_content
 
@@ -116,7 +116,7 @@ def test_request_view_root_group(airlock_client, settings):
 def test_request_view_with_directory(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace")
-    factories.write_request_file(release_request, "group", "some_dir/file.txt")
+    factories.add_request_file(release_request, "group", "some_dir/file.txt")
     response = airlock_client.get(
         f"/requests/view/{release_request.id}/group/some_dir/"
     )
@@ -130,7 +130,7 @@ def test_request_view_with_directory(airlock_client):
 def test_request_view_with_file(airlock_client, filetype):
     release_request = factories.create_release_request("workspace")
     airlock_client.login(output_checker=True)
-    factories.write_request_file(
+    factories.add_request_file(
         release_request, "group", "file.txt", "foobar", filetype=filetype
     )
     response = airlock_client.get(f"/requests/view/{release_request.id}/group/file.txt")
@@ -145,7 +145,7 @@ def test_request_view_with_file(airlock_client, filetype):
 def test_request_view_with_file_htmx(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace")
-    factories.write_request_file(release_request, "group", "file.txt", "foobar")
+    factories.add_request_file(release_request, "group", "file.txt", "foobar")
     response = airlock_client.get(
         f"/requests/view/{release_request.id}/group/file.txt",
         headers={"HX-Request": "true"},
@@ -365,9 +365,7 @@ def test_request_view_404_with_files(airlock_client):
 def test_request_view_redirects_to_directory(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace")
-    factories.write_request_file(
-        release_request, "group", "some_dir/file.txt", "foobar"
-    )
+    factories.add_request_file(release_request, "group", "some_dir/file.txt", "foobar")
 
     # test for group
     response = airlock_client.get(f"/requests/view/{release_request.id}/group")
@@ -386,7 +384,7 @@ def test_request_view_redirects_to_directory(airlock_client):
 def test_request_view_redirects_to_file(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace")
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
     response = airlock_client.get(
         f"/requests/view/{release_request.id}/group/file.txt/"
     )
@@ -400,9 +398,7 @@ def test_request_view_redirects_to_file(airlock_client):
 def test_request_contents_file(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace", id="id")
-    factories.write_request_file(
-        release_request, "default", "file.txt", contents="test"
-    )
+    factories.add_request_file(release_request, "default", "file.txt", contents="test")
     response = airlock_client.get("/requests/content/id/default/file.txt")
     assert response.status_code == 200
     assert response.content == b'<pre class="txt">\ntest\n</pre>\n'
@@ -418,7 +414,7 @@ def test_request_contents_file(airlock_client):
 def test_request_contents_dir(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace", id="id")
-    factories.write_request_file(
+    factories.add_request_file(
         release_request, "default", "foo/file.txt", contents="test"
     )
     response = airlock_client.get("/requests/content/id/default/foo")
@@ -428,7 +424,7 @@ def test_request_contents_dir(airlock_client):
 def test_request_contents_file_not_exists(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace", id="id")
-    factories.write_request_file(
+    factories.add_request_file(
         release_request, "default", "foo/file.txt", contents="test"
     )
     response = airlock_client.get("/requests/content/id/default/notexists.txt")
@@ -438,7 +434,7 @@ def test_request_contents_file_not_exists(airlock_client):
 def test_request_contents_group_not_exists(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_release_request("workspace", id="id")
-    factories.write_request_file(
+    factories.add_request_file(
         release_request, "default", "foo/file.txt", contents="test"
     )
     response = airlock_client.get("/requests/content/id/notexist/")
@@ -451,9 +447,7 @@ def test_request_download_file(airlock_client):
     release_request = factories.create_release_request(
         "workspace", id="id", user=author
     )
-    factories.write_request_file(
-        release_request, "default", "file.txt", contents="test"
-    )
+    factories.add_request_file(release_request, "default", "file.txt", contents="test")
     response = airlock_client.get("/requests/content/id/default/file.txt?download")
     assert response.status_code == 200
     assert response.as_attachment
@@ -533,7 +527,7 @@ def test_request_download_file_permissions(
     release_request = factories.create_release_request(
         "workspace", id="id", user=author
     )
-    factories.write_request_file(
+    factories.add_request_file(
         release_request, "default", "file.txt", contents="test", user=author
     )
     response = airlock_client.get("/requests/content/id/default/file.txt?download")
@@ -604,7 +598,7 @@ def test_request_submit_author(airlock_client):
     release_request = factories.create_release_request(
         "test1", user=airlock_client.user
     )
-    factories.write_request_file(release_request, "group", "path/test.txt")
+    factories.add_request_file(release_request, "group", "path/test.txt")
     bll.group_edit(
         release_request, "group", "my context", "my controls", airlock_client.user
     )
@@ -622,7 +616,7 @@ def test_request_submit_not_author(airlock_client):
     release_request = factories.create_release_request(
         "test1", user=other_author, status=RequestStatus.PENDING
     )
-    factories.write_request_file(release_request, "group", "path/test.txt")
+    factories.add_request_file(release_request, "group", "path/test.txt")
     bll.group_edit(release_request, "group", "my context", "my controls", other_author)
 
     response = airlock_client.post(f"/requests/submit/{release_request.id}")
@@ -637,7 +631,7 @@ def test_request_submit_missing_context_controls(airlock_client):
     release_request = factories.create_release_request(
         "test1", user=airlock_client.user
     )
-    factories.write_request_file(release_request, "group", "path/test.txt")
+    factories.add_request_file(release_request, "group", "path/test.txt")
 
     response = airlock_client.post(f"/requests/submit/{release_request.id}")
 
@@ -652,7 +646,7 @@ def test_request_withdraw_author(airlock_client):
     release_request = factories.create_release_request(
         "test1", user=airlock_client.user
     )
-    factories.write_request_file(release_request, "group", "path/test.txt")
+    factories.add_request_file(release_request, "group", "path/test.txt")
 
     response = airlock_client.post(f"/requests/withdraw/{release_request.id}")
 
@@ -667,7 +661,7 @@ def test_request_withdraw_not_author(airlock_client):
     release_request = factories.create_release_request(
         "test1", user=other_author, status=RequestStatus.PENDING
     )
-    factories.write_request_file(release_request, "group", "path/test.txt")
+    factories.add_request_file(release_request, "group", "path/test.txt")
 
     response = airlock_client.post(f"/requests/withdraw/{release_request.id}")
 
@@ -814,12 +808,12 @@ def test_requests_for_workspace(airlock_client):
     release_request1 = factories.create_release_request(
         "test1", user=author1, status=RequestStatus.PENDING
     )
-    factories.write_request_file(release_request1, "group", "path/test.txt")
+    factories.add_request_file(release_request1, "group", "path/test.txt")
 
     release_request2 = factories.create_release_request(
         "test1", user=author2, status=RequestStatus.PENDING
     )
-    factories.write_request_file(release_request2, "group", "path/test2.txt")
+    factories.add_request_file(release_request2, "group", "path/test2.txt")
 
     response = airlock_client.post("/requests/workspace/test1")
 
@@ -1118,7 +1112,7 @@ def test_file_withdraw_file_not_author(airlock_client):
     release_request = factories.create_release_request(
         "test1",
     )
-    factories.write_request_file(release_request, "group", "path/test.txt")
+    factories.add_request_file(release_request, "group", "path/test.txt")
 
     airlock_client.login(workspaces=["test1"])
     response = airlock_client.post(
@@ -1399,7 +1393,7 @@ def test_group_edit_success(airlock_client):
     release_request = factories.create_release_request(
         "workspace", user=airlock_client.user
     )
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     response = airlock_client.post(
         f"/requests/edit/{release_request.id}/group",
@@ -1426,7 +1420,7 @@ def test_group_edit_no_change(airlock_client, bll):
     release_request = factories.create_release_request(
         "workspace", user=airlock_client.user
     )
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
     bll.group_edit(
         release_request,
         "group",
@@ -1459,7 +1453,7 @@ def test_group_edit_bad_user(airlock_client):
     other = factories.create_user("other", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(other)
 
@@ -1479,7 +1473,7 @@ def test_group_edit_bad_group(airlock_client):
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(author)
 
@@ -1510,7 +1504,7 @@ def test_group_comment_create_success(
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     user = factories.create_user(
         output_checker=output_checker, workspaces=["workspace"]
@@ -1542,7 +1536,7 @@ def test_group_comment_create_bad_user(airlock_client):
     other = factories.create_user("other", ["other"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(other)
 
@@ -1559,7 +1553,7 @@ def test_group_comment_create_bad_form(airlock_client):
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(author)
 
@@ -1579,7 +1573,7 @@ def test_group_comment_create_bad_group(airlock_client):
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(author)
 
@@ -1596,7 +1590,7 @@ def test_group_comment_delete(airlock_client):
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(author)
     airlock_client.post(
@@ -1632,7 +1626,7 @@ def test_group_comment_delete_bad_form(airlock_client):
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(author)
     airlock_client.post(
@@ -1664,7 +1658,7 @@ def test_group_comment_delete_bad_group(airlock_client):
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(author)
     airlock_client.post(
@@ -1696,7 +1690,7 @@ def test_group_comment_delete_missing_comment(airlock_client):
     author = factories.create_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(release_request, "group", "file.txt")
+    factories.add_request_file(release_request, "group", "file.txt")
 
     airlock_client.login_with_user(author)
     airlock_client.post(

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -533,7 +533,7 @@ def test_workspace_multiselect_add_files_one_valid(airlock_client, bll):
     release_request = factories.create_release_request(
         workspace, user=airlock_client.user
     )
-    factories.write_request_file(release_request, "group1", "test/path1.txt")
+    factories.add_request_file(release_request, "group1", "test/path1.txt")
 
     response = airlock_client.post(
         "/workspaces/multiselect/test1",
@@ -562,8 +562,8 @@ def test_workspace_multiselect_add_files_none_valid(airlock_client, bll):
     release_request = factories.create_release_request(
         workspace, user=airlock_client.user
     )
-    factories.write_request_file(release_request, "group1", "test/path1.txt")
-    factories.write_request_file(release_request, "group1", "test/path2.txt")
+    factories.add_request_file(release_request, "group1", "test/path1.txt")
+    factories.add_request_file(release_request, "group1", "test/path2.txt")
 
     response = airlock_client.post(
         "/workspaces/multiselect/test1",

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -229,7 +229,7 @@ def test_workspace_get_workspace_file_status(bll):
     workspace = bll.get_workspace("workspace", user)
     assert workspace.get_workspace_file_status(path) == WorkspaceFileStatus.UNRELEASED
 
-    factories.write_request_file(release_request, "group", path)
+    factories.add_request_file(release_request, "group", path)
     # refresh workspace
     workspace = bll.get_workspace("workspace", user)
     assert workspace.get_workspace_file_status(path) == WorkspaceFileStatus.UNDER_REVIEW
@@ -372,7 +372,7 @@ def test_request_returned_author_get_workspace_file_status(bll):
 
 def test_request_container(mock_notifications):
     release_request = factories.create_release_request("workspace", id="id")
-    factories.write_request_file(release_request, "group", "bar.html")
+    factories.add_request_file(release_request, "group", "bar.html")
 
     assert release_request.root() == settings.REQUEST_DIR / "workspace/id"
     assert release_request.get_id() == "id"
@@ -1357,9 +1357,7 @@ def test_notification_error(bll, notifications_stubber, caplog):
     )
     author = factories.create_user("author", ["workspace"], False)
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(
-        release_request, "group", "test/file.txt", approved=True
-    )
+    factories.add_request_file(release_request, "group", "test/file.txt", approved=True)
     bll.group_edit(release_request, "group", "foo", "bar", author)
     release_request = factories.refresh_release_request(release_request)
     bll.set_status(release_request, RequestStatus.SUBMITTED, author)
@@ -1447,7 +1445,7 @@ def test_submit_request(bll, mock_notifications):
     release_request = factories.create_release_request(
         "workspace", user=author, status=RequestStatus.PENDING
     )
-    factories.write_request_file(release_request, "group", "test/file.txt")
+    factories.add_request_file(release_request, "group", "test/file.txt")
     bll.group_edit(release_request, "group", "foo", "bar", author)
     release_request = bll.get_release_request(release_request.id, author)
     bll.submit_request(release_request, author)
@@ -2982,7 +2980,7 @@ def test_dal_methods_have_audit_event_parameter():
 def test_group_edit_author(bll):
     author = factories.create_user("author", ["workspace"], False)
     release_request = factories.create_release_request("workspace", user=author)
-    factories.write_request_file(
+    factories.add_request_file(
         release_request,
         "group",
         "test/file.txt",

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -622,18 +622,6 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
     )
 
     notification_responses = parse_notification_responses(mock_notifications)
-    # Notifications expected for:
-    # - set status to submitted
-    # - set status to partially reviewed
-    # - set status to reviewed
-    # - set status to returned
-    # - set status to submitted
-    # - set status to partially reviewed
-    # - set status to reviewed
-    # - set status to returned
-    # - set status to approved
-    # - set status to released
-    # (Note: files are added to the request when it is in pending status, so no notifications sent.)
     assert notification_responses["count"] == 9
     request_json = notification_responses["request_json"]
     expected_notifications = [

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -372,7 +372,7 @@ def test_request_returned_author_get_workspace_file_status(bll):
 
 def test_request_container(mock_notifications):
     release_request = factories.create_release_request("workspace", id="id")
-    factories.add_request_file(release_request, "group", "bar.html")
+    release_request = factories.add_request_file(release_request, "group", "bar.html")
 
     assert release_request.root() == settings.REQUEST_DIR / "workspace/id"
     assert release_request.get_id() == "id"

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -656,9 +656,9 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
         AuditEventType.REQUEST_FILE_APPROVE,
         AuditEventType.REQUEST_REVIEW,
         AuditEventType.REQUEST_REVIEW,
-        # return reqjest
+        # return request
         AuditEventType.REQUEST_RETURN,
-        # withdraw an resubmitt
+        # withdraw and resubmit
         AuditEventType.REQUEST_FILE_WITHDRAW,
         AuditEventType.REQUEST_SUBMIT,
         # re-review

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -36,9 +36,9 @@ def workspace():
 @pytest.fixture
 def release_request(workspace):
     rr = factories.create_release_request(workspace)
-    factories.write_request_file(rr, "group1", "some_dir/file_a.txt")
-    factories.write_request_file(rr, "group1", "some_dir/file_c.txt")
-    factories.write_request_file(rr, "group2", "some_dir/file_b.txt")
+    factories.add_request_file(rr, "group1", "some_dir/file_a.txt")
+    factories.add_request_file(rr, "group1", "some_dir/file_c.txt")
+    factories.add_request_file(rr, "group2", "some_dir/file_b.txt")
     return factories.refresh_release_request(rr)
 
 

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -63,7 +63,7 @@ def test_renderers_get_renderer_request(
     grouppath = "group" / filepath
     request = factories.create_release_request("workspace")
     # use a csv as test data, it works for other types too
-    factories.write_request_file(request, "group", filepath, "a,b,c\n1,2,3")
+    factories.add_request_file(request, "group", filepath, "a,b,c\n1,2,3")
 
     time = 1709652904  # date this test was written
     abspath = request.abspath(grouppath)

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -63,7 +63,7 @@ def test_renderers_get_renderer_request(
     grouppath = "group" / filepath
     request = factories.create_release_request("workspace")
     # use a csv as test data, it works for other types too
-    factories.add_request_file(request, "group", filepath, "a,b,c\n1,2,3")
+    request = factories.add_request_file(request, "group", filepath, "a,b,c\n1,2,3")
 
     time = 1709652904  # date this test was written
     abspath = request.abspath(grouppath)


### PR DESCRIPTION
In a few places, we use the DAL directly from the test factories to manipulate state. This is convenient, but has two drawbacks:

1) It potentially allows invalid states to be created
2) It requires duplicating some logic, particularly the creation of event logs.

This change moves to using only BLL methods to manipulate state. This requires us to respect some limitations that previously we had ignored. Most of that is handled in the test factories, but in one case a test needed a fair bit more setup to get into the right state.

Note that we still use the dal in a couple of places in the test factories, for creating filegroups and audit events directly. However, the former is very simple, and the latter has no BLL equivalent.