### PR TITLE
Show request review progress on requests list page

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -52,6 +52,13 @@ class RequestStatus(Enum):
     RETURNED = "RETURNED"
     RELEASED = "RELEASED"
 
+    def description(self):
+        if self == RequestStatus.PARTIALLY_REVIEWED:
+            return "1 REVIEW COMPLETE"
+        if self == RequestStatus.REVIEWED:
+            return "ALL REVIEWS COMPLETE"
+        return self.name
+
 
 class RequestStatusOwner(Enum):
     """Who can write to a request in this state."""

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1074,11 +1074,17 @@ class ReleaseRequest:
             for request_file in self.output_files().values()
         )
 
-    def all_files_reviewed_by_reviewer(self, reviewer: User) -> bool:
-        return all(
-            rfile.get_file_vote_for_user(reviewer)
-            not in [None, RequestFileVote.UNDECIDED]
+    def files_reviewed_by_reviewer_count(self, reviewer: User) -> int:
+        return sum(
+            1
             for rfile in self.output_files().values()
+            if rfile.get_file_vote_for_user(reviewer)
+            not in [None, RequestFileVote.UNDECIDED]
+        )
+
+    def all_files_reviewed_by_reviewer(self, reviewer: User) -> bool:
+        return self.files_reviewed_by_reviewer_count(reviewer) == len(
+            self.output_files()
         )
 
     def completed_reviews_count(self):

--- a/airlock/templates/_components/header.html
+++ b/airlock/templates/_components/header.html
@@ -1,6 +1,6 @@
 <header class="header">
   <h1 class="header__title">
-    {{ title }} {% if context == "request" %}{% pill variant="info" text=release_request.status.name %}{% endif %}
+    {{ title }} {% if context == "request" %}{% pill variant="info" text=release_request.status.description %}{% endif %}
   </h1>
 
   {% if context == "request" and workspace.get_url %}

--- a/airlock/templates/requests.html
+++ b/airlock/templates/requests.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load airlock %}
+
 {% block metatitle %}Requests |  Airlock{% endblock metatitle %}
 
 {% block content %}
@@ -8,8 +10,9 @@
 
     {% #card title="Requests by "|add:request.user.username %}
       {% #list_group id="authored-requests" %}
-        {% for request in authored_requests %}
-          {% #list_group_item href=request.get_url %}{{ request.workspace }}: {{ request.status.name }}{% /list_group_item %}
+        {% for release_request in authored_requests %}
+          {% #list_group_rich_item url=release_request.get_url status_text=release_request.status.description title=release_request.workspace %}
+          {% /list_group_rich_item %}
         {% empty %}
           {% list_group_empty title="No requests" description="You do not have any authored requests" %}
         {% endfor %}
@@ -34,8 +37,9 @@
 
       {% #card title="Requests returned for changes/questions" %}
         {% #list_group id="returned-requests" %}
-          {% for request in returned_requests %}
-            {% #list_group_item href=request.get_url %}{{ request.workspace }} by {{ request.author }}{% /list_group_item %}
+          {% for release_request in returned_requests %}
+            {% #list_group_rich_item url=release_request.get_url status_text=release_request.status.description title=release_request.workspace %}
+            {% /list_group_rich_item %}
           {% empty %}
             {% list_group_empty title="No returned requests" description="There are no returned requests awaiting re-submission" %}
           {% endfor %}
@@ -45,8 +49,9 @@
       {% if approved_requests %}
         {% #card title="Approved requests awaiting release" %}
           {% #list_group id="returned-requests" %}
-            {% for request in approved_requests %}
-              {% #list_group_item href=request.get_url %}{{ request.workspace }} by {{ request.author }}{% /list_group_item %}
+            {% for release_request in approved_requests %}
+              {% #list_group_rich_item url=release_request.get_url status_text=release_request.status.description title=release_request.workspace %}
+              {% /list_group_rich_item %}
             {% endfor %}
           {% /list_group %}
         {% /card %}

--- a/airlock/templates/requests.html
+++ b/airlock/templates/requests.html
@@ -20,7 +20,9 @@
       {% #card title="Outstanding requests awaiting review" %}
         {% #list_group id="outstanding-requests" %}
           {% for request in outstanding_requests %}
-            {% #list_group_item href=request.get_url %}{{ request.workspace }} by {{ request.author }}{% /list_group_item %}
+            {% #list_group_item href=request.get_url %}
+              {{ request.workspace }} by {{ request.author }} {% pill variant="info" text=request.status.name %}
+            {% /list_group_item %}
           {% empty %}
             {% list_group_empty title="No outstanding requests" description="There are no outstanding requests awaiting review" %}
           {% endfor %}

--- a/airlock/templates/requests.html
+++ b/airlock/templates/requests.html
@@ -19,10 +19,13 @@
     {% if request.user.output_checker %}
       {% #card title="Outstanding requests awaiting review" %}
         {% #list_group id="outstanding-requests" %}
-          {% for request in outstanding_requests %}
-            {% #list_group_item href=request.get_url %}
-              {{ request.workspace }} by {{ request.author }} {% pill variant="info" text=request.status.name %}
-            {% /list_group_item %}
+          {% for release_request, request_progress in outstanding_requests %}
+            {% fragment as title %}{{ release_request.workspace }} by {{ release_request.author }}{% endfragment %}
+            {% #list_group_rich_item url=release_request.get_url status_text=release_request.status.description title=title %}
+              <p class="text-right text-xs">
+                {{ request_progress }}
+              </p>
+            {% /list_group_rich_item %}
           {% empty %}
             {% list_group_empty title="No outstanding requests" description="There are no outstanding requests awaiting review" %}
           {% endfor %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -44,8 +44,20 @@ def request_index(request):
     outstanding_requests = []
     returned_requests = []
     approved_requests = []
+
+    def get_reviewer_progress(release_request):
+        progress = f"Your review: {release_request.files_reviewed_by_reviewer_count(request.user)}/{len(release_request.output_files())} files"
+        if request.user.username not in release_request.completed_reviews:
+            progress += " (incomplete)"
+        return progress
+
     if request.user.output_checker:
-        outstanding_requests = bll.get_outstanding_requests_for_review(request.user)
+        outstanding_requests = [
+            (outstanding_request, get_reviewer_progress(outstanding_request))
+            for outstanding_request in bll.get_outstanding_requests_for_review(
+                request.user
+            )
+        ]
         returned_requests = bll.get_returned_requests(request.user)
         approved_requests = bll.get_approved_requests(request.user)
 

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -299,8 +299,10 @@ def test_e2e_release_files(
     find_and_click(page.get_by_test_id("nav-requests"))
     expect(page).to_have_url(live_server.url + "/requests/")
 
-    request_link = page.locator("#authored-requests").get_by_role("link")
-    expect(request_link).to_contain_text("SUBMITTED")
+    authored_request_locator = page.locator("#authored-requests")
+    expect(authored_request_locator).to_contain_text("SUBMITTED")
+
+    request_link = authored_request_locator.get_by_role("link")
     # The literal request URL in the html includes the root path (".")
     expect(request_link).to_have_attribute("href", f"/requests/view/{request_id}/")
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -728,13 +728,15 @@ def test_request_index_user_request_progress(airlock_client):
             checkers_b=[airlock_client.user],
         ),
     )
-    # partially reviewed by someone else, no files reviewed
+    # completed review by other checker, making the request partially reviewed.
+    # no files reviewed by the user.
     r2 = factories.create_request_at_status(
         "other_workspace",
         status=RequestStatus.PARTIALLY_REVIEWED,
         files=generate_files(reviewed=True),
     )
-    # partially reviewed by someone else, some files reviewed
+    # completed review by other checker, making the request partially reviewed.
+    # some files reviewed by the user.
     r3 = factories.create_request_at_status(
         "other1_workspace",
         status=RequestStatus.PARTIALLY_REVIEWED,
@@ -744,7 +746,7 @@ def test_request_index_user_request_progress(airlock_client):
             checkers_b=[airlock_client.user, default_checkers[0]],
         ),
     )
-    # partially reviewed by user, all files reviewed
+    # review completed by the user, making the request partially reviewed
     r4 = factories.create_request_at_status(
         "other2_workspace",
         author=other,
@@ -762,7 +764,7 @@ def test_request_index_user_request_progress(airlock_client):
         status=RequestStatus.REVIEWED,
         files=generate_files(reviewed=True),
     )
-    # fully reviewed by other user
+    # fully reviewed by user & one other checker
     r6_checkers = [airlock_client.user, default_checkers[0]]
     r6 = factories.create_request_at_status(
         "other4_workspace",


### PR DESCRIPTION
Fixes #253 

Show the request status and the current reviewer's progress on the request list page for each outstanding request. If their review isn't complete it says so (including if they have reviewed all files but not pressed the "Complete review" button). If their review is complete, I've assumed it's obvious from the request status and we don't need to say so.

Also made the user requests, returned and approved ones show the status in the same format as the outstanding ones. 

![Screenshot from 2024-07-18 17-27-07](https://github.com/user-attachments/assets/e052e322-deae-44af-94cd-fa3fbc15b974)
