### PR TITLE
Small add file permission refactor

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -467,6 +467,13 @@ class Workspace:
             WorkspaceFileStatus.WITHDRAWN,
         ]
 
+    def file_can_be_added(self, relpath: UrlPath) -> bool:
+        return self.get_workspace_file_status(relpath) in [
+            WorkspaceFileStatus.UNRELEASED,
+            WorkspaceFileStatus.CONTENT_UPDATED,
+            WorkspaceFileStatus.WITHDRAWN,
+        ]
+
 
 @dataclass(frozen=True)
 class CodeRepo:

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from airlock import exceptions
-from airlock.enums import WorkspaceFileStatus
 from airlock.types import UrlPath
 from airlock.utils import is_valid_file_type
 
@@ -48,13 +47,6 @@ def can_add_file_to_request(workspace: "Workspace", relpath: UrlPath):
     return True
 
 
-VALID_WORKSPACEFILE_STATES_TO_ADD = [
-    WorkspaceFileStatus.UNRELEASED,
-    WorkspaceFileStatus.CONTENT_UPDATED,
-    WorkspaceFileStatus.WITHDRAWN,
-]
-
-
 def check_can_add_file_to_request(workspace: "Workspace", relpath: UrlPath):
     """
     This file can be added to the request.
@@ -69,10 +61,10 @@ def check_can_add_file_to_request(workspace: "Workspace", relpath: UrlPath):
     if workspace.file_has_been_released(relpath):
         raise exceptions.RequestPermissionDenied("Cannot add released file to request")
 
-    workspace_status = workspace.get_workspace_file_status(relpath)
-    if workspace_status not in VALID_WORKSPACEFILE_STATES_TO_ADD:
+    if not workspace.file_can_be_added(relpath):
+        status = workspace.get_workspace_file_status(relpath)
         raise exceptions.RequestPermissionDenied(
-            f"Cannot add file in status {workspace_status}"
+            f"Cannot add file to request if it is in status {status}"
         )
 
 

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -165,9 +165,6 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
                 existing_file = RequestFileMetadata.objects.get(
                     request_id=request_id, relpath=relpath
                 )
-                # We should never be able to attempt to add a file to a request
-                # with a different filetype
-                assert existing_file.filetype == filetype
             except RequestFileMetadata.DoesNotExist:
                 # create the RequestFile
                 RequestFileMetadata.objects.create(


### PR DESCRIPTION
* the UI would not present the option to add a file in the state UNDER_REVIEW. Although the BLL function would accept a file in that state, the BLL's call to the DAL would then correctly reject it
* I believe the existing function in policies.py was derived from the BLL function
