### PR TITLE
Prevent resetting of file votes after a review has been submitted

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1991,17 +1991,17 @@ class BusinessLogicLayer:
     ):
         if self.STATUS_OWNERS[release_request.status] != RequestStatusOwner.REVIEWER:
             raise self.ApprovalPermissionDenied(
-                f"cannot approve file from request in state {release_request.status.name}"
+                f"cannot review file from request in state {release_request.status.name}"
             )
 
         if user.username == release_request.author:
             raise self.ApprovalPermissionDenied(
-                "cannot approve files in your own request"
+                "cannot review files in your own request"
             )
 
         if not user.output_checker:
             raise self.ApprovalPermissionDenied(
-                "only an output checker can approve a file"
+                "only an output checker can review a file"
             )
 
         if relpath not in release_request.output_files():

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -2064,6 +2064,11 @@ class BusinessLogicLayer:
 
         self._verify_permission_to_review_file(release_request, relpath, user)
 
+        if user.username in release_request.submitted_reviews:
+            raise self.ApprovalPermissionDenied(
+                "cannot reset file from submitted review"
+            )
+
         audit = AuditEvent.from_request(
             request=release_request,
             type=AuditEventType.REQUEST_FILE_RESET_REVIEW,

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -97,46 +97,50 @@
           </div>
         {% endif %}
 
-        <div class="btn-group">
-          {% if file_approve_url %}
-            <form action="{{ file_approve_url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn btn-group__btn--left" id="file-approve-button" type="submit">
+        {% if voting_buttons.show %}
+          <div class="btn-group">
+            {% if voting_buttons.approve.disabled %}
+              <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active" id="file-approve-button" disabled="true">
                 Approve file
               </button>
-            </form>
-          {% elif file_reset_review_url and file_reject_url %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active" id="file-approve-button" disabled="true">
-              Approve file
-            </button>
-          {% endif %}
+            {% else %}
+              <form action="{{ voting_buttons.approve.url }}" method="POST">
+                {% csrf_token %}
+                <button aria-pressed="false" class="btn-group__btn btn-group__btn--left" id="file-approve-button" type="submit">
+                  Approve file
+                </button>
+              </form>
+            {% endif %}
 
-          {% if file_reject_url %}
-            <form action="{{ file_reject_url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn" id="file-reject-button" type="submit">
+
+            {% if voting_buttons.reject.disabled %}
+              <button aria-pressed="true" class="btn-group__btn btn-group__btn--active" id="file-reject-button" disabled="true">
                 Request changes
               </button>
-            </form>
-          {% elif file_reset_review_url and file_approve_url %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--active" id="file-reject-button" disabled="true">
-              Request changes
-            </button>
-          {% endif %}
+            {% else %}
+              <form action="{{ voting_buttons.reject.url }}" method="POST">
+                {% csrf_token %}
+                <button aria-pressed="false" class="btn-group__btn" id="file-reject-button" type="submit">
+                  Request changes
+                </button>
+              </form>
+            {% endif %}
 
-          {% if file_reset_review_url %}
-            <form action="{{ file_reset_review_url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reset-button" type="submit">
+            {% if voting_buttons.reset_review.disabled %}
+              <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
                 Undecided
               </button>
-            </form>
-          {% elif file_approve_url and file_reject_url %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
-              Undecided
-            </button>
-          {% endif %}
-        </div>
+            {% else %}
+              <form action="{{ voting_buttons.reset_review.url }}" method="POST">
+                {% csrf_token %}
+                <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reset-button" type="submit">
+                  Undecided
+                </button>
+              </form>
+            {% endif %}
+
+          </div>
+        {% endif %}
       {% endif %}
     {% endif %}
 

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -270,6 +270,10 @@ def request_view(request, request_id: str, path: str = ""):
                 assert False, "Invalid RequestFileVote value"
         else:
             file_reset_review_url = None
+        
+        # Disable reset button for submitted reviews
+        if user_has_submitted_review:
+            file_reset_review_url = None
 
     if (
         release_request.is_under_review()

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import requests
 from django.conf import settings
 from django.contrib import messages
@@ -235,45 +237,49 @@ def request_view(request, request_id: str, path: str = ""):
         kwargs={"request_id": request_id},
     )
 
-    if (
-        is_directory_url
-        or not release_request.is_under_review()
-        or release_request.request_filetype(path)
-        in [RequestFileType.SUPPORTING, RequestFileType.WITHDRAWN]
-    ):
-        file_approve_url = None
-        file_reject_url = None
-        file_reset_review_url = None
-    else:
-        file_approve_url = reverse(
-            "file_approve",
-            kwargs={"request_id": request_id, "path": path},
-        )
-        file_reject_url = reverse(
-            "file_reject",
-            kwargs={"request_id": request_id, "path": path},
-        )
-        file_reset_review_url = reverse(
-            "file_reset_review",
-            kwargs={"request_id": request_id, "path": path},
-        )
+    # set up the voting buttons, defaulting to hidden state
+    voting_buttons: Dict[str, Any] = {
+        "show": False,
+        "approve": {"url": None, "disabled": True},
+        "reject": {"url": None, "disabled": True},
+        "reset_review": {"url": None, "disabled": True},
+    }
 
+    # We can we show the buttons if:
+    # - the path is a file
+    # - this request can currently be reviewed
+    # - the file is an output file (we can't review supporting, withdrawn or code filetypes)
+    if (
+        not is_directory_url
+        and release_request.is_under_review()
+        and release_request.request_filetype(path) == RequestFileType.OUTPUT
+    ):
+        # show the buttons and add their respective URLs
+        voting_buttons["show"] = True
+        for vote in ["approve", "reject", "reset_review"]:
+            voting_buttons[vote] = {
+                "url": reverse(f"file_{vote}", args=(request_id, path)),
+                "disabled": False,
+            }
+
+        # Now determine whether any of the buttons should be disabled
+        # disable buttons for the current vote status
         request_file = release_request.get_request_file_from_urlpath(relpath)
         existing_review = request_file.reviews.get(request.user.username)
-
-        if existing_review and existing_review.status != RequestFileVote.UNDECIDED:
-            if existing_review.status == RequestFileVote.APPROVED:
-                file_approve_url = None
-            elif existing_review.status == RequestFileVote.REJECTED:
-                file_reject_url = None
-            else:
+        existing_review_status = existing_review.status if existing_review else None
+        match existing_review_status:
+            case RequestFileVote.APPROVED:
+                voting_buttons["approve"]["disabled"] = True
+            case RequestFileVote.REJECTED:
+                voting_buttons["reject"]["disabled"] = True
+            case RequestFileVote.UNDECIDED | None:
+                voting_buttons["reset_review"]["disabled"] = True
+            case _:  # pragma: no cover
                 assert False, "Invalid RequestFileVote value"
-        else:
-            file_reset_review_url = None
-        
-        # Disable reset button for submitted reviews
+
+        # Disable reset button for already submitted review
         if user_has_submitted_review:
-            file_reset_review_url = None
+            voting_buttons["reset_review"]["disabled"] = True
 
     if (
         release_request.is_under_review()
@@ -303,9 +309,7 @@ def request_view(request, request_id: str, path: str = ""):
         # TODO file these in from user/models
         "is_author": is_author,
         "is_output_checker": request.user.output_checker,
-        "file_approve_url": file_approve_url,
-        "file_reject_url": file_reject_url,
-        "file_reset_review_url": file_reset_review_url,
+        "voting_buttons": voting_buttons,
         "file_withdraw_url": file_withdraw_url,
         "request_submit_url": request_submit_url,
         "request_review_url": request_review_url,

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -402,6 +402,15 @@ def test_e2e_release_files(
 
     # submit review for this output-checker
     find_and_click(page.locator("#submit-review-button"))
+
+    # After submitting the review, the output-checker can change their vote, but can't reset it
+    find_and_click(file_link)
+    # file is already approved, so the approve button is disable
+    expect(page.locator("#file-approve-button")).to_be_disabled()
+    # they can change their minds and request changes, but can't reset now
+    expect(page.locator("#file-reject-button")).not_to_be_disabled()
+    expect(page.locator("#file-reset-button")).to_be_disabled()
+
     # Logout (by clearing cookies) and log in as second output-checker to do second approval
     # and release
     context.clear_cookies()

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -2805,7 +2805,6 @@ def test_reset_review_file_after_review_submitted(bll):
         files=[factories.request_file(path=path)],
     )
     checker = factories.create_user(output_checker=True)
-    # request_file = release_request.get_request_file_from_output_path(path)
 
     rfile = _get_request_file(release_request, path)
     assert rfile.get_file_vote_for_user(checker) is None


### PR DESCRIPTION
After a user submits a review, the request changes status (to PARTIALLY_REVIEWED or REVIEWED). In these statuses, users can still change their votes. However, we want to prevent them from re-setting votes to undecided, to avoid the possibility of returning a request with incomplete file reviews.

Also includes some refactoring of the voting button logic in the view to make the template logic simpler.