### PR TITLE
Replace `pip-compile` command with `compile-reqs`

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,12 +30,16 @@ virtualenv:
     fi
 
 
-# run pip-compile with our standard settings
-pip-compile *args: devenv
+# compile all requirements.in files (by default only adds/removes packages; `-U` upgrades all; `-P <package>` upgrades one)
+compile-reqs *ARGS: devenv
     #!/usr/bin/env bash
     set -euo pipefail
 
-    $BIN/pip-compile --allow-unsafe --generate-hashes --strip-extras {{ args }}
+    command="pip-compile --quiet --allow-unsafe --generate-hashes --strip-extras"
+    for req_file in requirements.prod.in requirements.dev.in; do
+      echo $command "$req_file" "$@"
+      $BIN/$command "$req_file" "$@"
+    done
 
 
 # create a valid .env if none exists


### PR DESCRIPTION
This follows on from #617 by adding a single `just` command which does the right thing with respect to compiling requirements files.

There's now no need for a separate `pip-compile` command: it's easy enough to run specific `pip-compile` commands by hand if you really need to, and the new command echos what it's doing for transparency.

The command name itself deliberately doesn't include `pip`: its use is an implementation detail and it's possible we'll swap it for `uv` further down the line.