### PR TITLE
Change source code links to go directly to project.yaml

### DIFF
--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -118,6 +118,7 @@ def request_view(request, request_id: str, path: str = ""):
                     "commit": release_request.get_request_file_from_urlpath(
                         path
                     ).commit,
+                    "path": "project.yaml",
                 },
             )
             + f"?return_url={release_request.get_url(path)}"

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -121,6 +121,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
                 kwargs={
                     "workspace_name": workspace.name,
                     "commit": workspace.get_manifest_for_file(path).get("commit"),
+                    "path": "project.yaml",
                 },
             )
             + f"?return_url={workspace.get_url(path)}"


### PR DESCRIPTION
The root of a code repo doesn't contain any displayable information,
so it was showing a blank page, which was somewhat confusing to land
on from the source code link in a workspace/request file.

As every linked coderepo should have a project.yaml, and that's the
most likely place a user is going to want to start from when
browsing the source code, we link directly to the project.yaml from
the workspace/request files, instead of to the root.