### PR TITLE
Show a sensible dialogue when updating a file

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -458,20 +458,6 @@ class Workspace:
     def request_filetype(self, relpath: UrlPath) -> None:
         return None
 
-    def file_has_been_released(self, relpath: UrlPath) -> bool:
-        return self.get_workspace_file_status(relpath) == WorkspaceFileStatus.RELEASED
-
-    def file_can_be_added(self, relpath: UrlPath) -> bool:
-        return self.get_workspace_file_status(relpath) in [
-            WorkspaceFileStatus.UNRELEASED,
-            WorkspaceFileStatus.WITHDRAWN,
-        ]
-
-    def file_can_be_updated(self, relpath: UrlPath) -> bool:
-        return self.get_workspace_file_status(relpath) in [
-            WorkspaceFileStatus.CONTENT_UPDATED,
-        ]
-
 
 @dataclass(frozen=True)
 class CodeRepo:

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -461,17 +461,15 @@ class Workspace:
     def file_has_been_released(self, relpath: UrlPath) -> bool:
         return self.get_workspace_file_status(relpath) == WorkspaceFileStatus.RELEASED
 
-    def file_can_be_updated(self, relpath: UrlPath) -> bool:
-        return self.get_workspace_file_status(relpath) in [
-            WorkspaceFileStatus.CONTENT_UPDATED,
-            WorkspaceFileStatus.WITHDRAWN,
-        ]
-
     def file_can_be_added(self, relpath: UrlPath) -> bool:
         return self.get_workspace_file_status(relpath) in [
             WorkspaceFileStatus.UNRELEASED,
-            WorkspaceFileStatus.CONTENT_UPDATED,
             WorkspaceFileStatus.WITHDRAWN,
+        ]
+
+    def file_can_be_updated(self, relpath: UrlPath) -> bool:
+        return self.get_workspace_file_status(relpath) in [
+            WorkspaceFileStatus.CONTENT_UPDATED,
         ]
 
 
@@ -1640,6 +1638,12 @@ class BusinessLogicLayer:
         relpath: UrlPath,
         user: User,
     ) -> ReleaseRequest:
+        relpath = UrlPath(relpath)
+        workspace = self.get_workspace(release_request.workspace, user)
+        permissions.check_user_can_update_file_on_request(
+            user, release_request, workspace, relpath
+        )
+
         request_file = release_request.get_request_file_from_output_path(relpath)
         return self.replace_file_in_request(
             release_request, relpath, user, request_file.group, request_file.filetype
@@ -1653,6 +1657,12 @@ class BusinessLogicLayer:
         group_name: str = "default",
         filetype: RequestFileType = RequestFileType.OUTPUT,
     ) -> ReleaseRequest:
+        relpath = UrlPath(relpath)
+        workspace = self.get_workspace(release_request.workspace, user)
+        permissions.check_user_can_add_file_to_request(
+            user, release_request, workspace, relpath
+        )
+
         return self.replace_file_in_request(
             release_request, relpath, user, group_name, filetype
         )
@@ -1667,7 +1677,7 @@ class BusinessLogicLayer:
     ) -> ReleaseRequest:
         relpath = UrlPath(relpath)
         workspace = self.get_workspace(release_request.workspace, user)
-        permissions.check_user_can_update_file_on_request(
+        permissions.check_user_can_replace_file_in_request(
             user, release_request, workspace, relpath
         )
 

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -81,9 +81,6 @@ class FileForm(forms.Form):
     )
 
 
-FileFormSet = formset_factory(FileForm, extra=0)
-
-
 class FileTypeForm(forms.Form):
     FILETYPE_CHOICES = [
         (RequestFileType.OUTPUT.name, RequestFileType.OUTPUT.name.title()),
@@ -123,6 +120,7 @@ class RequiredOneBaseFormSet(BaseFormSet):  # type: ignore
 
 
 FileTypeFormSet = formset_factory(FileTypeForm, extra=0, formset=RequiredOneBaseFormSet)
+FileFormSet = formset_factory(FileForm, extra=0, formset=RequiredOneBaseFormSet)
 
 
 class GroupEditForm(forms.Form):

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -74,6 +74,16 @@ class AddFileForm(forms.Form):
             return new_filegroup
 
 
+class FileForm(forms.Form):
+    file = forms.CharField(
+        required=True,
+        widget=forms.HiddenInput(),
+    )
+
+
+FileFormSet = formset_factory(FileForm, extra=0)
+
+
 class FileTypeForm(forms.Form):
     FILETYPE_CHOICES = [
         (RequestFileType.OUTPUT.name, RequestFileType.OUTPUT.name.title()),

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -151,6 +151,23 @@ def user_can_add_file_to_request(
     return True
 
 
+def check_user_can_replace_file_in_request(
+    user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
+):
+    check_user_can_edit_request(user, request)
+    policies.check_can_replace_file_in_request(workspace, relpath)
+
+
+def user_can_replace_file_in_request(
+    user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
+):  # pragma: no cover; not currently used
+    try:
+        check_user_can_update_file_on_request(user, request, workspace, relpath)
+    except exceptions.RequestPermissionDenied:
+        return False
+    return True
+
+
 def check_user_can_update_file_on_request(
     user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
 ):

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -162,7 +162,7 @@ def user_can_replace_file_in_request(
     user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
 ):  # pragma: no cover; not currently used
     try:
-        check_user_can_update_file_on_request(user, request, workspace, relpath)
+        check_user_can_replace_file_in_request(user, request, workspace, relpath)
     except exceptions.RequestPermissionDenied:
         return False
     return True

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -79,7 +79,10 @@ def can_replace_file_in_request(workspace: "Workspace", relpath: UrlPath):
 
 def check_can_replace_file_in_request(workspace: "Workspace", relpath: UrlPath):
     """
-    This file can replace an existing file in the request.
+    This file can replace an existing file in the request, which currently happens
+    in two scenarios:
+    * when a file on a request is updated;
+    * or when a file on a request in the withdrawn state is re-added.
     We expect that check_can_edit_request has already been called.
     """
     # The file is an allowed type

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -132,9 +132,7 @@ def check_can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):
 
     status = workspace.get_workspace_file_status(relpath)
 
-    if status not in [
-        WorkspaceFileStatus.CONTENT_UPDATED,
-    ]:
+    if status != WorkspaceFileStatus.CONTENT_UPDATED:
         raise exceptions.RequestPermissionDenied(
             "Cannot update file in request if it is not updated on disk"
         )

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -69,6 +69,37 @@ def check_can_add_file_to_request(workspace: "Workspace", relpath: UrlPath):
         )
 
 
+def can_replace_file_in_request(workspace: "Workspace", relpath: UrlPath):
+    try:
+        check_can_replace_file_in_request(workspace, relpath)
+    except exceptions.RequestPermissionDenied:
+        return False
+    return True
+
+
+def check_can_replace_file_in_request(workspace: "Workspace", relpath: UrlPath):
+    """
+    This file can replace an existing file in the request.
+    We expect that check_can_edit_request has already been called.
+    """
+    # The file is an allowed type
+    if not is_valid_file_type(Path(relpath)):
+        raise exceptions.RequestPermissionDenied(
+            f"Cannot add file of type {relpath.suffix} to request"
+        )
+    # The file hasn't already been released
+    if workspace.file_has_been_released(relpath):
+        raise exceptions.RequestPermissionDenied("Cannot add released file to request")
+
+    if not (
+        workspace.file_can_be_added(relpath) or workspace.file_can_be_updated(relpath)
+    ):
+        status = workspace.get_workspace_file_status(relpath)
+        raise exceptions.RequestPermissionDenied(
+            f"Cannot add or update file in request if it is in status {status}"
+        )
+
+
 def check_can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):
     """
     This file can be updated on the request.

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -100,6 +100,14 @@ def check_can_replace_file_in_request(workspace: "Workspace", relpath: UrlPath):
         )
 
 
+def can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):
+    try:
+        check_can_update_file_on_request(workspace, relpath)
+    except exceptions.RequestPermissionDenied:
+        return False
+    return True
+
+
 def check_can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):
     """
     This file can be updated on the request.

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from airlock import exceptions
-from airlock.enums import RequestFileVote, RequestStatus
+from airlock.enums import RequestFileVote, RequestStatus, WorkspaceFileStatus
 from airlock.types import UrlPath
 from airlock.utils import is_valid_file_type
 
@@ -58,12 +58,17 @@ def check_can_add_file_to_request(workspace: "Workspace", relpath: UrlPath):
         raise exceptions.RequestPermissionDenied(
             f"Cannot add file of type {relpath.suffix} to request"
         )
+
+    status = workspace.get_workspace_file_status(relpath)
+
     # The file hasn't already been released
-    if workspace.file_has_been_released(relpath):
+    if status == WorkspaceFileStatus.RELEASED:
         raise exceptions.RequestPermissionDenied("Cannot add released file to request")
 
-    if not workspace.file_can_be_added(relpath):
-        status = workspace.get_workspace_file_status(relpath)
+    if status not in [
+        WorkspaceFileStatus.UNRELEASED,
+        WorkspaceFileStatus.WITHDRAWN,
+    ]:
         raise exceptions.RequestPermissionDenied(
             f"Cannot add file to request if it is in status {status}"
         )
@@ -90,13 +95,17 @@ def check_can_replace_file_in_request(workspace: "Workspace", relpath: UrlPath):
         raise exceptions.RequestPermissionDenied(
             f"Cannot add file of type {relpath.suffix} to request"
         )
+
+    status = workspace.get_workspace_file_status(relpath)
+
     # The file hasn't already been released
-    if workspace.file_has_been_released(relpath):
+    if status == WorkspaceFileStatus.RELEASED:
         raise exceptions.RequestPermissionDenied("Cannot add released file to request")
 
-    if not (
-        workspace.file_can_be_added(relpath) or workspace.file_can_be_updated(relpath)
-    ):
+    if status not in [
+        WorkspaceFileStatus.WITHDRAWN,
+        WorkspaceFileStatus.CONTENT_UPDATED,
+    ]:
         status = workspace.get_workspace_file_status(relpath)
         raise exceptions.RequestPermissionDenied(
             f"Cannot add or update file in request if it is in status {status}"
@@ -121,7 +130,11 @@ def check_can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):
             f"Cannot update file of type {relpath.suffix} in request"
         )
 
-    if not workspace.file_can_be_updated(relpath):
+    status = workspace.get_workspace_file_status(relpath)
+
+    if status not in [
+        WorkspaceFileStatus.CONTENT_UPDATED,
+    ]:
         raise exceptions.RequestPermissionDenied(
             "Cannot update file in request if it is not updated on disk"
         )

--- a/airlock/templates/file_browser/file.html
+++ b/airlock/templates/file_browser/file.html
@@ -8,13 +8,15 @@
           hx-target="#multiselect_modal"
           hx-swap="outerHtml"
         >
-          {% #button type="submit" name="action" value="add_files" variant="success" %}
-            {% if path_item.workspace_status.value == "UPDATED" %}
+          {% if path_item.workspace_status.value == "UPDATED" %}
+            {% #button type="submit" name="action" value="update_files" variant="success" %}
               Update File in Request
-            {% else %}
+            {% /button %}
+          {% else %}
+            {% #button type="submit" name="action" value="add_files" variant="success" %}
               Add File to Request
-            {% endif %}
-          {% /button %}
+            {% /button %}
+          {% endif %}
           <input type=hidden name="selected" value="{{ path_item.relpath }}"/>
           <input type=hidden name="next_url" value="{{ request.path }}"/>
           {% csrf_token %}

--- a/airlock/templates/update_files.html
+++ b/airlock/templates/update_files.html
@@ -1,10 +1,6 @@
 {# hide default button, as we are going to autoshow the modal anyway #}
 {% fragment as button %}
 {% endfragment %}
-<style>
-  div.filetype-radio div { display: hidden; }
-  div.filetype-radio label { display: hidden; }
-</style>
 {% #modal id="updateRequestFile" custom_button=button autoshow=True %}
   {% #card container=True title="Update Files in Request" %}
     <form action="{{ add_file_url }}" method="POST" aria-label="add-file-form">

--- a/airlock/templates/update_files.html
+++ b/airlock/templates/update_files.html
@@ -1,0 +1,41 @@
+{# hide default button, as we are going to autoshow the modal anyway #}
+{% fragment as button %}
+{% endfragment %}
+<style>
+  div.filetype-radio div { display: hidden; }
+  div.filetype-radio label { display: hidden; }
+</style>
+{% #modal id="updateRequestFile" custom_button=button autoshow=True %}
+  {% #card container=True title="Update Files in Request" %}
+    <form action="{{ add_file_url }}" method="POST" aria-label="add-file-form">
+      {% csrf_token %}
+      {{ form.next_url }}
+      {{ formset.management_form }}
+      {% #list_group %}
+        {% for name, reason in files_ignored.items %}
+          {% #list_group_item %}
+            <div class="flex items-center gap-2 justify-between">
+              <span>{{ name }}</span>
+              <span class="flex flex-row">{{ reason }}</span>
+            </div>
+          {% /list_group_item %}
+        {% endfor %}
+        {% for formset_form in formset %}
+          {% #list_group_item %}
+            <div class="flex items-center gap-2 justify-between">
+              <span>{{ formset_form.file.value }}</span>
+              {{ formset_form.file }}
+            </div>
+          {% /list_group_item %}
+        {% endfor %}
+      {% /list_group %}
+
+      <div class="mt-2">
+        {% #button type="submit" variant="success" id="update-file-button" disabled=no_valid_files %}
+          Update Files in Request
+        {% /button %}
+        {% #button variant="danger" type="cancel" %}Cancel{% /button %}
+      </div>
+    </form>
+  {% /card %}
+{% /modal %}

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -61,6 +61,11 @@ urlpatterns = [
         airlock.views.workspace_add_file_to_request,
         name="workspace_add_file",
     ),
+    path(
+        "workspaces/update-file-in-request/<str:workspace_name>",
+        airlock.views.workspace_update_file_in_request,
+        name="workspace_update_file",
+    ),
     # requests
     path(
         "requests/",

--- a/airlock/views/__init__.py
+++ b/airlock/views/__init__.py
@@ -25,6 +25,7 @@ from .workspace import (
     workspace_contents,
     workspace_index,
     workspace_multiselect,
+    workspace_update_file_in_request,
     workspace_view,
 )
 
@@ -55,6 +56,7 @@ __all__ = [
     "workspace_multiselect",
     "workspace_contents",
     "workspace_index",
+    "workspace_update_file_in_request",
     "workspace_view",
     "serve_docs",
 ]

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -290,7 +290,7 @@ def multiselect_update_files(request, multiform, workspace):
 
 
 # also displays errors if present
-def add_or_update_forms_are_valid(request, form, formset):
+def add_or_update_form_is_valid(request, form, formset):
     errors = False
 
     if not form.is_valid():
@@ -333,7 +333,7 @@ def workspace_add_file_to_request(request, workspace_name):
     form = AddFileForm(request.POST, release_request=release_request)
     formset = FileTypeFormSet(request.POST)
 
-    errors = add_or_update_forms_are_valid(request, form, formset)
+    errors = add_or_update_form_is_valid(request, form, formset)
     next_url = get_next_url(workspace, form)
 
     if errors:
@@ -389,7 +389,7 @@ def workspace_update_file_in_request(request, workspace_name):
     form = AddFileForm(request.POST, release_request=release_request)
     formset = FileFormSet(request.POST)
 
-    errors = add_or_update_forms_are_valid(request, form, formset)
+    errors = add_or_update_form_is_valid(request, form, formset)
     next_url = get_next_url(workspace, form)
 
     if errors:

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -261,7 +261,7 @@ def multiselect_update_files(request, multiform, workspace):
         if policies.can_update_file_on_request(workspace, UrlPath(f)):
             files_to_add.append(f)
         else:
-            files_ignored[f] = "cannot add using the update dialogue"
+            files_ignored[f] = "file cannot be updated"
 
     add_file_form = AddFileForm(
         release_request=workspace.current_request,

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -90,8 +90,9 @@ def workspace_view(request, workspace_name: str, path: str = ""):
     # Only show the add file form button if the multiselect_add condition is true,
     # and also this pathitem is a file that can be added to a request - i.e. it is a
     # valid file and it's not already on the current request for the user
-    add_file = multiselect_add and policies.can_add_file_to_request(
-        workspace, path_item.relpath
+    add_file = multiselect_add and (
+        policies.can_add_file_to_request(workspace, path_item.relpath)
+        or policies.can_replace_file_in_request(workspace, path_item.relpath)
     )
 
     project = workspace.project()

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -482,20 +482,12 @@ def test_e2e_update_file(page, live_server, dev_users):
 
     # Update file in request
     # Find the add file button and click on it to open the modal
-    find_and_click(page.locator("button[value=add_files]"))
-
-    # By default, the selected filetype is OUTPUT
-    expect(page.locator("input[name=form-0-filetype][value=OUTPUT]")).to_be_checked()
-    expect(
-        page.locator("input[name=form-0-filetype][value=SUPPORTING]")
-    ).not_to_be_checked()
+    find_and_click(page.locator("button[value=update_files]"))
 
     # Click the button to add the file to a release request
-    find_and_click(page.get_by_role("form").locator("#add-file-button"))
+    find_and_click(page.get_by_role("form").locator("#update-file-button"))
 
-    expect(page.locator("body")).to_contain_text(
-        "Output file has been updated in request"
-    )
+    expect(page.locator("body")).to_contain_text("file has been updated in request")
 
 
 def test_e2e_withdraw_and_readd_file(page, live_server, dev_users):

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -700,10 +700,7 @@ def test_workspace_multiselect_update_files(
     assert response.status_code == 200
     assert "test/path1.txt" in response.rendered_content
     assert "test/path2.txt" in response.rendered_content
-    assert (
-        response.rendered_content.count("cannot add using the update dialogue")
-        == ignored_count
-    )
+    assert response.rendered_content.count("file cannot be updated") == ignored_count
 
 
 def test_workspace_multiselect_add_released_file_not_valid(airlock_client, bll):

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -3,8 +3,9 @@ from django.contrib import messages
 from django.contrib.messages.api import get_messages
 from django.urls import reverse
 
+from airlock import policies
 from airlock.business_logic import Project
-from airlock.enums import RequestFileType, RequestStatus
+from airlock.enums import RequestFileType, RequestStatus, WorkspaceFileStatus
 from airlock.types import UrlPath
 from tests import factories
 from tests.conftest import get_trace
@@ -605,6 +606,106 @@ def test_workspace_multiselect_add_files_none_valid(airlock_client, bll):
     assert 'name="filegroup"' not in response.rendered_content
 
 
+def test_workspace_multiselect_add_files_updated_file(airlock_client, bll):
+    airlock_client.login(workspaces=["test1"])
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path1.txt")
+    factories.write_workspace_file(workspace, "test/path2.txt")
+    release_request = factories.create_release_request(
+        workspace, user=airlock_client.user
+    )
+    factories.add_request_file(release_request, "group1", "test/path1.txt")
+    factories.add_request_file(release_request, "group1", "test/path2.txt")
+
+    factories.write_workspace_file(workspace, "test/path1.txt", "changed1")
+    # refresh workspace
+    workspace = bll.get_workspace("test1", airlock_client.user)
+    policies.check_can_update_file_on_request(workspace, "test/path1.txt")
+
+    response = airlock_client.post(
+        "/workspaces/multiselect/test1",
+        data={
+            "action": "add_files",
+            "selected": [
+                "test/path1.txt",
+                "test/path2.txt",
+            ],
+            "next_url": workspace.get_url("test/path.txt"),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "test/path1.txt" in response.rendered_content
+    assert "test/path2.txt" in response.rendered_content
+    assert response.rendered_content.count("cannot update using the add dialogue") == 1
+    assert response.rendered_content.count("already in group") == 1
+    assert 'name="filegroup"' not in response.rendered_content
+
+
+@pytest.mark.parametrize(
+    "path1_updated,path2_updated,ignored_count",
+    [
+        (True, True, 0),
+        (True, False, 1),
+        (False, False, 2),
+    ],
+)
+def test_workspace_multiselect_update_files(
+    airlock_client, bll, path1_updated, path2_updated, ignored_count
+):
+    author = factories.create_user("author", workspaces=["test1"])
+    airlock_client.login_with_user(author)
+
+    workspace = factories.create_workspace("test1")
+    path1 = "test/path1.txt"
+    path2 = "test/path2.txt"
+
+    factories.create_request_at_status(
+        "test1",
+        author=airlock_client.user,
+        status=RequestStatus.RETURNED,
+        files=[
+            factories.request_file(path=path1, group="default", changes_requested=True),
+            factories.request_file(path=path2, group="default", changes_requested=True),
+        ],
+    )
+
+    assert workspace.get_workspace_file_status(path1) == WorkspaceFileStatus.UNRELEASED
+    assert workspace.get_workspace_file_status(path2) == WorkspaceFileStatus.UNRELEASED
+
+    if path1_updated:
+        factories.write_workspace_file(workspace, path1, "changed1")
+        # refresh workspace
+        workspace = bll.get_workspace("test1", airlock_client.user)
+        policies.check_can_update_file_on_request(workspace, path1)
+
+    if path2_updated:
+        factories.write_workspace_file(workspace, path2, "changed1")
+        # refresh workspace
+        workspace = bll.get_workspace("test1", airlock_client.user)
+        policies.check_can_update_file_on_request(workspace, path2)
+
+    response = airlock_client.post(
+        "/workspaces/multiselect/test1",
+        data={
+            "action": "update_files",
+            "selected": [
+                "test/path1.txt",
+                "test/path2.txt",
+            ],
+            "next_url": workspace.get_url("test/path1.txt"),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "test/path1.txt" in response.rendered_content
+    assert "test/path2.txt" in response.rendered_content
+    assert (
+        response.rendered_content.count("cannot add using the update dialogue")
+        == ignored_count
+    )
+
+
 def test_workspace_multiselect_add_released_file_not_valid(airlock_client, bll):
     airlock_client.login(workspaces=["test1"])
     workspace = factories.create_workspace("test1")
@@ -928,6 +1029,73 @@ def test_workspace_request_file_invalid_formset(airlock_client, bll):
     message = all_messages[0]
     assert message.level == messages.ERROR
     assert "At least one form must be completed" in message.message
+
+
+def test_workspace_request_update_file_invalid_status(airlock_client, bll):
+    airlock_client.login(workspaces=["test1"])
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt")
+
+    assert bll.get_current_request(workspace.name, airlock_client.user) is None
+    response = airlock_client.post(
+        "/workspaces/update-file-in-request/test1",
+        data={
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-0-file": "test/path.txt",
+            "next_url": workspace.get_url("test/path.txt"),
+        },
+        follow=True,
+    )
+    assert response.status_code == 200
+
+    all_messages = [msg for msg in response.context["messages"]]
+    assert len(all_messages) == 1
+    message = all_messages[0]
+    assert message.level == messages.ERROR
+    assert (
+        "Cannot update file in request if it is not updated on disk" in message.message
+    )
+
+
+def test_workspace_request_update_file_request_path_does_not_exist(airlock_client):
+    airlock_client.login(workspaces=["test1"])
+    workspace = factories.create_workspace("test1")
+
+    response = airlock_client.post(
+        "/workspaces/update-file-in-request/test1",
+        data={
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-0-file": "test/path.txt",
+            "next_url": workspace.get_url("test/path.txt"),
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_workspace_request_update_file_invalid_formset(airlock_client, bll):
+    airlock_client.login(workspaces=["test1"])
+
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt")
+
+    response = airlock_client.post(
+        "/workspaces/update-file-in-request/test1",
+        data={
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "next_url": workspace.get_url("test/path.txt"),
+        },
+        follow=True,
+    )
+
+    all_messages = [msg for msg in response.context["messages"]]
+    assert len(all_messages) == 1
+    message = all_messages[0]
+    assert message.level == messages.ERROR
+    assert "file: This field is required" in message.message
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -1095,6 +1095,29 @@ def test_workspace_request_update_file_invalid_formset(airlock_client, bll):
     assert "file: This field is required" in message.message
 
 
+def test_workspace_request_update_file_empty_formset(airlock_client, bll):
+    airlock_client.login(workspaces=["test1"])
+
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt")
+
+    response = airlock_client.post(
+        "/workspaces/update-file-in-request/test1",
+        data={
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "next_url": workspace.get_url("test/path.txt"),
+        },
+        follow=True,
+    )
+
+    all_messages = [msg for msg in response.context["messages"]]
+    assert len(all_messages) == 1
+    message = all_messages[0]
+    assert message.level == messages.ERROR
+    assert "At least one form must be completed." in message.message
+
+
 @pytest.mark.parametrize(
     "urlpath,post_data",
     [


### PR DESCRIPTION
* before this PR, when updating a file we were showing the add file dialogue
  * this included filetype & group selectors which were being ignored 
* create (& use) a new multiselect view & form to use for updating files
* refactor the code for re-adding a withdrawn file & updating a file using the new policies/permissions files
* at the moment updating a file is limited to one file, but this lays a lot of the groundwork to implement a multiselect update files button on the workspace view

<img width="546" alt="Screenshot 2024-08-09 at 16 38 50" src="https://github.com/user-attachments/assets/aacd12c2-7d3f-415a-b8db-49747c718657">
