### PR TITLE
Amend policy for adding a file to a request & reuse

### DIFF
--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -165,9 +165,6 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
                 existing_file = RequestFileMetadata.objects.get(
                     request_id=request_id, relpath=relpath
                 )
-                # We should never be able to attempt to add a file to a request
-                # with a different filetype
-                assert existing_file.filetype == filetype
             except RequestFileMetadata.DoesNotExist:
                 # create the RequestFile
                 RequestFileMetadata.objects.create(


### PR DESCRIPTION
* the UI would not present the option to add a file in the state `UNDER_REVIEW`. Although the BLL function would accept it, I think the DAL would correctly reject it
* I believe the existing function in `policies.py` was derived from the BLL function