### PR TITLE
Move all the enums to their own module

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -7,7 +7,6 @@ import secrets
 import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Protocol, Self, Sequence, cast
@@ -20,6 +19,18 @@ from django.utils.module_loading import import_string
 
 import old_api
 from airlock import exceptions, permissions, renderers
+from airlock.enums import (
+    AuditEventType,
+    NotificationEventType,
+    RequestFileDecision,
+    RequestFileType,
+    RequestFileVote,
+    RequestStatus,
+    RequestStatusOwner,
+    ReviewTurnPhase,
+    Visibility,
+    WorkspaceFileStatus,
+)
 from airlock.lib.git import (
     GitError,
     list_files_from_repo,
@@ -27,7 +38,7 @@ from airlock.lib.git import (
     read_file_from_repo,
 )
 from airlock.notifications import send_notification_event
-from airlock.types import FileMetadata, UrlPath, WorkspaceFileStatus
+from airlock.types import FileMetadata, UrlPath
 from airlock.users import User
 from airlock.utils import is_valid_file_type
 
@@ -37,67 +48,6 @@ ROOT_PATH = UrlPath()  # empty path
 logger = logging.getLogger(__name__)
 
 
-class RequestStatus(Enum):
-    """Status for release Requests"""
-
-    # author set statuses
-    PENDING = "PENDING"
-    SUBMITTED = "SUBMITTED"
-    WITHDRAWN = "WITHDRAWN"
-    # output checker set statuses
-    APPROVED = "APPROVED"
-    REJECTED = "REJECTED"
-    PARTIALLY_REVIEWED = "PARTIALLY_REVIEWED"
-    REVIEWED = "REVIEWED"
-    RETURNED = "RETURNED"
-    RELEASED = "RELEASED"
-
-    def description(self):
-        if self == RequestStatus.PARTIALLY_REVIEWED:
-            return "ONE REVIEW SUBMITTED"
-        if self == RequestStatus.REVIEWED:
-            return "ALL REVIEWS SUBMITTED"
-        return self.name
-
-
-class RequestStatusOwner(Enum):
-    """Who can write to a request in this state."""
-
-    AUTHOR = "AUTHOR"
-    REVIEWER = "REVIEWER"
-    SYSTEM = "SYSTEM"
-
-
-class RequestFileType(Enum):
-    OUTPUT = "output"
-    SUPPORTING = "supporting"
-    WITHDRAWN = "withdrawn"
-    CODE = "code"
-
-
-class RequestFileVote(Enum):
-    """An individual output checker's vote on a specific file."""
-
-    APPROVED = "APPROVED"
-    CHANGES_REQUESTED = "CHANGES_REQUESTED"
-    UNDECIDED = "UNDECIDED"  # set on CHANGES_REQUESTED files by Airlock when a request is re-submitted
-
-    def description(self):
-        return self.name.replace("_", " ").title()
-
-
-class RequestFileDecision(Enum):
-    """The current state of all user reviews on this file."""
-
-    CHANGES_REQUESTED = "CHANGES_REQUESTED"
-    APPROVED = "APPROVED"
-    CONFLICTED = "CONFLICTED"
-    INCOMPLETE = "INCOMPLETE"
-
-    def description(self):  # pragma: nocover
-        return self.name.replace("_", " ").title()
-
-
 @dataclass
 class RequestFileStatus:
     """The current visible decision and inidividual vote for a specific user."""
@@ -105,93 +55,6 @@ class RequestFileStatus:
     user: User
     decision: RequestFileDecision
     vote: RequestFileVote | None
-
-
-class Visibility(Enum):
-    """The visibility of comments."""
-
-    # only visible to output-checkers
-    PRIVATE = "PRIVATE"
-    # visible to all
-    PUBLIC = "PUBLIC"
-
-    @classmethod
-    def choices(cls):
-        return {
-            Visibility.PRIVATE: "Only visible to output-checkers",
-            Visibility.PUBLIC: "Visible to all users",
-        }
-
-    # These will be for tooltips once those are working inside of pills
-    def description(self):  # pragma: no cover
-        return self.choices()[self]
-
-    def blinded_description(self):  # pragma: no cover
-        return "Only visible to you until two reviews have been completed"
-
-
-class ReviewTurnPhase(Enum):
-    """What phase is the request in."""
-
-    # author's phase
-    AUTHOR = "AUTHOR"
-    # can only see your own votes/comments
-    INDEPENDENT = "INDEPENDENT"
-    # output-checkers can see all votes/comments
-    CONSOLIDATING = "CONSOLIDATING"
-    # can see everything
-    COMPLETE = "COMPLETE"
-
-
-class AuditEventType(Enum):
-    """Audit log events.
-
-    Note that the string values are stored in the local_db database via
-    AuditEvent.type.  Any changes to values will require a database migration.
-    See eg #562.
-    """
-
-    # file access
-    WORKSPACE_FILE_VIEW = "WORKSPACE_FILE_VIEW"
-    REQUEST_FILE_VIEW = "REQUEST_FILE_VIEW"
-    REQUEST_FILE_DOWNLOAD = "REQUEST_FILE_DOWNLOAD"
-
-    # request status
-    REQUEST_CREATE = "REQUEST_CREATE"
-    REQUEST_SUBMIT = "REQUEST_SUBMIT"
-    REQUEST_WITHDRAW = "REQUEST_WITHDRAW"
-    REQUEST_REVIEW = "REQUEST_REVIEW"
-    REQUEST_APPROVE = "REQUEST_APPROVE"
-    REQUEST_REJECT = "REQUEST_REJECT"
-    REQUEST_RETURN = "REQUEST_RETURN"
-    REQUEST_RELEASE = "REQUEST_RELEASE"
-
-    # request edits
-    REQUEST_EDIT = "REQUEST_EDIT"
-    REQUEST_COMMENT = "REQUEST_COMMENT"
-    REQUEST_COMMENT_DELETE = "REQUEST_COMMENT_DELETE"
-
-    # request file status
-    REQUEST_FILE_ADD = "REQUEST_FILE_ADD"
-    REQUEST_FILE_UPDATE = "REQUEST_FILE_UPDATE"
-    REQUEST_FILE_WITHDRAW = "REQUEST_FILE_WITHDRAW"
-    REQUEST_FILE_APPROVE = "REQUEST_FILE_APPROVE"
-    REQUEST_FILE_REQUEST_CHANGES = "REQUEST_FILE_REQUEST_CHANGES"
-    REQUEST_FILE_RESET_REVIEW = "REQUEST_FILE_RESET_REVIEW"
-    REQUEST_FILE_UNDECIDED = "REQUEST_FILE_UNDECIDED"
-    REQUEST_FILE_RELEASE = "REQUEST_FILE_RELEASE"
-
-
-class NotificationEventType(Enum):
-    REQUEST_SUBMITTED = "request_submitted"
-    REQUEST_WITHDRAWN = "request_withdrawn"
-    REQUEST_PARTIALLY_REVIEWED = "request_partially_reviewed"
-    REQUEST_REVIEWED = "request_reviewed"
-    REQUEST_APPROVED = "request_approved"
-    REQUEST_RELEASED = "request_released"
-    REQUEST_REJECTED = "request_rejected"
-    REQUEST_RETURNED = "request_returned"
-    REQUEST_RESUBMITTED = "request_resubmitted"
 
 
 READONLY_EVENTS = {

--- a/airlock/enums.py
+++ b/airlock/enums.py
@@ -1,0 +1,174 @@
+from enum import Enum
+
+
+class WorkspaceFileStatus(Enum):
+    """Possible states of a workspace file."""
+
+    # Workspace path states
+    UNRELEASED = "UNRELEASED"
+    UNDER_REVIEW = "UNDER_REVIEW"
+    RELEASED = "RELEASED"
+    CONTENT_UPDATED = "UPDATED"
+    WITHDRAWN = "WITHDRAWN"
+
+    def formatted(self):
+        return self.value.title().replace("_", " ")
+
+
+class RequestStatus(Enum):
+    """Status for release Requests"""
+
+    # author set statuses
+    PENDING = "PENDING"
+    SUBMITTED = "SUBMITTED"
+    WITHDRAWN = "WITHDRAWN"
+    # output checker set statuses
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    PARTIALLY_REVIEWED = "PARTIALLY_REVIEWED"
+    REVIEWED = "REVIEWED"
+    RETURNED = "RETURNED"
+    RELEASED = "RELEASED"
+
+    def description(self):
+        if self == RequestStatus.PARTIALLY_REVIEWED:
+            return "ONE REVIEW SUBMITTED"
+        if self == RequestStatus.REVIEWED:
+            return "ALL REVIEWS SUBMITTED"
+        return self.name
+
+
+class RequestFileVote(Enum):
+    """An individual output checker's vote on a specific file."""
+
+    APPROVED = "APPROVED"
+    CHANGES_REQUESTED = "CHANGES_REQUESTED"
+    UNDECIDED = "UNDECIDED"  # set on CHANGES_REQUESTED files by Airlock when a request is re-submitted
+
+    def description(self):
+        return self.name.replace("_", " ").title()
+
+
+class RequestStatusOwner(Enum):
+    """Who can write to a request in this state."""
+
+    AUTHOR = "AUTHOR"
+    REVIEWER = "REVIEWER"
+    SYSTEM = "SYSTEM"
+
+
+class RequestFileType(Enum):
+    OUTPUT = "output"
+    SUPPORTING = "supporting"
+    WITHDRAWN = "withdrawn"
+    CODE = "code"
+
+
+class RequestFileDecision(Enum):
+    """The current state of all user reviews on this file."""
+
+    CHANGES_REQUESTED = "CHANGES_REQUESTED"
+    APPROVED = "APPROVED"
+    CONFLICTED = "CONFLICTED"
+    INCOMPLETE = "INCOMPLETE"
+
+    def description(self):  # pragma: nocover
+        return self.name.replace("_", " ").title()
+
+
+class Visibility(Enum):
+    """The visibility of comments."""
+
+    # only visible to output-checkers
+    PRIVATE = "PRIVATE"
+    # visible to all
+    PUBLIC = "PUBLIC"
+
+    @classmethod
+    def choices(cls):
+        return {
+            Visibility.PRIVATE: "Only visible to output-checkers",
+            Visibility.PUBLIC: "Visible to all users",
+        }
+
+    # These will be for tooltips once those are working inside of pills
+    def description(self):  # pragma: no cover
+        return self.choices()[self]
+
+    def blinded_description(self):  # pragma: no cover
+        return "Only visible to you until two reviews have been completed"
+
+
+class ReviewTurnPhase(Enum):
+    """What phase is the request in."""
+
+    # author's phase
+    AUTHOR = "AUTHOR"
+    # can only see your own votes/comments
+    INDEPENDENT = "INDEPENDENT"
+    # output-checkers can see all votes/comments
+    CONSOLIDATING = "CONSOLIDATING"
+    # can see everything
+    COMPLETE = "COMPLETE"
+
+
+class AuditEventType(Enum):
+    """Audit log events.
+
+    Note that the string values are stored in the local_db database via
+    AuditEvent.type.  Any changes to values will require a database migration.
+    See eg #562.
+    """
+
+    # file access
+    WORKSPACE_FILE_VIEW = "WORKSPACE_FILE_VIEW"
+    REQUEST_FILE_VIEW = "REQUEST_FILE_VIEW"
+    REQUEST_FILE_DOWNLOAD = "REQUEST_FILE_DOWNLOAD"
+
+    # request status
+    REQUEST_CREATE = "REQUEST_CREATE"
+    REQUEST_SUBMIT = "REQUEST_SUBMIT"
+    REQUEST_WITHDRAW = "REQUEST_WITHDRAW"
+    REQUEST_REVIEW = "REQUEST_REVIEW"
+    REQUEST_APPROVE = "REQUEST_APPROVE"
+    REQUEST_REJECT = "REQUEST_REJECT"
+    REQUEST_RETURN = "REQUEST_RETURN"
+    REQUEST_RELEASE = "REQUEST_RELEASE"
+
+    # request edits
+    REQUEST_EDIT = "REQUEST_EDIT"
+    REQUEST_COMMENT = "REQUEST_COMMENT"
+    REQUEST_COMMENT_DELETE = "REQUEST_COMMENT_DELETE"
+
+    # request file status
+    REQUEST_FILE_ADD = "REQUEST_FILE_ADD"
+    REQUEST_FILE_UPDATE = "REQUEST_FILE_UPDATE"
+    REQUEST_FILE_WITHDRAW = "REQUEST_FILE_WITHDRAW"
+    REQUEST_FILE_APPROVE = "REQUEST_FILE_APPROVE"
+    REQUEST_FILE_REQUEST_CHANGES = "REQUEST_FILE_REQUEST_CHANGES"
+    REQUEST_FILE_RESET_REVIEW = "REQUEST_FILE_RESET_REVIEW"
+    REQUEST_FILE_UNDECIDED = "REQUEST_FILE_UNDECIDED"
+    REQUEST_FILE_RELEASE = "REQUEST_FILE_RELEASE"
+
+
+class NotificationEventType(Enum):
+    REQUEST_SUBMITTED = "request_submitted"
+    REQUEST_WITHDRAWN = "request_withdrawn"
+    REQUEST_PARTIALLY_REVIEWED = "request_partially_reviewed"
+    REQUEST_REVIEWED = "request_reviewed"
+    REQUEST_APPROVED = "request_approved"
+    REQUEST_RELEASED = "request_released"
+    REQUEST_REJECTED = "request_rejected"
+    REQUEST_RETURNED = "request_returned"
+    REQUEST_RESUBMITTED = "request_resubmitted"
+
+
+class PathType(Enum):
+    """Types of PathItems in a tree."""
+
+    FILE = "file"
+    DIR = "directory"
+    WORKSPACE = "workspace"
+    REQUEST = "request"
+    FILEGROUP = "filegroup"
+    REPO = "repo"

--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from enum import Enum
 from pathlib import Path
 
 from airlock.business_logic import (
@@ -12,24 +11,13 @@ from airlock.business_logic import (
     CodeRepo,
     ReleaseRequest,
     RequestFileStatus,
-    RequestFileType,
     Workspace,
 )
-from airlock.types import FileMetadata, UrlPath, WorkspaceFileStatus
+from airlock.enums import PathType, RequestFileType, WorkspaceFileStatus
+from airlock.types import FileMetadata, UrlPath
 from airlock.users import User
 from airlock.utils import is_valid_file_type
 from services.tracing import instrument
-
-
-class PathType(Enum):
-    """Types of PathItems in a tree."""
-
-    FILE = "file"
-    DIR = "directory"
-    WORKSPACE = "workspace"
-    REQUEST = "request"
-    FILEGROUP = "filegroup"
-    REPO = "repo"
 
 
 @dataclass

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -1,7 +1,8 @@
 from django import forms
 from django.forms.formsets import BaseFormSet, formset_factory
 
-from airlock.business_logic import FileGroup, RequestFileType, Visibility
+from airlock.business_logic import FileGroup
+from airlock.enums import RequestFileType, Visibility
 
 
 class ListField(forms.Field):

--- a/airlock/types.py
+++ b/airlock/types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from enum import Enum
 from functools import cached_property
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
@@ -18,20 +17,6 @@ if TYPE_CHECKING:  # pragma: no cover
     class UrlPath(PurePosixPath): ...
 else:
     UrlPath = PurePosixPath
-
-
-class WorkspaceFileStatus(Enum):
-    """Possible states of a workspace file."""
-
-    # Workspace path states
-    UNRELEASED = "UNRELEASED"
-    UNDER_REVIEW = "UNDER_REVIEW"
-    RELEASED = "RELEASED"
-    CONTENT_UPDATED = "UPDATED"
-    WITHDRAWN = "WITHDRAWN"
-
-    def formatted(self):
-        return self.value.title().replace("_", " ")
 
 
 @dataclass

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -15,14 +15,8 @@ from django.views.decorators.vary import vary_on_headers
 from opentelemetry import trace
 
 from airlock import exceptions, permissions
-from airlock.business_logic import (
-    ROOT_PATH,
-    RequestFileType,
-    RequestFileVote,
-    RequestStatus,
-    Visibility,
-    bll,
-)
+from airlock.business_logic import ROOT_PATH, bll
+from airlock.enums import RequestFileType, RequestFileVote, RequestStatus, Visibility
 from airlock.file_browser_api import get_request_tree
 from airlock.forms import GroupCommentDeleteForm, GroupCommentForm, GroupEditForm
 from airlock.types import UrlPath

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -10,13 +10,15 @@ from django.views.decorators.vary import vary_on_headers
 from opentelemetry import trace
 
 from airlock import exceptions, permissions
-from airlock.business_logic import (
-    RequestFileType,
-    bll,
-)
+from airlock.business_logic import bll
+from airlock.enums import RequestFileType, WorkspaceFileStatus
 from airlock.file_browser_api import get_workspace_tree
-from airlock.forms import AddFileForm, FileTypeFormSet, MultiselectForm
-from airlock.types import UrlPath, WorkspaceFileStatus
+from airlock.forms import (
+    AddFileForm,
+    FileTypeFormSet,
+    MultiselectForm,
+)
+from airlock.types import UrlPath
 from airlock.views.helpers import (
     display_form_errors,
     display_multiple_messages,

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -4,9 +4,11 @@ from django.utils import timezone
 from airlock import exceptions
 from airlock.business_logic import (
     AuditEvent,
-    AuditEventType,
     BusinessLogicLayer,
     DataAccessLayerProtocol,
+)
+from airlock.enums import (
+    AuditEventType,
     RequestFileType,
     RequestFileVote,
     RequestStatus,

--- a/local_db/migrations/0002_requestmetadata_status.py
+++ b/local_db/migrations/0002_requestmetadata_status.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations
 
-import airlock.business_logic
+import airlock.enums
 import local_db.models
 
 
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             model_name="requestmetadata",
             name="status",
             field=local_db.models.EnumField(
-                default=airlock.business_logic.RequestStatus["PENDING"]
+                default=airlock.enums.RequestStatus["PENDING"]
             ),
         ),
     ]

--- a/local_db/migrations/0005_requestfilemetadata_filetype.py
+++ b/local_db/migrations/0005_requestfilemetadata_filetype.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations
 
-import airlock.business_logic
+import airlock.enums
 import local_db.models
 
 
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
             model_name="requestfilemetadata",
             name="filetype",
             field=local_db.models.EnumField(
-                default=airlock.business_logic.RequestFileType["OUTPUT"]
+                default=airlock.enums.RequestFileType["OUTPUT"]
             ),
         ),
     ]

--- a/local_db/migrations/0006_filereview.py
+++ b/local_db/migrations/0006_filereview.py
@@ -4,7 +4,7 @@ import django.db.models.deletion
 import django.utils.timezone
 from django.db import migrations, models
 
-import airlock.business_logic
+import airlock.enums
 import local_db.models
 
 
@@ -30,9 +30,7 @@ class Migration(migrations.Migration):
                 (
                     "status",
                     local_db.models.EnumField(
-                        default=airlock.business_logic.RequestFileVote[
-                            "CHANGES_REQUESTED"
-                        ]
+                        default=airlock.enums.RequestFileVote["CHANGES_REQUESTED"]
                     ),
                 ),
                 ("created_at", models.DateTimeField(default=django.utils.timezone.now)),

--- a/local_db/migrations/0009_alter_auditlog_type_alter_filereview_status_and_more.py
+++ b/local_db/migrations/0009_alter_auditlog_type_alter_filereview_status_and_more.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations
 
-import airlock.business_logic
+import airlock.enums
 import local_db.models
 
 
@@ -15,22 +15,22 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="auditlog",
             name="type",
-            field=local_db.models.EnumField(enum=airlock.business_logic.AuditEventType),
+            field=local_db.models.EnumField(enum=airlock.enums.AuditEventType),
         ),
         migrations.AlterField(
             model_name="filereview",
             name="status",
             field=local_db.models.EnumField(
-                default=airlock.business_logic.RequestFileVote["CHANGES_REQUESTED"],
-                enum=airlock.business_logic.RequestFileVote,
+                default=airlock.enums.RequestFileVote["CHANGES_REQUESTED"],
+                enum=airlock.enums.RequestFileVote,
             ),
         ),
         migrations.AlterField(
             model_name="requestfilemetadata",
             name="filetype",
             field=local_db.models.EnumField(
-                default=airlock.business_logic.RequestFileType["OUTPUT"],
-                enum=airlock.business_logic.RequestFileType,
+                default=airlock.enums.RequestFileType["OUTPUT"],
+                enum=airlock.enums.RequestFileType,
             ),
         ),
     ]

--- a/local_db/migrations/0018_filegroupcomment_visibility.py
+++ b/local_db/migrations/0018_filegroupcomment_visibility.py
@@ -2,7 +2,7 @@
 
 from django.db import migrations
 
-import airlock.business_logic
+import airlock.enums
 import local_db.models
 
 
@@ -16,8 +16,8 @@ class Migration(migrations.Migration):
             model_name="filegroupcomment",
             name="visibility",
             field=local_db.models.EnumField(
-                default=airlock.business_logic.Visibility.PUBLIC,
-                enum=airlock.business_logic.Visibility,
+                default=airlock.enums.Visibility.PUBLIC,
+                enum=airlock.enums.Visibility,
             ),
             preserve_default=False,
         ),

--- a/local_db/models.py
+++ b/local_db/models.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 # it's not really worth it
 from ulid import ulid  # type: ignore
 
-from airlock.business_logic import (
+from airlock.enums import (
     AuditEventType,
     RequestFileType,
     RequestFileVote,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,11 +16,13 @@ from airlock.business_logic import (
     CodeRepo,
     ReleaseRequest,
     RequestFile,
+    Workspace,
+    bll,
+)
+from airlock.enums import (
     RequestFileType,
     RequestFileVote,
     RequestStatus,
-    Workspace,
-    bll,
 )
 from airlock.lib.git import ensure_git_init
 from airlock.types import UrlPath

--- a/tests/functional/test_code_pages.py
+++ b/tests/functional/test_code_pages.py
@@ -3,7 +3,7 @@ from urllib.parse import urlsplit
 import pytest
 from playwright.sync_api import expect
 
-from airlock.business_logic import RequestStatus
+from airlock.enums import RequestStatus
 from tests import factories
 
 

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -2,7 +2,8 @@ import re
 
 from playwright.sync_api import expect
 
-from airlock.business_logic import RequestStatus, bll
+from airlock.business_logic import bll
+from airlock.enums import RequestStatus
 from airlock.types import UrlPath
 from tests import factories
 

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -1,7 +1,7 @@
 import pytest
 from playwright.sync_api import expect
 
-from airlock.business_logic import RequestStatus
+from airlock.enums import RequestStatus
 from tests import factories
 from tests.functional.conftest import login_as_user
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -4,14 +4,14 @@ import pytest
 import requests
 
 from airlock import exceptions
-from airlock.business_logic import (
+from airlock.business_logic import bll
+from airlock.enums import (
     AuditEventType,
     RequestFileType,
     RequestFileVote,
     RequestStatus,
     RequestStatusOwner,
     Visibility,
-    bll,
 )
 from airlock.types import UrlPath
 from tests import factories

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -3,11 +3,8 @@ from django.contrib import messages
 from django.contrib.messages.api import get_messages
 from django.urls import reverse
 
-from airlock.business_logic import (
-    Project,
-    RequestFileType,
-    RequestStatus,
-)
+from airlock.business_logic import Project
+from airlock.enums import RequestFileType, RequestStatus
 from airlock.types import UrlPath
 from tests import factories
 from tests.conftest import get_trace

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -1,8 +1,8 @@
 import pytest
 
 from airlock import exceptions
-from airlock.business_logic import (
-    AuditEvent,
+from airlock.business_logic import AuditEvent
+from airlock.enums import (
     AuditEventType,
     RequestStatus,
     Visibility,

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -15,22 +15,25 @@ import old_api
 from airlock import exceptions
 from airlock.business_logic import (
     AuditEvent,
-    AuditEventType,
     BusinessLogicLayer,
     CodeRepo,
     Comment,
     DataAccessLayerProtocol,
-    NotificationEventType,
     ReleaseRequest,
+    Workspace,
+)
+from airlock.enums import (
+    AuditEventType,
+    NotificationEventType,
     RequestFileDecision,
     RequestFileType,
     RequestFileVote,
     RequestStatus,
     ReviewTurnPhase,
     Visibility,
-    Workspace,
+    WorkspaceFileStatus,
 )
-from airlock.types import UrlPath, WorkspaceFileStatus
+from airlock.types import UrlPath
 from airlock.users import User
 from tests import factories
 

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -3,18 +3,19 @@ import textwrap
 import pytest
 from django.template.loader import render_to_string
 
-from airlock.business_logic import (
+from airlock.enums import (
+    PathType,
     RequestFileDecision,
     RequestFileVote,
     RequestStatus,
+    WorkspaceFileStatus,
 )
 from airlock.file_browser_api import (
-    PathType,
     get_code_tree,
     get_request_tree,
     get_workspace_tree,
 )
-from airlock.types import UrlPath, WorkspaceFileStatus
+from airlock.types import UrlPath
 from tests import factories
 from tests.conftest import get_trace
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -2,7 +2,8 @@ import json
 
 import requests
 
-from airlock.business_logic import BusinessLogicLayer, RequestStatus
+from airlock.business_logic import BusinessLogicLayer
+from airlock.enums import RequestStatus
 from airlock.notifications import send_notification_event
 
 

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -1,7 +1,7 @@
 import pytest
 
 from airlock import exceptions, permissions
-from airlock.business_logic import RequestStatus
+from airlock.enums import RequestStatus
 from tests import factories
 
 


### PR DESCRIPTION
We have a lot of enums in Airlock. In addition to reducing the size of business_logic_layer.py, moving them to their own modules avoids circular imports when various different modules need to use them.

Note: the one enum in old_api/schema.py is left where it is, as we expect to replace old_api at some point in the (nearish?) future.