### PR TITLE
Refactor mark undecided, group edit and commenting permissions

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -2036,7 +2036,7 @@ class BusinessLogicLayer:
         if not comment:
             raise exceptions.FileNotFound(f"Comment {comment_id} not found")
 
-        permissions.check_user_can_delete_comment(user, comment)
+        permissions.check_user_can_delete_comment(user, release_request, comment)
 
         audit = AuditEvent.from_request(
             request=release_request,

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1957,15 +1957,7 @@ class BusinessLogicLayer:
         user: User,
     ):
         """Change an existing changes-requested file in a returned request to undecided before re-submitting"""
-        if release_request.status != RequestStatus.RETURNED:
-            raise exceptions.RequestReviewDenied(
-                f"cannot change file review to {RequestFileVote.UNDECIDED.name} from request in state {release_request.status.name}"
-            )
-
-        if review.status != RequestFileVote.CHANGES_REQUESTED:
-            raise exceptions.RequestReviewDenied(
-                f"cannot change file review from {review.status.name} to {RequestFileVote.UNDECIDED.name} from request in state {release_request.status.name}"
-            )
+        policies.check_can_mark_file_undecided(release_request, review)
 
         audit = AuditEvent.from_request(
             request=release_request,

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -284,18 +284,25 @@ def user_can_comment_on_group(user: User, request: "ReleaseRequest"):
     return True
 
 
-def check_user_can_delete_comment(user: User, comment: "Comment"):
+def check_user_can_delete_comment(
+    user: User, request: "ReleaseRequest", comment: "Comment"
+):
+    # Only the author of a comment can delete it
     if not user.username == comment.author:
         raise exceptions.RequestPermissionDenied(
             f"User {user.username} is not the author of this comment, so cannot delete"
         )
+    # Restrictions on deleting comments are the same as for creating them. This
+    # means that comments can't be changed once a user has completed their turn, and
+    # comments can't be deleted at all after a request has moved into a final state
+    check_user_can_comment_on_group(user, request)
 
 
 def user_can_delete_comment(
-    user: User, comment: "Comment"
+    user: User, request: "ReleaseRequest", comment: "Comment"
 ):  # pragma: no cover; not currently used
     try:
-        check_user_can_delete_comment(user, comment)
+        check_user_can_delete_comment(user, request, comment)
     except exceptions.RequestPermissionDenied:
         return False
     return True

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:  # pragma: no cover
     # imports are not executed at runtime.
     # https://peps.python.org/pep-0484/#forward-references
     # https://mypy.readthedocs.io/en/stable/runtime_troubles.html#import-cycles`
-    from airlock.business_logic import ReleaseRequest, Workspace
+    from airlock.business_logic import Comment, ReleaseRequest, Workspace
 
 
 def check_user_can_view_workspace(user: User | None, workspace_name: str):
@@ -120,7 +120,7 @@ def check_user_can_edit_request(user: User, request: "ReleaseRequest"):
     """
     if user.username != request.author:
         raise exceptions.RequestPermissionDenied(
-            f"only author {request.author} can modify the files in this request"
+            f"only author {request.author} can edit this request"
         )
     check_user_can_action_request_for_workspace(user, request.workspace)
     policies.check_can_edit_request(request)
@@ -243,5 +243,59 @@ def user_can_submit_review(
     try:
         check_user_can_submit_review(user, request)
     except exceptions.RequestReviewDenied:
+        return False
+    return True
+
+
+def check_user_can_comment_on_group(user: User, request: "ReleaseRequest"):
+    # Users with no permission to view workspace can never comment
+    if not user_can_view_workspace(user, request.workspace):
+        raise exceptions.RequestPermissionDenied(
+            f"User {user.username} does not have permission to comment"
+        )
+
+    if not user_has_role_on_workspace(user, request.workspace):
+        # if user does not have a role on the workspace, they are an output-checker
+        # and can only comment if the request is in under review status
+        try:
+            policies.check_can_review_request(request)
+        except exceptions.RequestReviewDenied:
+            raise exceptions.RequestPermissionDenied(
+                f"User {user.username} does not have permission to comment on request in {request.status.name} status"
+            )
+    else:
+        # if user has a role on the workspace (even if not the author), they are allowed
+        # to comment on behalf of the author.
+        if not user_can_review_request(user, request):
+            # non-output-checkers and author can only comment in editable status
+            policies.check_can_edit_request(request)
+        else:
+            # output-checkers who have access to the workspace can comment in both
+            # editable and reviewable status, as they could be commenting as either
+            # checker or collaborator
+            policies.check_can_modify_request(request)
+
+
+def user_can_comment_on_group(user: User, request: "ReleaseRequest"):
+    try:
+        check_user_can_comment_on_group(user, request)
+    except exceptions.RequestPermissionDenied:
+        return False
+    return True
+
+
+def check_user_can_delete_comment(user: User, comment: "Comment"):
+    if not user.username == comment.author:
+        raise exceptions.RequestPermissionDenied(
+            f"User {user.username} is not the author of this comment, so cannot delete"
+        )
+
+
+def user_can_delete_comment(
+    user: User, comment: "Comment"
+):  # pragma: no cover; not currently used
+    try:
+        check_user_can_delete_comment(user, comment)
+    except exceptions.RequestPermissionDenied:
         return False
     return True

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -36,7 +36,7 @@ def check_can_edit_request(request: "ReleaseRequest"):
     """
     if not request.is_editing():
         raise exceptions.RequestPermissionDenied(
-            f"cannot modify files in request that is in state {request.status.name}"
+            f"cannot edit request that is in state {request.status.name}"
         )
 
 
@@ -115,4 +115,18 @@ def check_can_mark_file_undecided(request: "ReleaseRequest", review: "FileReview
     if review.status != RequestFileVote.CHANGES_REQUESTED:
         raise exceptions.RequestReviewDenied(
             f"cannot change file review from {review.status.name} to {RequestFileVote.UNDECIDED.name} from request in state {request.status.name}"
+        )
+
+
+def check_can_modify_request(request: "ReleaseRequest"):
+    """
+    This request can be modified i.e. it is in, or can be moved to, a
+    status in which files can be added/withdrawn/reviewed.
+    These are statuses that are considered "final" and system-owned,
+    plus the APPROVED status, in which the only allowed modification
+    is to move the request to RELEASED.
+    """
+    if request.is_final() or request.status == RequestStatus.APPROVED:
+        raise exceptions.RequestPermissionDenied(
+            "This request can no longer be modified."
         )

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -134,32 +134,8 @@ def request_view(request, request_id: str, path: str = ""):
     group_comment_create_url = None
     group_comment_delete_url = None
 
-    can_edit_group = (
-        # no-one can edit context/controls for final requests
-        not release_request.is_final()
-        # only authors can edit context/controls
-        and is_author
-        # and only if the request is in draft i.e. in an author-owned turn
-        and release_request.is_editing()
-    )
-
-    can_comment = (
-        # no-one can comment on final requests
-        not release_request.is_final()
-        # user who can review can comment if the request is under review
-        and (
-            permissions.user_can_review_request(request.user, release_request)
-            and release_request.is_under_review()
-        )
-        or
-        # any user with access to the workspace can comment if the request is in draft
-        (
-            permissions.user_has_role_on_workspace(
-                request.user, release_request.workspace
-            )
-            and release_request.is_editing()
-        )
-    )
+    can_edit_group = permissions.user_can_edit_request(request.user, release_request)
+    can_comment = permissions.user_can_comment_on_group(request.user, release_request)
 
     activity = []
     group_activity = []

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -54,7 +54,7 @@ def test_request_id_does_not_exist(airlock_client):
 
 def test_request_view_root_summary(airlock_client):
     airlock_client.login(output_checker=True)
-    audit_user = factories.create_user("audit_user")
+    audit_user = factories.create_user("audit_user", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=audit_user,
@@ -87,7 +87,7 @@ def test_request_view_root_summary(airlock_client):
 def test_request_view_root_group(airlock_client, settings):
     settings.SHOW_C3 = True
     airlock_client.login(output_checker=True)
-    audit_user = factories.create_user("audit_user")
+    audit_user = factories.create_user("audit_user", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=audit_user,
@@ -295,7 +295,9 @@ def test_request_view_complete_turn_alert(
     users = {
         "researcher": factories.create_user("researcher", workspaces=["workspace"]),
         "researcher1": factories.create_user("researcher", output_checker=False),
-        "checker": factories.create_user("checker", output_checker=True),
+        "checker": factories.create_user(
+            "checker", output_checker=True, workspaces=["workspace"]
+        ),
     }
     airlock_client.login(users[login_as].username, output_checker=True)
     release_request = factories.create_request_at_status(
@@ -342,7 +344,7 @@ def test_request_view_with_reviewed_request(airlock_client):
 
 @pytest.mark.parametrize("status", list(RequestStatus))
 def test_request_view_with_authored_request_file(airlock_client, status):
-    airlock_client.login(output_checker=True)
+    airlock_client.login(output_checker=True, workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=airlock_client.user,
@@ -663,7 +665,14 @@ def test_request_index_user_permitted_requests(airlock_client):
 
 def test_request_index_user_output_checker(airlock_client):
     airlock_client.login(workspaces=["test_workspace"], output_checker=True)
-    other = factories.create_user("other")
+    other = factories.create_user(
+        "other",
+        workspaces=[
+            "other_workspace",
+            "other_other_workspace",
+            "other_other1_workspace",
+        ],
+    )
     r1 = factories.create_request_at_status(
         "test_workspace", author=airlock_client.user, status=RequestStatus.SUBMITTED
     )
@@ -697,7 +706,16 @@ def test_request_index_user_output_checker(airlock_client):
 
 def test_request_index_user_request_progress(airlock_client):
     airlock_client.login(workspaces=["test_workspace"], output_checker=True)
-    other = factories.create_user("other")
+    other = factories.create_user(
+        "other",
+        workspaces=[
+            "other_workspace",
+            "other1_workspace",
+            "other2_workspace",
+            "other3_workspace",
+            "other4_workspace",
+        ],
+    )
     default_checkers = factories.get_default_output_checkers()
 
     def generate_files(reviewed=False, checkers_a=None, checkers_b=None):
@@ -808,7 +826,7 @@ def test_request_submit_author(airlock_client):
 
 def test_request_submit_not_author(airlock_client):
     airlock_client.login(workspaces=["test1"])
-    other_author = factories.create_user("other", [], False)
+    other_author = factories.create_user("other", ["test1"], False)
     release_request = factories.create_release_request(
         "test1", user=other_author, status=RequestStatus.PENDING
     )
@@ -889,7 +907,7 @@ def test_request_return_author(airlock_client):
 
 def test_request_return_output_checker(airlock_client):
     airlock_client.login(workspaces=["test1"], output_checker=True)
-    other_author = factories.create_user("other", [], False)
+    other_author = factories.create_user("other", ["test1"], False)
     release_request = factories.create_request_at_status(
         "test1",
         author=other_author,
@@ -1503,7 +1521,7 @@ def test_requests_release_workspace_403(airlock_client):
 
 
 def test_requests_release_author_403(airlock_client):
-    airlock_client.login(output_checker=True)
+    airlock_client.login(output_checker=True, workspaces=["workspace"])
     factories.create_request_at_status(
         "workspace",
         id="request_id",

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1207,7 +1207,7 @@ def test_provider_get_current_request_for_user_output_checker(bll):
     ],
 )
 def test_set_status(current, future, valid_author, valid_checker, withdrawn_after, bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_user("author", ["workspace1", "workspace2"], False)
     checker = factories.create_user(output_checker=True)
     file_reviewers = [checker, factories.create_user("checker1", [], True)]
     audit_type = bll.STATUS_AUDIT_EVENT[future]
@@ -1421,7 +1421,9 @@ def test_set_status_approved(all_files_approved, bll, mock_notifications):
 
 
 def test_set_status_cannot_action_own_request(bll):
-    user = factories.create_user(output_checker=True)
+    user = factories.create_user(
+        output_checker=True, workspaces=["workspace1", "workspace2"]
+    )
     release_request1 = factories.create_request_at_status(
         "workspace", author=user, status=RequestStatus.SUBMITTED
     )

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -167,7 +167,9 @@ def test_get_request_tree_general(release_request):
 
 
 def test_get_request_tree_status(bll):
-    author = factories.create_user("author", output_checker=True)
+    author = factories.create_user(
+        "author", output_checker=True, workspaces=["workspace"]
+    )
     checker1 = factories.create_user("checker1", [], True)
     checker2 = factories.create_user("checker2", [], True)
 


### PR DESCRIPTION
Refactors permissions and policies for:
- marking a file as undecided (this is a policy only as it's done by the system when a request is returned)
- editing group (adding context/controls)
- creating comments
- deleting comments

Some of the permissions were previously implemented in view/template logic only, especially around comments. This moves them into the BLL, so a bunch of tests also needed updating.

Permissions for deleting comments is also updated, so users can now only delete comments when it their turn (same as for creating comments). This means that comments e.g. can't disappear during a review, or be removed after a request is in a final status.