### PR TITLE
Directory table columns for request/repos

### DIFF
--- a/airlock/templates/file_browser/_includes/directory_table/repo.html
+++ b/airlock/templates/file_browser/_includes/directory_table/repo.html
@@ -1,0 +1,18 @@
+{% load airlock %}
+
+{% #table class="dir_table" id="customTable" %}
+  {% #table_head %}
+    <tr>
+      <th>
+        <div class="flex flex-row gap-2">File{% datatable_sort_icon %}</div>
+      </th>
+    </tr>
+  {% /table_head %}
+  <tbody>
+    {% for path in path_item.children %}
+      <tr>
+        <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+{% /table %}

--- a/airlock/templates/file_browser/_includes/directory_table/request.html
+++ b/airlock/templates/file_browser/_includes/directory_table/request.html
@@ -1,0 +1,30 @@
+{% load airlock %}
+
+{% #table class="dir_table" id="customTable" %}
+  {% #table_head %}
+    <tr>
+      <th>
+        <div class="flex flex-row gap-2">File{% datatable_sort_icon %}</div>
+      </th>
+      <th>
+        <div class="flex flex-row gap-2">File Type{% datatable_sort_icon %}</div>
+      </th>
+      <th>
+        <div class="flex flex-row gap-2">Size{% datatable_sort_icon %}</div>
+      </th>
+      <th>
+        <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
+      </th>
+    </tr>
+  {% /table_head %}
+  <tbody>
+    {% for path in path_item.children %}
+      <tr>
+        <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
+        <td>{{ path.request_filetype.name|title }}</td>
+        <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
+        <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+{% /table %}

--- a/airlock/templates/file_browser/_includes/directory_table/workspace.html
+++ b/airlock/templates/file_browser/_includes/directory_table/workspace.html
@@ -1,0 +1,42 @@
+{% load airlock %}
+
+{% #table class="dir_table" id="customTable" %}
+  {% #table_head %}
+    <tr>
+      <th>
+        <div class="flex flex-row gap-2">File{% datatable_sort_icon %}</div>
+      </th>
+      <th>
+        <div class="flex flex-row gap-2">Review State{% datatable_sort_icon %}</div>
+      </th>
+      <th>
+        <div class="flex flex-row gap-2">Size{% datatable_sort_icon %}</div>
+      </th>
+      <th>
+        <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
+      </th>
+      {% if workspace.is_active and multiselect_add %}
+        <th data-searchable="false" data-sortable="false">
+          <input class="selectall" type="checkbox" onchange="toggleSelectAll(this)" />
+        </th>
+      {% endif %}
+    </tr>
+  {% /table_head %}
+  <tbody>
+    {% for path in path_item.children %}
+      <tr>
+        <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
+        <td>{{ path.display_status }}</td>
+        <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
+        <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
+        {% if workspace.is_active and multiselect_add %}
+          <td>
+            {% if not path.is_directory %}
+              {% form_checkbox name="selected" value=path.relpath custom_field=True %}
+            {% endif %}
+          </td>
+        {% endif %}
+      </tr>
+    {% endfor %}
+  </tbody>
+{% /table %}

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -1,5 +1,4 @@
 {% load django_vite %}
-{% load airlock %}
 {% load static %}
 
 <style>
@@ -59,60 +58,8 @@
       {% csrf_token %}
       <input type=hidden name="next_url" value="{{ request.path }}"/>
 
-      {% #table class="dir_table" id="customTable" %}
-        {% #table_head %}
-          <tr>
-            <th>
-              <div class="flex flex-row gap-2">File{% datatable_sort_icon %}</div>
-            </th>
-            {% if context == "workspace" %}
-              <th>
-                <div class="flex flex-row gap-2">Review State{% datatable_sort_icon %}</div>
-              </th>
-            {% elif context == "request" %}
-              <th>
-                <div class="flex flex-row gap-2">File Type{% datatable_sort_icon %}</div>
-              </th>
-            {% endif %}
-            {% if context != "repo" %}
-              <th>
-                <div class="flex flex-row gap-2">Size{% datatable_sort_icon %}</div>
-              </th>
-              <th>
-                <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
-              </th>
-            {% endif %}
-            {% if context == "workspace" and workspace.is_active and multiselect_add %}
-              <th data-searchable="false" data-sortable="false">
-                <input class="selectall" type="checkbox" onchange="toggleSelectAll(this)" />
-              </th>
-            {% endif %}
-          </tr>
-        {% /table_head %}
-        <tbody>
-          {% for path in path_item.children %}
-            <tr>
-              <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
-              {% if context == "workspace" %}
-                <td>{{ path.display_status }}</td>
-              {% elif context == "request" %}
-                <td>{{ path.request_filetype.name|title }}</td>
-              {% endif %}
-              {% if context != "repo" %}
-                <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
-                <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
-                {% if context == "workspace" and workspace.is_active and multiselect_add %}
-                  <td>
-                    {% if not path.is_directory %}
-                      {% form_checkbox name="selected" value=path.relpath custom_field=True %}
-                    {% endif %}
-                  </td>
-                {% endif %}
-              {% endif %}
-            </tr>
-          {% endfor %}
-        </tbody>
-      {% /table %}
+      {% include "file_browser/_includes/directory_table/"|add:context|add:".html" %}
+
     </form>
 
     {% vite_asset "assets/src/scripts/components.js" %}

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -69,6 +69,10 @@
               <th>
                 <div class="flex flex-row gap-2">Review State{% datatable_sort_icon %}</div>
               </th>
+            {% elif context == "request" %}
+              <th>
+                <div class="flex flex-row gap-2">File Type{% datatable_sort_icon %}</div>
+              </th>
             {% endif %}
             <th>
               <div class="flex flex-row gap-2">Size{% datatable_sort_icon %}</div>
@@ -89,6 +93,8 @@
               <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
               {% if context == "workspace" %}
                 <td>{{ path.display_status }}</td>
+              {% elif context == "request" %}
+                <td>{{ path.request_filetype.name|title }}</td>
               {% endif %}
               <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
               <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>

--- a/airlock/templates/file_browser/directory.html
+++ b/airlock/templates/file_browser/directory.html
@@ -74,12 +74,14 @@
                 <div class="flex flex-row gap-2">File Type{% datatable_sort_icon %}</div>
               </th>
             {% endif %}
-            <th>
-              <div class="flex flex-row gap-2">Size{% datatable_sort_icon %}</div>
-            </th>
-            <th>
-              <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
-            </th>
+            {% if context != "repo" %}
+              <th>
+                <div class="flex flex-row gap-2">Size{% datatable_sort_icon %}</div>
+              </th>
+              <th>
+                <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
+              </th>
+            {% endif %}
             {% if context == "workspace" and workspace.is_active and multiselect_add %}
               <th data-searchable="false" data-sortable="false">
                 <input class="selectall" type="checkbox" onchange="toggleSelectAll(this)" />
@@ -96,14 +98,16 @@
               {% elif context == "request" %}
                 <td>{{ path.request_filetype.name|title }}</td>
               {% endif %}
-              <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
-              <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
-              {% if context == "workspace" and workspace.is_active and multiselect_add %}
-                <td>
-                  {% if not path.is_directory %}
-                    {% form_checkbox name="selected" value=path.relpath custom_field=True %}
-                  {% endif %}
-                </td>
+              {% if context != "repo" %}
+                <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
+                <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
+                {% if context == "workspace" and workspace.is_active and multiselect_add %}
+                  <td>
+                    {% if not path.is_directory %}
+                      {% form_checkbox name="selected" value=path.relpath custom_field=True %}
+                    {% endif %}
+                  </td>
+                {% endif %}
               {% endif %}
             </tr>
           {% endfor %}


### PR DESCRIPTION
Adds the file type to the request directory table - fixes #479 
![image](https://github.com/user-attachments/assets/f09dc0f9-236c-467e-8932-741ea9bcdd33)

Remove metadata columns from the repo directory table - fixes #551 
![Screenshot from 2024-07-24 11-38-19](https://github.com/user-attachments/assets/baaec50f-0f79-4130-be05-714af1ddb7c2)

Plus some refactoring of the table into individual workspace/request/repo files. This means a bit of repetition, but makes the individual templates cleaner.