### PR TITLE
Htmx the file voting

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 
+from django.utils.text import slugify
+
 from airlock.business_logic import (
     ROOT_PATH,
     AirlockContainer,
@@ -86,6 +88,10 @@ class PathItem:
             children=[self],
             expanded=True,
         )
+
+    def slug(self):
+        "Slugified relpath that can be used as an id for htmx"
+        return slugify(str(self.relpath))
 
     def name(self):
         if self.relpath == ROOT_PATH:

--- a/airlock/static/assets/file_browser/index.css
+++ b/airlock/static/assets/file_browser/index.css
@@ -212,3 +212,9 @@
   border-color: var(--color-gray-500);
   color: white;
 }
+
+
+/* Complete/Reject/Return/Release button group */
+.request-btn-group {
+  gap: 0.5em;
+}

--- a/airlock/templates/file_browser/_includes/action_required_alert.html
+++ b/airlock/templates/file_browser/_includes/action_required_alert.html
@@ -1,0 +1,7 @@
+{% if request_action_required %}
+  <div class="mt-4">
+    {% #alert variant="warning" title="Action required" dismissible=True %}
+      {{ request_action_required }}
+    {% /alert %}
+  </div>
+{% endif %}

--- a/airlock/templates/file_browser/_includes/decision.html
+++ b/airlock/templates/file_browser/_includes/decision.html
@@ -1,0 +1,9 @@
+{% if decision %}
+  <div class="request-file-status">
+    <span>Decision:
+      <span class="file-status file-status--{{ decision.name.lower }}">
+        {{ decision.description }}
+      </span>
+    </span>
+  </div>
+{% endif %}

--- a/airlock/templates/file_browser/_includes/file_leaf.html
+++ b/airlock/templates/file_browser/_includes/file_leaf.html
@@ -1,0 +1,4 @@
+<a class="tree__file {{ path_item.html_classes }}" href="{{ path_item.url }}">
+  <span class="tree__file-icon"></span>
+  <span class="tree__file-name">{{ path_item.display }}</span>
+</a>

--- a/airlock/templates/file_browser/_includes/request_review_buttons.html
+++ b/airlock/templates/file_browser/_includes/request_review_buttons.html
@@ -1,0 +1,69 @@
+{% load static %}
+<div class="btn-group request-btn-group">
+  {% if release_request.status_owner.name == "REVIEWER" %}
+{% comment %} User can complete review if they haven't already {% endcomment %}
+    {% if user_has_completed_review %}
+      {% #button disabled=True class="relative group" small=True variant="secondary" id="complete-review-button" %}
+        Complete review
+        {% tooltip class="airlock-tooltip" content="You have already completed your review" %}
+      {% /button %}
+    {% elif user_has_reviewed_all_files %}
+      <form action="{{ request_review_url }}" method="POST">
+        {% csrf_token %}
+        {% #button type="submit" small=True tooltip="Complete Review" variant="secondary" id="complete-review-button" %}Complete review{% /button %}
+      </form>
+    {% else %}
+      {% #button disabled=True class="relative group" small=True variant="secondary" id="complete-review-button" %}
+        Complete review
+        {% tooltip class="airlock-tooltip" content="You must review all files before you can complete your review" %}
+      {% /button %}
+    {% endif %}
+{% comment %} A fully reviewed request can be returned or rejected {% endcomment %}
+    {% if release_request.status.name == "REVIEWED" %}
+      {% #modal id="rejectRequest" button_small=True button_text="Reject request" button_variant="danger" %}
+        {% #card container=True title="Reject this request" %}
+          <form action="{{ request_reject_url }}" method="POST">
+            {% csrf_token %}
+
+            <div class="pb-8">
+              This will reject the entire request. Once a request is
+              rejected, it cannot be resubmitted and must be recreated
+              from scratch. Please confirm you wish to reject this
+              request.
+            </div>
+            {% #button type="submit" variant="danger" class="action-button" small=True id="reject-request-button" %}Reject request{% /button %}
+            {% #button variant="primary" type="cancel" %}Cancel{% /button %}
+          </form>
+        {% /card %}
+      {% /modal %}
+      <form action="{{ request_return_url }}" method="POST">
+        {% csrf_token %}
+        {% #button type="submit" small=True tooltip="Return request for changes/clarification" variant="secondary" id="return-request-button" %}Return request{% /button %}
+      </form>
+    {% else %}
+      {% #button disabled=True class="relative group" small=True variant="danger" id="reject-request-button" data-modal="rejectRequest" %}
+        Reject request
+        {% tooltip class="airlock-tooltip" content="Rejecting a request is disabled until review has been completed by two reviewers" %}
+      {% /button %}
+      {% #button disabled=True class="relative group" small=True variant="secondary" id="return-request-button" %}
+        Return request
+        {% tooltip class="airlock-tooltip" content="Returning a request is disabled until review has been completed by two reviewers" %}
+      {% /button %}
+    {% endif %}
+  {% endif %}
+{% comment %} A fully reviewed or approved request can be released if all its files are also approved {% endcomment %}
+  {% if release_request.can_be_released %}
+    <form action="{{ release_files_url }}" method="POST" hx-post="{{ release_files_url }}" hx-disabled-elt="button">
+      {% csrf_token %}
+      {% #button small=True type="submit" tooltip="Release files to jobs.opensafely.org" variant="warning" id="release-files-button" %}
+        Release files
+        <img height="16" width="16" class="icon icon--green-700 animate-spin htmx-indicator" src="{% static 'icons/progress_activity.svg' %}" alt="">
+      {% /button %}
+    </form>
+  {% elif release_request.status_owner.name == "REVIEWER" %}
+    {% #button disabled=True class="relative group" small=True variant="warning" id="release-files-button" %}
+      Release files
+      {% tooltip class="airlock-tooltip" content="Releasing to jobs.opensafely.org is disabled until all files have been approved by by two reviewers" %}
+    {% /button %}
+  {% endif %}
+</div>

--- a/airlock/templates/file_browser/_includes/vote.html
+++ b/airlock/templates/file_browser/_includes/vote.html
@@ -1,0 +1,7 @@
+{% if vote %}
+  <span>Your review:
+    <span class="file-status file-status--{{ vote.name.lower }}">
+      {{ vote.description }}
+    </span>
+  </span>
+{% endif %}

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -61,15 +61,11 @@
       {% endif %}
 
       {% if path_item.is_output %}
-        {% with decision=path_item.request_status.decision %}
-          <div class="request-file-status">
-            <span>Decision:
-              <span class="file-status file-status--{{ decision.name.lower }}">
-                {{ decision.description }}
-              </span>
-            </span>
-          </div>
-        {% endwith %}
+        <div id="file-decision">
+          {% with decision=path_item.request_status.decision %}
+            {% include 'file_browser/_includes/decision.html' %}
+          {% endwith %}
+        </div>
       {% endif %}
 
       {% if is_author %}
@@ -84,58 +80,14 @@
         {% endif %}
       {% elif is_output_checker %}
         {% if path_item.is_output %}
-          <div>
+          <div id="your-vote">
             {% with vote=path_item.request_status.vote %}
-              {% if vote %}
-                <span>Your review:
-                  <span class="file-status file-status--{{ vote.name.lower }}">
-                    {{ vote.description }}
-                  </span>
-                </span>
-              {% endif %}
+              {% include 'file_browser/_includes/vote.html' %}
             {% endwith %}
           </div>
         {% endif %}
-
-        <div class="btn-group">
-          {% if file_approve_url %}
-            <form action="{{ file_approve_url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn btn-group__btn--left" id="file-approve-button" type="submit">
-                Approve file
-              </button>
-            </form>
-          {% elif file_reset_review_url and file_reject_url %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active" id="file-approve-button" disabled="true">
-              Approve file
-            </button>
-          {% endif %}
-
-          {% if file_reject_url %}
-            <form action="{{ file_reject_url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn" id="file-reject-button" type="submit">
-                Request changes
-              </button>
-            </form>
-          {% elif file_reset_review_url and file_approve_url %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--active" id="file-reject-button" disabled="true">
-              Request changes
-            </button>
-          {% endif %}
-
-          {% if file_reset_review_url %}
-            <form action="{{ file_reset_review_url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reset-button" type="submit">
-                Undecided
-              </button>
-            </form>
-          {% elif file_approve_url and file_reject_url %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
-              Undecided
-            </button>
-          {% endif %}
+        <div class="btn-group" id="file-review-buttons" >
+          {% include 'file_browser/file_review_buttons.html' %}
         </div>
       {% endif %}
     {% endif %}

--- a/airlock/templates/file_browser/file_review_buttons.html
+++ b/airlock/templates/file_browser/file_review_buttons.html
@@ -54,4 +54,13 @@ content by htmx.
   <span hx-swap-oob="true" id="{{ path_item.slug }}">
     {% include "file_browser/_includes/file_leaf.html" %}
   </span>
+
+  <div hx-swap-oob="true" id="request-review-buttons">
+    {% include "file_browser/_includes/request_review_buttons.html" %}
+  </div>
+
+  <div hx-swap-oob="true" id="action-required-alert">
+    {% include "file_browser/_includes/action_required_alert.html" %}
+  </div>
+
 {% endif %}

--- a/airlock/templates/file_browser/file_review_buttons.html
+++ b/airlock/templates/file_browser/file_review_buttons.html
@@ -1,0 +1,52 @@
+{% if file_approve_url %}
+  <form hx-post="{{ file_approve_url }}" hx-target="#file-review-buttons" hx-swap="innerHtml">
+    {% csrf_token %}
+    <button aria-pressed="false" class="btn-group__btn btn-group__btn--left" id="file-approve-button" type="submit">
+      Approve file
+    </button>
+  </form>
+{% elif file_reset_review_url and file_reject_url %}
+  <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active" id="file-approve-button" disabled="true">
+    Approve file
+  </button>
+{% endif %}
+
+{% if file_reject_url %}
+  <form hx-post="{{ file_reject_url }}" hx-target="#file-review-buttons" hx-swap="innerHtml">
+    {% csrf_token %}
+    <button aria-pressed="false" class="btn-group__btn" id="file-reject-button" type="submit">
+      Request changes
+    </button>
+  </form>
+{% elif file_reset_review_url and file_approve_url %}
+  <button aria-pressed="true" class="btn-group__btn btn-group__btn--active" id="file-reject-button" disabled="true">
+    Request changes
+  </button>
+{% endif %}
+
+{% if file_reset_review_url %}
+  <form hx-post="{{ file_reset_review_url }}" hx-target="#file-review-buttons" hx-swap="innerHtml">
+    {% csrf_token %}
+    <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reset-button" type="submit">
+      Undecided
+    </button>
+  </form>
+{% elif file_approve_url and file_reject_url %}
+  <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
+    Undecided
+  </button>
+{% endif %}
+
+{% if request.htmx %}
+  <div hx-swap-oob="true" id="your-vote">
+    {% include 'file_browser/_includes/vote.html' %}
+  </div>
+
+  <div hx-swap-oob="true" id="file-decision">
+    {% include 'file_browser/_includes/decision.html' %}
+  </div>
+
+  <span hx-swap-oob="true" id="{{ path_item.slug }}">
+    {% include "file_browser/_includes/file_leaf.html" %}
+  </span>
+{% endif %}

--- a/airlock/templates/file_browser/file_review_buttons.html
+++ b/airlock/templates/file_browser/file_review_buttons.html
@@ -37,7 +37,12 @@
   </button>
 {% endif %}
 
-{% if request.htmx %}
+{% comment %}
+These hx-swap-oob elements should only be rendered if this was loaded by an htmx vote.
+Note we can't just rely on request.htmx here, because the tree also loads this
+content by htmx.
+{% endcomment %}
+{% if htmx_vote %}
   <div hx-swap-oob="true" id="your-vote">
     {% include 'file_browser/_includes/vote.html' %}
   </div>

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -114,7 +114,7 @@
         hx-on:htmx:after-request="setTreeSelection(this, event)"
         hx-push-url="true"
         hx-select="#selected-contents"
-        hx-swap="outerHTML"
+        hx-swap="outerHTML show:window:top"
         hx-target="#selected-contents"
         id="tree"
       >

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -72,83 +72,16 @@
             {% /modal %}
           {% endif %}
         {% elif is_output_checker %}
-          {% if release_request.status_owner.name == "REVIEWER" %}
-            {% comment %} User can complete review if they haven't already {% endcomment %}
-            {% if user_has_completed_review %}
-              {% #button disabled=True class="relative group" small=True variant="secondary" id="complete-review-button" %}
-                Complete review
-                {% tooltip class="airlock-tooltip" content="You have already completed your review" %}
-              {% /button %}
-            {% elif user_has_reviewed_all_files %}
-              <form action="{{ request_review_url }}" method="POST">
-                {% csrf_token %}
-                {% #button type="submit" small=True tooltip="Complete Review" variant="secondary" id="complete-review-button" %}Complete review{% /button %}
-              </form>
-            {% else %}
-              {% #button disabled=True class="relative group" small=True variant="secondary" id="complete-review-button" %}
-                Complete review
-                {% tooltip class="airlock-tooltip" content="You must review all files before you can complete your review" %}
-              {% /button %}
-            {% endif %}
-            {% comment %} A fully reviewed request can be returned or rejected {% endcomment %}
-            {% if release_request.status.name == "REVIEWED" %}
-              {% #modal id="rejectRequest" button_small=True button_text="Reject request" button_variant="danger" %}
-                {% #card container=True title="Reject this request" %}
-                  <form action="{{ request_reject_url }}" method="POST">
-                    {% csrf_token %}
-
-                    <div class="pb-8">
-                      This will reject the entire request. Once a request is
-                      rejected, it cannot be resubmitted and must be recreated
-                      from scratch. Please confirm you wish to reject this
-                      request.
-                    </div>
-                    {% #button type="submit" variant="danger" class="action-button" small=True id="reject-request-button" %}Reject request{% /button %}
-                    {% #button variant="primary" type="cancel" %}Cancel{% /button %}
-                  </form>
-                {% /card %}
-              {% /modal %}
-              <form action="{{ request_return_url }}" method="POST">
-                {% csrf_token %}
-                {% #button type="submit" small=True tooltip="Return request for changes/clarification" variant="secondary" id="return-request-button" %}Return request{% /button %}
-              </form>
-            {% else %}
-              {% #button disabled=True class="relative group" small=True variant="danger" id="reject-request-button" data-modal="rejectRequest" %}
-                Reject request
-                {% tooltip class="airlock-tooltip" content="Rejecting a request is disabled until review has been completed by two reviewers" %}
-              {% /button %}
-              {% #button disabled=True class="relative group" small=True variant="secondary" id="return-request-button" %}
-                Return request
-                {% tooltip class="airlock-tooltip" content="Returning a request is disabled until review has been completed by two reviewers" %}
-              {% /button %}
-            {% endif %}
-          {% endif %}
-          {% comment %} A fully reviewed or approved request can be released if all its files are also approved {% endcomment %}
-          {% if release_request.can_be_released %}
-            <form action="{{ release_files_url }}" method="POST" hx-post="{{ release_files_url }}" hx-disabled-elt="button">
-              {% csrf_token %}
-              {% #button small=True type="submit" tooltip="Release files to jobs.opensafely.org" variant="warning" id="release-files-button" %}
-                Release files
-                <img height="16" width="16" class="icon icon--green-700 animate-spin htmx-indicator" src="{% static 'icons/progress_activity.svg' %}" alt="">
-              {% /button %}
-            </form>
-          {% elif release_request.status_owner.name == "REVIEWER" %}
-            {% #button disabled=True class="relative group" small=True variant="warning" id="release-files-button" %}
-              Release files
-              {% tooltip class="airlock-tooltip" content="Releasing to jobs.opensafely.org is disabled until all files have been approved by by two reviewers" %}
-            {% /button %}
-          {% endif %}
+          <div id="request-review-buttons">
+            {% include "file_browser/_includes/request_review_buttons.html" %}
+          </div>
         {% endif %}
       {% endif %}
     {% /airlock_header %}
 
-    {% if request_action_required %}
-      <div class="mt-4">
-        {% #alert variant="warning" title="Action required" dismissible=True %}
-          {{ request_action_required }}
-        {% /alert %}
-      </div>
-    {% endif %}
+    <div id="action-required-alert">
+      {% include "file_browser/_includes/action_required_alert.html" %}
+    </div>
 
   {% else %}
     {% #airlock_header context=context current_request=current_request title=title workspace=workspace return_url=return_url %}

--- a/airlock/templates/file_browser/tree.html
+++ b/airlock/templates/file_browser/tree.html
@@ -14,10 +14,11 @@
         {% endif %}
       </details>
     {% else %}
-      <a class="tree__file {{ child.html_classes }}" href="{{ child.url }}">
-        <span class="tree__file-icon"></span>
-        <span class="tree__file-name">{{ child.display }}</span>
-      </a>
+      <span id="{{ child.slug }}">
+        {% with path_item=child %}
+          {% include "file_browser/_includes/file_leaf.html" %}
+        {% endwith %}
+      </span>
     {% endif %}
   </li>
 {% endfor %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -20,7 +20,7 @@ from airlock.business_logic import (
     RequestStatus,
     bll,
 )
-from airlock.file_browser_api import get_request_tree
+from airlock.file_browser_api import PathItem, get_request_tree
 from airlock.forms import GroupCommentDeleteForm, GroupCommentForm, GroupEditForm
 from airlock.types import UrlPath
 from services.tracing import instrument
@@ -515,6 +515,11 @@ def file_vote_response(request, release_request_id, path, user):
             file_reject_url if vote != RequestFileVote.REJECTED else None
         ),
         "file_reset_review_url": file_reset_review_url if vote is not None else None,
+        "path_item": PathItem(
+            container=release_request,
+            request_status=request_file_status,
+            relpath=UrlPath(path),
+        ),
     }
 
     return render(request, "file_browser/file_review_buttons.html", context)

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -328,6 +328,7 @@ def request_view(request, request_id: str, path: str = ""):
         "group_comment_delete_url": group_comment_delete_url,
         "vote": "",
         "decision": "",
+        "htmx_vote": False,
     }
 
     return TemplateResponse(request, template, context)
@@ -506,6 +507,7 @@ def file_vote_response(request, release_request_id, path, user):
     vote = request_file_status.vote
 
     context = {
+        "htmx_vote": True,
         "vote": vote,
         "decision": request_file_status.decision,
         "file_approve_url": (

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -1093,7 +1093,7 @@ def test_file_approve(airlock_client):
     response = airlock_client.post(
         f"/requests/approve/{release_request.id}/group/{path}"
     )
-    assert response.status_code == 302
+    assert response.status_code == 200
     relpath = UrlPath(path)
     review = (
         bll.get_release_request(release_request.id, author)
@@ -1120,7 +1120,7 @@ def test_file_reject(airlock_client):
     response = airlock_client.post(
         f"/requests/reject/{release_request.id}/group/{path}"
     )
-    assert response.status_code == 302
+    assert response.status_code == 200
     relpath = UrlPath(path)
     review = (
         bll.get_release_request(release_request.id, author)
@@ -1147,7 +1147,7 @@ def test_file_reset_review(airlock_client):
     response = airlock_client.post(
         f"/requests/reject/{release_request.id}/group/{path}"
     )
-    assert response.status_code == 302
+    assert response.status_code == 200
     relpath = UrlPath(path)
     release_request = factories.refresh_release_request(release_request)
     review = release_request.get_request_file_from_output_path(relpath).reviews[
@@ -1160,7 +1160,7 @@ def test_file_reset_review(airlock_client):
     response = airlock_client.post(
         f"/requests/reset_review/{release_request.id}/group/{path}"
     )
-    assert response.status_code == 302
+    assert response.status_code == 200
     relpath = UrlPath(path)
     release_request = factories.refresh_release_request(release_request)
     reviews = release_request.filegroups["group"].files[relpath].reviews


### PR DESCRIPTION
Submits all the votes via htmx to avoid the page jumping around as reviewers click the voting buttons.
There are several elements that need to be updated when a vote changes:
- the voting buttons
- the vote status
- the overall decision status
- the file colour/icon in the tree
- the request level buttons (a vote can change which ones are enabled/disabled)
- the action required altert (a vote can change what action is available/required)

File withdrawal is currently still a full page reload - I think this will be less frequently used and less of an annoyance to users.

Demo of approving/rejecting/resetting in independent review phase (decision remains as incomplete, complete review button enabled and action-required alert shown when vote changes from undecided ):
[Screencast from 22-07-24 12:25:57.webm](https://github.com/user-attachments/assets/bf94a4e3-b2f3-4716-8c35-3c4a958430e1)

Demo of approving/rejecting in consolidating review phase (displayed decision changes with vote changes, release files button enabled only when approved):
[Screencast from 22-07-24 12:26:39.webm](https://github.com/user-attachments/assets/5eae59d6-3eaf-40f4-a000-662207fe3058)

Also changes the tree scrolling behaviour to always scroll to the top of the window instead of to the content. This might need to change later depending on whether users prefer it, but it's a simple thing to change.

Fixes #252 