### PR TITLE
Filter audit logs for visibility

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -2291,19 +2291,16 @@ class BusinessLogicLayer:
             release_request.id, group, comment_id, user.username, audit
         )
 
-    def get_audit_log(
+    def get_request_audit_log(
         self,
-        user: str | None = None,
-        workspace: str | None = None,
-        request: str | None = None,
+        user: User,
+        request: ReleaseRequest,
         group: str | None = None,
         exclude_readonly: bool = False,
         size: int | None = None,
     ) -> list[AuditEvent]:
         return self._dal.get_audit_log(
-            user=user,
-            workspace=workspace,
-            request=request,
+            request=request.id,
             group=group,
             exclude=READONLY_EVENTS if exclude_readonly else set(),
             size=size,

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -131,7 +131,6 @@ class Visibility(Enum):
     def description(self):
         return self.choices()[self]
 
-    @cached_property
     def independent_description(self):
         return "Only visible to you until both reviews submitted"
 
@@ -1009,10 +1008,13 @@ class ReleaseRequest:
         )
 
         for comment in visible_comments:
-            if current_phase == ReviewTurnPhase.INDEPENDENT:
-                # comments are temporarily hidden
+            # does this comment need to be blinded?
+            if (
+                comment.review_turn == self.review_turn
+                and current_phase == ReviewTurnPhase.INDEPENDENT
+            ):
                 metadata = {
-                    "description": comment.visibility.independent_description,
+                    "description": comment.visibility.independent_description(),
                     "class": "comment_blinded",
                 }
             else:

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -343,7 +343,10 @@ def filter_visible_items(
         match item.visibility:
             case Visibility.PUBLIC:
                 # can always see public items from previous rounds
-                if item.review_turn < current_turn:
+                if (
+                    item.review_turn < current_turn
+                    or current_phase == ReviewTurnPhase.COMPLETE
+                ):
                     yield item
                 # can see public items for other users if CONSOLIDATING and can review
                 elif current_phase == ReviewTurnPhase.CONSOLIDATING and user_can_review:
@@ -352,7 +355,10 @@ def filter_visible_items(
                 # have to be able to review this request to see *any* private items
                 if user_can_review:
                     # can always see private items from previous rounds
-                    if item.review_turn < current_turn:
+                    if (
+                        item.review_turn < current_turn
+                        or current_phase == ReviewTurnPhase.COMPLETE
+                    ):
                         yield item
                     # can only see private items from current round if we are not INDEPENDENTe
                     elif current_phase != ReviewTurnPhase.INDEPENDENT:

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -256,6 +256,8 @@ class AuditEvent:
         **kwargs: str,
     ):
         # Note: kwargs go straight to extra
+        # set review_turn from request
+        kwargs["review_turn"] = str(request.review_turn)
         event = cls(
             type=type,
             user=user.username,
@@ -287,6 +289,21 @@ class AuditEvent:
     def description(self):
         return AUDIT_MSG_FORMATS[self.type]
 
+    @property
+    def review_turn(self) -> int:
+        return int(self.extra.get("review_turn", 0))
+
+    @property
+    def author(self) -> str:
+        return self.user
+
+    @property
+    def visibility(self) -> CommentVisibility:
+        v = self.extra.get("visibility")
+        if v:
+            return CommentVisibility[v.upper()]
+        else:
+            return CommentVisibility.PUBLIC
 
 
 class VisibleItem(Protocol):
@@ -2248,6 +2265,7 @@ class BusinessLogicLayer:
             group=group,
             comment=comment,
             review_turn=str(release_request.review_turn),
+            visibility=visibility.name,
         )
 
         self._dal.group_comment_create(
@@ -2299,11 +2317,23 @@ class BusinessLogicLayer:
         exclude_readonly: bool = False,
         size: int | None = None,
     ) -> list[AuditEvent]:
-        return self._dal.get_audit_log(
+        """Fetches the audit log for this request, filtering for what the user can see."""
+
+        audits = self._dal.get_audit_log(
             request=request.id,
             group=group,
             exclude=READONLY_EVENTS if exclude_readonly else set(),
             size=size,
+        )
+
+        return list(
+            filter_visible_items(
+                audits,
+                request.review_turn,
+                request.get_turn_phase(),
+                request.user_can_review(user),
+                user,
+            )
         )
 
     def audit_workspace_file_access(

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -125,14 +125,15 @@ class Visibility(Enum):
     def choices(cls):
         return {
             Visibility.PRIVATE: "Only visible to output-checkers",
-            Visibility.PUBLIC: "Visible to all",
+            Visibility.PUBLIC: "Visible to all users",
         }
 
-    def description(self):
+    # These will be for tooltips once those are working inside of pills
+    def description(self):  # pragma: no cover
         return self.choices()[self]
 
-    def independent_description(self):
-        return "Only visible to you until both reviews submitted"
+    def blinded_description(self):  # pragma: no cover
+        return "Only visible to you until two reviews have been completed"
 
 
 class ReviewTurnPhase(Enum):
@@ -994,7 +995,7 @@ class ReleaseRequest:
 
     def get_visible_comments_for_group(
         self, group: str, user: User
-    ) -> list[tuple[Comment, dict[str, str]]]:
+    ) -> list[tuple[Comment, str]]:
         filegroup = self.filegroups[group]
         current_phase = self.get_turn_phase()
 
@@ -1013,17 +1014,11 @@ class ReleaseRequest:
                 comment.review_turn == self.review_turn
                 and current_phase == ReviewTurnPhase.INDEPENDENT
             ):
-                metadata = {
-                    "description": comment.visibility.independent_description(),
-                    "class": "comment_blinded",
-                }
+                html_class = "comment_blinded"
             else:
-                metadata = {
-                    "description": comment.visibility.description(),
-                    "class": f"comment_{comment.visibility.name.lower()}",
-                }
+                html_class = f"comment_{comment.visibility.name.lower()}"
 
-            comments.append((comment, metadata))
+            comments.append((comment, html_class))
 
         return comments
 

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -342,7 +342,7 @@ def filter_visible_items(
 
         match item.visibility:
             case Visibility.PUBLIC:
-                # can always see public items from previous rounds
+                # can always see public items from previous turns and completed turns
                 if (
                     item.review_turn < current_turn
                     or current_phase == ReviewTurnPhase.COMPLETE
@@ -354,13 +354,13 @@ def filter_visible_items(
             case Visibility.PRIVATE:
                 # have to be able to review this request to see *any* private items
                 if user_can_review:
-                    # can always see private items from previous rounds
+                    # can always see private items from previous turns
                     if (
                         item.review_turn < current_turn
                         or current_phase == ReviewTurnPhase.COMPLETE
                     ):
                         yield item
-                    # can only see private items from current round if we are not INDEPENDENTe
+                    # can only see private items from current turn if we are not INDEPENDENT
                     elif current_phase != ReviewTurnPhase.INDEPENDENT:
                         yield item
             case _:  # pragma: nocover

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms.formsets import BaseFormSet, formset_factory
 
-from airlock.business_logic import CommentVisibility, FileGroup, RequestFileType
+from airlock.business_logic import FileGroup, RequestFileType, Visibility
 
 
 class ListField(forms.Field):
@@ -142,9 +142,7 @@ class GroupCommentForm(forms.Form):
         # filter only the supplied visibilities, as it can vary depending on
         # user and request state
         choices = [
-            (k.name, v)
-            for k, v in CommentVisibility.choices().items()
-            if k in visibilities
+            (k.name, v) for k, v in Visibility.choices().items() if k in visibilities
         ]
         self.fields["visibility"].choices = choices  # type: ignore
         # choose first in list as default selected value

--- a/airlock/management/commands/audit.py
+++ b/airlock/management/commands/audit.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
 
     @transaction.atomic()
     def handle(self, *args, **options):
-        audit_log = bll.get_audit_log(
+        audit_log = bll._dal.get_audit_log(
             user=options["user"],
             workspace=options["workspace"],
             request=options["request"],

--- a/airlock/templates/file_browser/group.html
+++ b/airlock/templates/file_browser/group.html
@@ -27,17 +27,32 @@
   {% if show_c3 %}
     <div class="comments" style="margin-top: 1rem;">
       {% #list_group %}
-        {% for comment, metadata in group_comments %}
+        {% for comment, comment_class in group_comments %}
 
           {% fragment as comment_status %}
             <span>
               {% if request.user.output_checker %}
-                {% pill variant="info" text=metadata.description %}
+                {% if release_request.get_turn_phase.name == "INDEPENDENT" %}
+                  {% #pill variant="info" text="Blinded" class="group" %}
+                    Blinded
+                    {% comment%}
+                      TODO: get tooltips working for pills
+                      {% tooltip content=comment.visibility.blinded_description %}
+                    {% endcomment%}
+                  {% /pill%}
+                {% endif %}
+                {% #pill variant="info" class="group" %}
+                  {{ comment.visibility.name.title }}
+                  {% comment%}
+                    TODO: get tooltips working for pills
+                    {%tooltip content=comment.visibility.description %}
+                  {% endcomment%}
+                {% /pill%}
               {% endif %}
               {% pill variant="info" text=comment.created_at|date:"Y-m-d H:i" %}
             </span>
           {% endfragment %}
-          {% #list_group_rich_item custom_status=comment_status class=metadata.class title=comment.author %}
+          {% #list_group_rich_item custom_status=comment_status class=comment_class title=comment.author %}
             {{ comment.comment }}
             {% if request.user.username == comment.author %}
               <div>

--- a/airlock/templates/file_browser/workspace.html
+++ b/airlock/templates/file_browser/workspace.html
@@ -5,5 +5,3 @@
     {% /description_item %}
   {% /description_list %}
 {% /card %}
-
-{% include "activity.html" %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -14,10 +14,10 @@ from opentelemetry import trace
 
 from airlock.business_logic import (
     ROOT_PATH,
-    CommentVisibility,
     RequestFileType,
     RequestFileVote,
     RequestStatus,
+    Visibility,
     bll,
 )
 from airlock.file_browser_api import get_request_tree
@@ -649,7 +649,7 @@ def group_comment_create(request, request_id, group):
                 release_request,
                 group=group,
                 comment=form.cleaned_data["comment"],
-                visibility=CommentVisibility[form.cleaned_data["visibility"]],
+                visibility=Visibility[form.cleaned_data["visibility"]],
                 user=request.user,
             )
         except bll.RequestPermissionDenied as exc:  # pragma: nocover

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -161,7 +161,11 @@ def request_view(request, request_id: str, path: str = ""):
 
     if relpath == ROOT_PATH:
         # viewing the root
-        activity = bll.get_audit_log(request=release_request.id, exclude_readonly=True)
+        activity = bll.get_request_audit_log(
+            user=request.user,
+            request=release_request,
+            exclude_readonly=True,
+        )
 
     # if we are viewing a group page, load the specific group data and forms
     elif len(relpath.parts) == 1:
@@ -194,8 +198,11 @@ def request_view(request, request_id: str, path: str = ""):
             kwargs={"request_id": request_id, "group": group},
         )
 
-        group_activity = bll.get_audit_log(
-            request=release_request.id, group=group, exclude_readonly=True
+        group_activity = bll.get_request_audit_log(
+            user=request.user,
+            request=release_request,
+            group=group,
+            exclude_readonly=True,
         )
 
     if not is_author:

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -103,14 +103,7 @@ def workspace_view(request, workspace_name: str, path: str = ""):
         in VALID_WORKSPACEFILE_STATES_TO_ADD
     )
 
-    activity = []
     project = workspace.project()
-
-    # we are viewing the root, so load workspace audit log
-    if path == "":
-        activity = bll.get_audit_log(
-            workspace=workspace.name, exclude_readonly=True, size=20
-        )
 
     if path_item.is_directory() or path not in workspace.manifest["outputs"]:
         code_url = None
@@ -150,7 +143,6 @@ def workspace_view(request, workspace_name: str, path: str = ""):
                 kwargs={"workspace_name": workspace_name},
             ),
             # for workspace summary page
-            "activity": activity,
             "project": project,
             # for code button
             "code_url": code_url,

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -5,12 +5,12 @@ from airlock.business_logic import (
     AuditEvent,
     AuditEventType,
     BusinessLogicLayer,
-    CommentVisibility,
     DataAccessLayerProtocol,
     RequestFileType,
     RequestFileVote,
     RequestStatus,
     RequestStatusOwner,
+    Visibility,
 )
 from airlock.types import UrlPath
 from local_db.models import (
@@ -418,7 +418,7 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
         request_id: str,
         group: str,
         comment: str,
-        visibility: CommentVisibility,
+        visibility: Visibility,
         review_turn: int,
         username: str,
         audit: AuditEvent,

--- a/local_db/migrations/0018_filegroupcomment_visibility.py
+++ b/local_db/migrations/0018_filegroupcomment_visibility.py
@@ -16,8 +16,8 @@ class Migration(migrations.Migration):
             model_name="filegroupcomment",
             name="visibility",
             field=local_db.models.EnumField(
-                default=airlock.business_logic.CommentVisibility.PUBLIC,
-                enum=airlock.business_logic.CommentVisibility,
+                default=airlock.business_logic.Visibility.PUBLIC,
+                enum=airlock.business_logic.Visibility,
             ),
             preserve_default=False,
         ),

--- a/local_db/models.py
+++ b/local_db/models.py
@@ -11,10 +11,10 @@ from ulid import ulid  # type: ignore
 
 from airlock.business_logic import (
     AuditEventType,
-    CommentVisibility,
     RequestFileType,
     RequestFileVote,
     RequestStatus,
+    Visibility,
 )
 
 
@@ -158,7 +158,7 @@ class FileGroupComment(models.Model):
 
     comment = models.TextField()
     author = models.TextField()  # just username, as we have no User model
-    visibility = EnumField(enum=CommentVisibility)
+    visibility = EnumField(enum=Visibility)
     review_turn = models.IntegerField()
     created_at = models.DateTimeField(default=timezone.now)
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -5,11 +5,11 @@ import requests
 
 from airlock.business_logic import (
     AuditEventType,
-    CommentVisibility,
     RequestFileType,
     RequestFileVote,
     RequestStatus,
     RequestStatusOwner,
+    Visibility,
     bll,
 )
 from airlock.types import UrlPath
@@ -100,7 +100,7 @@ def test_request_view_root_group(airlock_client, settings):
         release_request,
         group="group1",
         comment="private comment",
-        visibility=CommentVisibility.PRIVATE,
+        visibility=Visibility.PRIVATE,
         user=airlock_client.user,
     )
 
@@ -1680,10 +1680,10 @@ def test_group_edit_bad_group(airlock_client):
 @pytest.mark.parametrize(
     "output_checker,visibility,allowed",
     [
-        (False, CommentVisibility.PUBLIC, True),
-        (False, CommentVisibility.PRIVATE, False),
-        (True, CommentVisibility.PUBLIC, True),
-        (True, CommentVisibility.PRIVATE, True),
+        (False, Visibility.PUBLIC, True),
+        (False, Visibility.PRIVATE, False),
+        (True, Visibility.PUBLIC, True),
+        (True, Visibility.PRIVATE, True),
     ],
 )
 def test_group_comment_create_success(

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -76,7 +76,6 @@ def test_request_view_root_summary(airlock_client):
     assert ">\n      1\n    <" in response.rendered_content
     assert "Recent activity" in response.rendered_content
     assert "audit_user" in response.rendered_content
-    assert "Created request" in response.rendered_content
 
 
 def test_request_view_root_group(airlock_client, settings):
@@ -109,7 +108,6 @@ def test_request_view_root_group(airlock_client, settings):
     assert response.status_code == 200
     assert "Recent activity" in response.rendered_content
     assert "audit_user" in response.rendered_content
-    assert "Added file" in response.rendered_content
     assert "private comment" in response.rendered_content
 
 
@@ -498,9 +496,9 @@ def test_request_contents_file(airlock_client):
     response = airlock_client.get("/requests/content/id/default/file.txt")
     assert response.status_code == 200
     assert response.content == b'<pre class="txt">\ntest\n</pre>\n'
-    audit_log = bll.get_audit_log(
-        user=airlock_client.user.username,
-        request=release_request.id,
+    audit_log = bll.get_request_audit_log(
+        user=airlock_client.user,
+        request=release_request,
     )
     assert audit_log[0].type == AuditEventType.REQUEST_FILE_VIEW
     assert audit_log[0].path == UrlPath("default/file.txt")
@@ -549,9 +547,9 @@ def test_request_download_file(airlock_client):
     assert response.as_attachment
     assert list(response.streaming_content) == [b"test"]
 
-    audit_log = bll.get_audit_log(
-        user=airlock_client.user.username,
-        request=release_request.id,
+    audit_log = bll.get_request_audit_log(
+        user=airlock_client.user,
+        request=release_request,
     )
     assert audit_log[0].type == AuditEventType.REQUEST_FILE_DOWNLOAD
     assert audit_log[0].path == UrlPath("default/file.txt")
@@ -632,9 +630,9 @@ def test_request_download_file_permissions(
         assert response.as_attachment
         assert list(response.streaming_content) == [b"test"]
 
-        audit_log = bll.get_audit_log(
-            user=airlock_client.user.username,
-            request=release_request.id,
+        audit_log = bll.get_request_audit_log(
+            user=airlock_client.user,
+            request=release_request,
         )
         assert audit_log[0].type == AuditEventType.REQUEST_FILE_DOWNLOAD
     else:

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -4,8 +4,8 @@ from airlock.business_logic import (
     AuditEvent,
     AuditEventType,
     BusinessLogicLayer,
-    CommentVisibility,
     RequestStatus,
+    Visibility,
 )
 from airlock.types import UrlPath
 from local_db import data_access, models
@@ -166,7 +166,7 @@ def test_group_comment_delete_bad_params():
         release_request.id,
         "group",
         "author comment",
-        CommentVisibility.PUBLIC,
+        Visibility.PUBLIC,
         release_request.review_turn,
         author,
         audit,

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -943,10 +943,11 @@ def test_provider_get_or_create_current_request_for_user(bll):
 
     audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log == [
-        AuditEvent.from_request(
-            release_request,
-            AuditEventType.REQUEST_CREATE,
-            user=user,
+        AuditEvent(
+            type=AuditEventType.REQUEST_CREATE,
+            user=user.username,
+            workspace=workspace.name,
+            request=release_request.id,
         )
     ]
 
@@ -1005,10 +1006,11 @@ def test_provider_get_current_request_for_former_user(bll):
 
     audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log == [
-        AuditEvent.from_request(
-            release_request,
-            AuditEventType.REQUEST_CREATE,
-            user=user,
+        AuditEvent(
+            type=AuditEventType.REQUEST_CREATE,
+            user=user.username,
+            workspace="workspace",
+            request=release_request.id,
         )
     ]
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -639,7 +639,7 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
     ]
     assert [event["event_type"] for event in request_json] == expected_notifications
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     expected_audit_logs = [
         # create request
         AuditEventType.REQUEST_CREATE,
@@ -941,7 +941,7 @@ def test_provider_get_or_create_current_request_for_user(bll):
     assert release_request.workspace == "workspace"
     assert release_request.author == user.username
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log == [
         AuditEvent.from_request(
             release_request,
@@ -1003,7 +1003,7 @@ def test_provider_get_current_request_for_former_user(bll):
     assert release_request.workspace == "workspace"
     assert release_request.author == user.username
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log == [
         AuditEvent.from_request(
             release_request,
@@ -1215,7 +1215,7 @@ def test_set_status(current, future, valid_author, valid_checker, withdrawn_afte
     if valid_author:
         bll.set_status(release_request1, future, user=author)
         assert release_request1.status == future
-        audit_log = bll.get_audit_log(request=release_request1.id)
+        audit_log = bll._dal.get_audit_log(request=release_request1.id)
         assert audit_log[0].type == audit_type
         assert audit_log[0].user == author.username
         assert audit_log[0].request == release_request1.id
@@ -1227,7 +1227,7 @@ def test_set_status(current, future, valid_author, valid_checker, withdrawn_afte
     if valid_checker:
         bll.set_status(release_request2, future, user=checker)
         assert release_request2.status == future
-        audit_log = bll.get_audit_log(request=release_request2.id)
+        audit_log = bll._dal.get_audit_log(request=release_request2.id)
         assert audit_log[0].type == audit_type
         assert audit_log[0].user == checker.username
         assert audit_log[0].request == release_request2.id
@@ -1602,7 +1602,7 @@ def test_add_file_to_request_states(status, success, bll):
         bll.add_file_to_request(release_request, path, author)
         assert release_request.abspath("default" / path).exists()
 
-        audit_log = bll.get_audit_log(request=release_request.id)
+        audit_log = bll._dal.get_audit_log(request=release_request.id)
         assert audit_log[0] == AuditEvent.from_request(
             release_request,
             AuditEventType.REQUEST_FILE_ADD,
@@ -1803,7 +1803,7 @@ def test_update_file_to_request_states(
 
     assert release_request.abspath("group" / path).exists()
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[0] == AuditEvent.from_request(
         release_request,
         AuditEventType.REQUEST_FILE_UPDATE,
@@ -1869,7 +1869,7 @@ def test_withdraw_file_from_request_pending(bll):
 
     bll.withdraw_file_from_request(release_request, "group" / path1, user=author)
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[0] == AuditEvent.from_request(
         release_request,
         AuditEventType.REQUEST_FILE_WITHDRAW,
@@ -1882,7 +1882,7 @@ def test_withdraw_file_from_request_pending(bll):
 
     bll.withdraw_file_from_request(release_request, "group" / path2, user=author)
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[0] == AuditEvent.from_request(
         release_request,
         AuditEventType.REQUEST_FILE_WITHDRAW,
@@ -1917,7 +1917,7 @@ def test_withdraw_file_from_request_returned(bll):
         RequestFileType.WITHDRAWN,
     ]
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[0] == AuditEvent.from_request(
         release_request,
         AuditEventType.REQUEST_FILE_WITHDRAW,
@@ -2602,7 +2602,7 @@ def test_approve_file(bll):
         == RequestFileDecision.INCOMPLETE
     )
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[0] == AuditEvent.from_request(
         release_request,
         AuditEventType.REQUEST_FILE_APPROVE,
@@ -2682,7 +2682,7 @@ def test_request_changes_to_file(bll):
         == RequestFileDecision.INCOMPLETE
     )
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[0] == AuditEvent.from_request(
         release_request,
         AuditEventType.REQUEST_FILE_REQUEST_CHANGES,
@@ -3116,7 +3116,7 @@ def test_group_edit_author(bll):
     assert release_request.filegroups["group"].context == "foo"
     assert release_request.filegroups["group"].controls == "bar"
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[0].request == release_request.id
     assert audit_log[0].type == AuditEventType.REQUEST_EDIT
     assert audit_log[0].user == author.username
@@ -3251,7 +3251,7 @@ def test_group_comment_create_success(
     assert comments[1].visibility == CommentVisibility.PUBLIC
     assert comments[1].author == "author"
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
 
     assert audit_log[1].request == release_request.id
     assert audit_log[1].type == AuditEventType.REQUEST_COMMENT
@@ -3338,7 +3338,7 @@ def test_group_comment_delete_success(bll):
     assert current_comment.comment == "not-a-typo comment"
     assert current_comment.author == "other"
 
-    audit_log = bll.get_audit_log(request=release_request.id)
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
     assert audit_log[2].request == release_request.id
     assert audit_log[2].type == AuditEventType.REQUEST_COMMENT
     assert audit_log[2].user == other.username

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -2477,7 +2477,7 @@ def test_request_comment_and_audit_visibility(bll):
     assert visible.comment("turn 3 checker 0 public", checkers[0])
 
 
-def test_get_visible_comments_for_group_metadata(bll):
+def test_get_visible_comments_for_group_class(bll):
     author = factories.create_user("author", workspaces=["workspace"])
     checkers = factories.get_default_output_checkers()
 
@@ -2519,24 +2519,8 @@ def test_get_visible_comments_for_group_metadata(bll):
             m for _, m in release_request.get_visible_comments_for_group("group", user)
         ]
 
-    assert get_comment_metadata(checkers[0]) == [
-        {
-            "description": Visibility.PRIVATE.independent_description(),
-            "class": "comment_blinded",
-        },
-        {
-            "description": Visibility.PUBLIC.independent_description(),
-            "class": "comment_blinded",
-        },
-    ]
-
-    assert get_comment_metadata(checkers[1]) == [
-        {
-            "description": Visibility.PRIVATE.independent_description(),
-            "class": "comment_blinded",
-        },
-    ]
-
+    assert get_comment_metadata(checkers[0]) == ["comment_blinded", "comment_blinded"]
+    assert get_comment_metadata(checkers[1]) == ["comment_blinded"]
     assert get_comment_metadata(author) == []
 
     factories.submit_independent_review(release_request)
@@ -2547,18 +2531,9 @@ def test_get_visible_comments_for_group_metadata(bll):
 
     for checker in checkers:
         assert get_comment_metadata(checker) == [
-            {
-                "description": Visibility.PRIVATE.description(),
-                "class": "comment_private",
-            },
-            {
-                "description": Visibility.PRIVATE.description(),
-                "class": "comment_private",
-            },
-            {
-                "description": Visibility.PUBLIC.description(),
-                "class": "comment_public",
-            },
+            "comment_private",
+            "comment_private",
+            "comment_public",
         ]
 
     assert get_comment_metadata(author) == []
@@ -2570,26 +2545,12 @@ def test_get_visible_comments_for_group_metadata(bll):
 
     for checker in checkers:
         assert get_comment_metadata(checker) == [
-            {
-                "description": Visibility.PRIVATE.description(),
-                "class": "comment_private",
-            },
-            {
-                "description": Visibility.PRIVATE.description(),
-                "class": "comment_private",
-            },
-            {
-                "description": Visibility.PUBLIC.description(),
-                "class": "comment_public",
-            },
+            "comment_private",
+            "comment_private",
+            "comment_public",
         ]
 
-    assert get_comment_metadata(author) == [
-        {
-            "description": Visibility.PUBLIC.description(),
-            "class": "comment_public",
-        },
-    ]
+    assert get_comment_metadata(author) == ["comment_public"]
 
     bll.submit_request(release_request, author)
     release_request = factories.refresh_release_request(release_request)
@@ -2615,45 +2576,16 @@ def test_get_visible_comments_for_group_metadata(bll):
 
     # comments from previous round are visible
     assert get_comment_metadata(checkers[0]) == [
-        # previous round comments
-        {
-            "description": Visibility.PRIVATE.description(),
-            "class": "comment_private",
-        },
-        {
-            "description": Visibility.PRIVATE.description(),
-            "class": "comment_private",
-        },
-        {
-            "description": Visibility.PUBLIC.description(),
-            "class": "comment_public",
-        },
-        {
-            "description": Visibility.PRIVATE.independent_description(),
-            "class": "comment_blinded",
-        },
-        # current round comment
+        "comment_private",
+        "comment_private",
+        "comment_public",
+        "comment_blinded",
     ]
-
     assert get_comment_metadata(checkers[1]) == [
-        # previous round comments
-        {
-            "description": Visibility.PRIVATE.description(),
-            "class": "comment_private",
-        },
-        {
-            "description": Visibility.PRIVATE.description(),
-            "class": "comment_private",
-        },
-        {
-            "description": Visibility.PUBLIC.description(),
-            "class": "comment_public",
-        },
-        # current round comment
-        {
-            "description": Visibility.PRIVATE.independent_description(),
-            "class": "comment_blinded",
-        },
+        "comment_private",
+        "comment_private",
+        "comment_public",
+        "comment_blinded",
     ]
 
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -2159,7 +2159,7 @@ def setup_empty_release_request():
 class VisibleItemsHelper:
     """Helper class to make assertions about visiblity of comments and audit logs.
 
-    It will fetch comments and audits that are visible a specific request and
+    It will fetch comments and audits that are visible for a specific request and
     user, and store them to make assertions about.
     """
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -2477,6 +2477,186 @@ def test_request_comment_and_audit_visibility(bll):
     assert visible.comment("turn 3 checker 0 public", checkers[0])
 
 
+def test_get_visible_comments_for_group_metadata(bll):
+    author = factories.create_user("author", workspaces=["workspace"])
+    checkers = factories.get_default_output_checkers()
+
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.SUBMITTED,
+        author=author,
+        files=[factories.request_file(group="group", path="file.txt", approved=True)],
+    )
+
+    bll.group_comment_create(
+        release_request,
+        "group",
+        "turn 1 checker 0 private",
+        Visibility.PRIVATE,
+        checkers[0],
+    )
+    bll.group_comment_create(
+        release_request,
+        "group",
+        "turn 1 checker 1 private",
+        Visibility.PRIVATE,
+        checkers[1],
+    )
+    bll.group_comment_create(
+        release_request,
+        "group",
+        "turn 1 checker 0 public",
+        Visibility.PUBLIC,
+        checkers[0],
+    )
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.review_turn == 1
+    assert release_request.get_turn_phase() == ReviewTurnPhase.INDEPENDENT
+
+    def get_comment_metadata(user):
+        return [
+            m for _, m in release_request.get_visible_comments_for_group("group", user)
+        ]
+
+    assert get_comment_metadata(checkers[0]) == [
+        {
+            "description": Visibility.PRIVATE.independent_description(),
+            "class": "comment_blinded",
+        },
+        {
+            "description": Visibility.PUBLIC.independent_description(),
+            "class": "comment_blinded",
+        },
+    ]
+
+    assert get_comment_metadata(checkers[1]) == [
+        {
+            "description": Visibility.PRIVATE.independent_description(),
+            "class": "comment_blinded",
+        },
+    ]
+
+    assert get_comment_metadata(author) == []
+
+    factories.submit_independent_review(release_request)
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.review_turn == 1
+    assert release_request.get_turn_phase() == ReviewTurnPhase.CONSOLIDATING
+
+    for checker in checkers:
+        assert get_comment_metadata(checker) == [
+            {
+                "description": Visibility.PRIVATE.description(),
+                "class": "comment_private",
+            },
+            {
+                "description": Visibility.PRIVATE.description(),
+                "class": "comment_private",
+            },
+            {
+                "description": Visibility.PUBLIC.description(),
+                "class": "comment_public",
+            },
+        ]
+
+    assert get_comment_metadata(author) == []
+
+    bll.return_request(release_request, checkers[0])
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.review_turn == 2
+    assert release_request.get_turn_phase() == ReviewTurnPhase.AUTHOR
+
+    for checker in checkers:
+        assert get_comment_metadata(checker) == [
+            {
+                "description": Visibility.PRIVATE.description(),
+                "class": "comment_private",
+            },
+            {
+                "description": Visibility.PRIVATE.description(),
+                "class": "comment_private",
+            },
+            {
+                "description": Visibility.PUBLIC.description(),
+                "class": "comment_public",
+            },
+        ]
+
+    assert get_comment_metadata(author) == [
+        {
+            "description": Visibility.PUBLIC.description(),
+            "class": "comment_public",
+        },
+    ]
+
+    bll.submit_request(release_request, author)
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.review_turn == 3
+    assert release_request.get_turn_phase() == ReviewTurnPhase.INDEPENDENT
+
+    bll.group_comment_create(
+        release_request,
+        "group",
+        "turn 3 checker 0 private",
+        Visibility.PRIVATE,
+        checkers[0],
+    )
+    bll.group_comment_create(
+        release_request,
+        "group",
+        "turn 3 checker 1 private",
+        Visibility.PRIVATE,
+        checkers[1],
+    )
+
+    release_request = factories.refresh_release_request(release_request)
+
+    # comments from previous round are visible
+    assert get_comment_metadata(checkers[0]) == [
+        # previous round comments
+        {
+            "description": Visibility.PRIVATE.description(),
+            "class": "comment_private",
+        },
+        {
+            "description": Visibility.PRIVATE.description(),
+            "class": "comment_private",
+        },
+        {
+            "description": Visibility.PUBLIC.description(),
+            "class": "comment_public",
+        },
+        {
+            "description": Visibility.PRIVATE.independent_description(),
+            "class": "comment_blinded",
+        },
+        # current round comment
+    ]
+
+    assert get_comment_metadata(checkers[1]) == [
+        # previous round comments
+        {
+            "description": Visibility.PRIVATE.description(),
+            "class": "comment_private",
+        },
+        {
+            "description": Visibility.PRIVATE.description(),
+            "class": "comment_private",
+        },
+        {
+            "description": Visibility.PUBLIC.description(),
+            "class": "comment_public",
+        },
+        # current round comment
+        {
+            "description": Visibility.PRIVATE.independent_description(),
+            "class": "comment_blinded",
+        },
+    ]
+
+
 def test_release_request_filegroups_with_no_files(bll):
     release_request, _, _ = setup_empty_release_request()
     assert release_request.filegroups == {}

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -18,7 +18,6 @@ from airlock.business_logic import (
     BusinessLogicLayer,
     CodeRepo,
     Comment,
-    CommentVisibility,
     DataAccessLayerProtocol,
     NotificationEventType,
     ReleaseRequest,
@@ -27,6 +26,7 @@ from airlock.business_logic import (
     RequestFileVote,
     RequestStatus,
     ReviewTurnPhase,
+    Visibility,
     Workspace,
 )
 from airlock.types import UrlPath, WorkspaceFileStatus
@@ -2231,14 +2231,14 @@ def test_request_comment_and_audit_visibility(bll):
         release_request,
         "group",
         "turn 1 checker 0 private",
-        CommentVisibility.PRIVATE,
+        Visibility.PRIVATE,
         checkers[0],
     )
     bll.group_comment_create(
         release_request,
         "group",
         "turn 1 checker 1 private",
-        CommentVisibility.PRIVATE,
+        Visibility.PRIVATE,
         checkers[1],
     )
 
@@ -2274,7 +2274,7 @@ def test_request_comment_and_audit_visibility(bll):
         release_request,
         "group",
         "turn 1 checker 0 public",
-        CommentVisibility.PUBLIC,
+        Visibility.PUBLIC,
         checkers[0],
     )
     release_request = factories.refresh_release_request(release_request)
@@ -2306,7 +2306,7 @@ def test_request_comment_and_audit_visibility(bll):
         release_request,
         "group",
         "turn 2 author public",
-        CommentVisibility.PUBLIC,
+        Visibility.PUBLIC,
         author,
     )
     release_request = factories.refresh_release_request(release_request)
@@ -2342,14 +2342,14 @@ def test_request_comment_and_audit_visibility(bll):
         release_request,
         "group",
         "turn 3 checker 0 private",
-        CommentVisibility.PRIVATE,
+        Visibility.PRIVATE,
         checkers[0],
     )
     bll.group_comment_create(
         release_request,
         "group",
         "turn 3 checker 1 private",
-        CommentVisibility.PRIVATE,
+        Visibility.PRIVATE,
         checkers[1],
     )
     # checker0 rejects the file now. Not realistic, but we want to check that
@@ -2403,7 +2403,7 @@ def test_request_comment_and_audit_visibility(bll):
         release_request,
         "group",
         "turn 3 checker 0 public",
-        CommentVisibility.PUBLIC,
+        Visibility.PUBLIC,
         checkers[0],
     )
     release_request = factories.refresh_release_request(release_request)
@@ -3314,10 +3314,10 @@ def test_group_comment_create_success(
 
     # check all visibilities
     bll.group_comment_create(
-        release_request, "group", "private", CommentVisibility.PRIVATE, checker
+        release_request, "group", "private", Visibility.PRIVATE, checker
     )
     bll.group_comment_create(
-        release_request, "group", "public", CommentVisibility.PUBLIC, author
+        release_request, "group", "public", Visibility.PUBLIC, author
     )
     release_request = factories.refresh_release_request(release_request)
 
@@ -3331,11 +3331,11 @@ def test_group_comment_create_success(
 
     comments = release_request.filegroups["group"].comments
     assert comments[0].comment == "private"
-    assert comments[0].visibility == CommentVisibility.PRIVATE
+    assert comments[0].visibility == Visibility.PRIVATE
     assert comments[0].author == "checker"
 
     assert comments[1].comment == "public"
-    assert comments[1].visibility == CommentVisibility.PUBLIC
+    assert comments[1].visibility == Visibility.PUBLIC
     assert comments[1].author == "author"
 
     audit_log = bll._dal.get_audit_log(request=release_request.id)
@@ -3370,18 +3370,18 @@ def test_group_comment_create_permissions(bll):
 
     with pytest.raises(bll.RequestPermissionDenied):
         bll.group_comment_create(
-            release_request, "group", "question?", CommentVisibility.PUBLIC, other
+            release_request, "group", "question?", Visibility.PUBLIC, other
         )
 
     bll.group_comment_create(
-        release_request, "group", "collaborator", CommentVisibility.PUBLIC, collaborator
+        release_request, "group", "collaborator", Visibility.PUBLIC, collaborator
     )
     release_request = factories.refresh_release_request(release_request)
 
     assert len(release_request.filegroups["group"].comments) == 1
 
     bll.group_comment_create(
-        release_request, "group", "checker", CommentVisibility.PUBLIC, checker
+        release_request, "group", "checker", Visibility.PUBLIC, checker
     )
     release_request = factories.refresh_release_request(release_request)
 
@@ -3401,10 +3401,10 @@ def test_group_comment_delete_success(bll):
     assert release_request.filegroups["group"].comments == []
 
     bll.group_comment_create(
-        release_request, "group", "typo comment", CommentVisibility.PUBLIC, other
+        release_request, "group", "typo comment", Visibility.PUBLIC, other
     )
     bll.group_comment_create(
-        release_request, "group", "not-a-typo comment", CommentVisibility.PUBLIC, other
+        release_request, "group", "not-a-typo comment", Visibility.PUBLIC, other
     )
 
     release_request = factories.refresh_release_request(release_request)
@@ -3460,10 +3460,10 @@ def test_group_comment_delete_permissions(bll):
     )
 
     bll.group_comment_create(
-        release_request, "group", "author comment", CommentVisibility.PUBLIC, author
+        release_request, "group", "author comment", Visibility.PUBLIC, author
     )
     bll.group_comment_create(
-        release_request, "group", "checker comment", CommentVisibility.PUBLIC, checker
+        release_request, "group", "checker comment", Visibility.PUBLIC, checker
     )
     release_request = factories.refresh_release_request(release_request)
 
@@ -3503,7 +3503,7 @@ def test_group_comment_create_invalid_params(bll):
         bll.group_comment_delete(release_request, "group", 1, author)
 
     bll.group_comment_create(
-        release_request, "group", "author comment", CommentVisibility.PUBLIC, author
+        release_request, "group", "author comment", Visibility.PUBLIC, author
     )
     release_request = factories.refresh_release_request(release_request)
 


### PR DESCRIPTION
This is an identical resubmission of https://github.com/opensafely-core/airlock/pull/570

I accidentally merged that then reverted. This is that with clean history, and rebased on all the main change since then.

- **Factor out the core visibility logic to be reusable**
- **Remove activity log from workspace.**
- **Switch tests that assert against audit logs to use the DAL**
- **Rename get_audit_log to get_request_audit_log**
- **Filter audit logs by visibility**
- **Cover the new filtered audit logs in tests**
- **Clarify filter_visible_items logic**
- **Rename CommentVisibility to Visibility**
- **Fix visible logic when phase is COMPLETE**
- **Fix bug in comment descriptions and class**
- **Refactor the comment visiblity pills**
- **Fix comment typos**
