### PR TITLE
Paginate the activity log

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -102,6 +102,22 @@ And then update with the latest upstream assets:
 just assets/update
 ```
 
+### Testing upstream assets locally
+
+By default, `just assets/update` with fetch the job-server repo from
+GitHub. You can optionally use a local job-server checkout. This is
+useful if you are making changes to the job-server assets and want to
+test how they will be applied in Airlock.
+
+```bash
+just assets/update /absolute/path/to/local/job-server
+```
+
+Note: do not commit assets updated using a local job-server checkout. Merge
+your job-server changes first, then run `just assets/update` to update from
+the upstream repo.
+
+
 ## Opentelemetry
 
 To log opentelemetry traces to the console in local environments,

--- a/airlock/static/assets/activity.js
+++ b/airlock/static/assets/activity.js
@@ -1,1 +1,1 @@
-window.initCustomTable();
+window.initCustomTable(10);

--- a/airlock/static/assets/datatable-loader.js
+++ b/airlock/static/assets/datatable-loader.js
@@ -2,9 +2,15 @@ const observer = new MutationObserver((mutations, obs) => {
   const sorterButton = document.querySelector(
     "button.datatable-sorter"
   );
+  const paginationEl = document.querySelector("#pagination-nav")
   if (sorterButton) {
     document.querySelector("#airlock-table p.spinner").style.display = "none";
     document.querySelector("#airlock-table table.datatable").style.display = "table";
+    // If we have paginationEl, display it
+    // The upstream code hides the pagination until the page numbers have been populated
+    if (paginationEl !== null) {
+      document.querySelector("#pagination-nav").classList.remove("hidden")
+    };
     obs.disconnect();
     clearTimeout();
     return;

--- a/airlock/static/assets/datatable-loader.js
+++ b/airlock/static/assets/datatable-loader.js
@@ -1,4 +1,4 @@
-const observer = new MutationObserver((mutations, obs) => {
+var observer = new MutationObserver((mutations, obs) => {
   const sorterButton = document.querySelector(
     "button.datatable-sorter"
   );

--- a/airlock/templates/activity.html
+++ b/airlock/templates/activity.html
@@ -35,6 +35,46 @@
           {% endfor %}
         </tbody>
       </table>
+    </table>
+
+    <nav id="pagination-nav" class="hidden flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3" aria-label="Pagination">
+      <div class="sm:block">
+        <p class="text-sm text-gray-700">
+          Page
+          <strong data-table-pagination="page-number">#</strong>
+          of
+          <strong data-table-pagination="total-pages">#</strong>
+        </p>
+      </div>
+      <div class="flex flex-1 justify-between gap-4 sm:justify-end">
+        <button
+          data-table-pagination="previous-page"
+          class="
+                 px-4 py-2 text-sm font-medium
+                 inline-flex items-center justify-center border rounded-md shadow-sm transition-buttons duration-200
+                 border border-slate-400/75 text-slate-700 !shadow-none
+                 hover:bg-slate-200
+                 focus:bg-slate-200 focus:ring-slate-500 focus:ring-offset-white
+                 hover:shadow-lg
+                 focus:outline-none focus:ring-2 focus:ring-offset-2"
+        >
+          Previous
+        </button>
+        <button
+          data-table-pagination="next-page"
+          class="
+                 px-4 py-2 text-sm font-medium
+                 inline-flex items-center justify-center border rounded-md shadow-sm transition-buttons duration-200
+                 border border-slate-400/75 text-slate-700 !shadow-none
+                 hover:bg-slate-200
+                 focus:bg-slate-200 focus:ring-slate-500 focus:ring-offset-white
+                 hover:shadow-lg
+                 focus:outline-none focus:ring-2 focus:ring-offset-2"
+        >
+          Next
+        </button>
+      </div>
+    </nav>
     </div>
   {% else %}
     {% #list_group %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -148,9 +148,7 @@ def request_view(request, request_id: str, path: str = ""):
 
     if relpath == ROOT_PATH:
         # viewing the root
-        activity = bll.get_audit_log(
-            request=release_request.id, exclude_readonly=True, size=20
-        )
+        activity = bll.get_audit_log(request=release_request.id, exclude_readonly=True)
 
     # if we are viewing a group page, load the specific group data and forms
     elif len(relpath.parts) == 1:
@@ -184,7 +182,7 @@ def request_view(request, request_id: str, path: str = ""):
         )
 
         group_activity = bll.get_audit_log(
-            request=release_request.id, group=group, exclude_readonly=True, size=20
+            request=release_request.id, group=group, exclude_readonly=True
         )
 
     if not is_author:

--- a/assets/justfile
+++ b/assets/justfile
@@ -11,17 +11,32 @@ clean:
     rm -rf $ASSETS_DIST
 
 
-update: clean
+# Update upstream assets from job-server
+update JOBSERVER_DIR="": clean
     #!/bin/bash
     set -euo pipefail
-    tmpdir=$(mktemp -d)
-    git clone --depth=1 https://github.com/opensafely-core/job-server $tmpdir
-    just -d $tmpdir --justfile $tmpdir/justfile assets-install
-    just -d $tmpdir --justfile $tmpdir/justfile assets-build
+
+    jobserver_dir={{ JOBSERVER_DIR }}
+
+    if [ -z "$jobserver_dir" ]; then
+        jobserver_dir=$(mktemp -d)
+        git clone --depth=1 https://github.com/opensafely-core/job-server "$jobserver_dir";
+    else
+        # If we have a jobserver_dir, make sure it's an absolute path, otherwise calls to
+        # the job-server --justfile below may fail unexpectedly, because we're likely to
+        # be calling this justfile from one directory up (as in just/assets update).
+        if [ ! "${jobserver_dir:0:1}" = "/" ]; then
+            echo "JOBSERVER_DIR must be an absolute path to your local job-server directory"
+            exit 1
+        fi 
+    fi
+
+    just -d "$jobserver_dir" --justfile "$jobserver_dir"/justfile assets-install
+    just -d "$jobserver_dir" --justfile "$jobserver_dir"/justfile assets-build
     mkdir -p dist templates
-    cp -r $tmpdir/templates/_components/* ./templates/_components/
-    cp $tmpdir/jobserver/views/components.py ./base_views.py
+    cp -r "$jobserver_dir"/templates/_components/* ./templates/_components/
+    cp "$jobserver_dir"/jobserver/views/components.py ./base_views.py
     mkdir -p dist
-    cp -r $tmpdir/assets/dist/* ./dist/
-    cp -r $tmpdir/assets/dist/.vite ./dist/
+    cp -r "$jobserver_dir"/assets/dist/* ./dist/
+    cp -r "$jobserver_dir"/assets/dist/.vite ./dist/
 


### PR DESCRIPTION
Fixes #499 
 
Add pagination to the activity log and limit the number shown per page to 10 (this required a small change to upstream job-server assets).

I've reused the pagination code we used to have for CSV datatables.

![image](https://github.com/user-attachments/assets/54f4a150-055d-464e-948a-106d3c66cf9b)

Also QoL change to the assets justfile to make testing upstream asset changes easier.