### PR TITLE
Hide multiselect for updated files

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -202,6 +202,9 @@ class PathItem:
     def is_valid(self):
         return is_valid_file_type(Path(self.relpath))
 
+    def is_updated(self):
+        return self.workspace_status == WorkspaceFileStatus.CONTENT_UPDATED
+
     def html_classes(self):
         """Semantic html classes for this PathItem.
 

--- a/airlock/templates/file_browser/_includes/directory_table/workspace.html
+++ b/airlock/templates/file_browser/_includes/directory_table/workspace.html
@@ -31,7 +31,7 @@
         <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
         {% if workspace.is_active and multiselect_add %}
           <td>
-            {% if not path.is_directory %}
+            {% if not path.is_directory and not path.is_updated %}
               {% form_checkbox name="selected" value=path.relpath custom_field=True %}
             {% endif %}
           </td>

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -466,10 +466,7 @@ def test_e2e_update_file(page, live_server, dev_users):
     # Log in as researcher
     login_as(live_server, page, "researcher")
 
-    page.goto(live_server.url + workspace.get_url("subdir/"))
-
-    # click on the multi-select checkbox
-    find_and_click(page.locator('input[name="selected"]'))
+    page.goto(live_server.url + workspace.get_url("subdir/file.txt"))
 
     # Update file in request
     # Find the add file button and click on it to open the modal


### PR DESCRIPTION
* updating files introduces significant complications into the multiselect, let's disable it for now & create a ticket to implement that later
* researchers can update files individually from the file view


<img width="1136" alt="Screenshot 2024-08-01 at 15 54 42" src="https://github.com/user-attachments/assets/a1b6bd39-4f5d-473a-b486-79a817764599">

