### PR TITLE
Remove factories request creation workaround

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1308,14 +1308,11 @@ class BusinessLogicLayer:
         # and is not an output-cheker
         request = self.get_current_request(workspace, user)
 
-        # requests for output-checkers, and for archived workspaces and inactive
-        # projects are still viewable, check if user has permission to create one
-        # Note: we check this here, as this function is only used when we are
-        # about to modify a request, so do a look ahead check to make sure we can
-        permissions.check_user_can_action_request_for_workspace(user, workspace)
-
         if request is not None:
             return request
+
+        # check if user has permission to create one
+        permissions.check_user_can_action_request_for_workspace(user, workspace)
 
         audit = AuditEvent(
             type=AuditEventType.REQUEST_CREATE,

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -1077,7 +1077,6 @@ class DataAccessLayerProtocol(Protocol):
         author: str,
         status: RequestStatus,
         audit: AuditEvent,
-        id: str | None = None,  # noqa: A002
     ):
         raise NotImplementedError()
 
@@ -1273,19 +1272,18 @@ class BusinessLogicLayer:
         workspace: str,
         author: User,
         status: RequestStatus = RequestStatus.PENDING,
-        id: str | None = None,  # noqa: A002
     ) -> ReleaseRequest:
         """Factory function to create a release_request.
 
         Is private because it is meant to be used directly by our test factories
         to set up state - it is not part of the public API.
         """
-        # id is used to set specific ids in tests. We should probably not allow this.
         audit = AuditEvent(
             type=self.STATUS_AUDIT_EVENT[status],
             user=author.username,
             workspace=workspace,
-            # DAL will set request id once its created
+            # for this specific audit, the DAL will set request id once its
+            # created, as we do not know it yet
         )
         return ReleaseRequest.from_dict(
             self._dal.create_release_request(
@@ -1293,7 +1291,6 @@ class BusinessLogicLayer:
                 author=author.username,
                 status=status,
                 audit=audit,
-                id=id,
             )
         )
 

--- a/local_db/data_access.py
+++ b/local_db/data_access.py
@@ -37,7 +37,6 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
         author: str,
         status: RequestStatus,
         audit: AuditEvent,
-        id: str | None = None,  # noqa: A002
     ):
         # Note: id is created automatically, but can be set manually if needed
         with transaction.atomic():
@@ -45,9 +44,8 @@ class LocalDBDataAccessLayer(DataAccessLayerProtocol):
                 workspace=workspace,
                 author=author,
                 status=status,
-                id=id,  # noqa: A002
             )
-            # ensure correct id
+            # special case: ensure audit has correct id now that we know it
             audit.request = metadata.id
             self._create_audit_log(audit)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,18 +68,18 @@ def bll(monkeypatch):
 
 @pytest.fixture
 def release_files_stubber(responses):
-    def release_files(request, jobserver_id="jobserver-id", body=None):
+    def release_files(request, body=None):
         responses.post(
             f"{settings.AIRLOCK_API_ENDPOINT}/releases/workspace/{request.workspace}",
             status=201,
-            headers={"Release-Id": jobserver_id},
+            headers={"Release-Id": request.id},
             body=body,
         )
 
         if not isinstance(body, Exception):
             for _ in request.get_output_file_paths():
                 responses.post(
-                    f"{settings.AIRLOCK_API_ENDPOINT}/releases/release/{jobserver_id}",
+                    f"{settings.AIRLOCK_API_ENDPOINT}/releases/release/{request.id}",
                     status=201,
                 )
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -30,32 +30,42 @@ from airlock.users import User
 
 
 def create_user(
-    username="testuser", workspaces=None, output_checker=False, last_refresh=None
+    username="testuser",
+    workspaces: list[str] | None = None,
+    output_checker=False,
+    last_refresh=None,
 ):
     """Factory to create a user.
 
-    For ease of use, workspaces can either be a list of workspaces, which is
-    converted into an appropriate dict. Or it can be an explicit dict, but must
-    include all expected dict parameters.
+    For ease of use, workspaces is just a flat list of workspace name, which is
+    converted into an appropriate dict with all the right keys.
+
+    If you need to create a more complex workspace dict, you can call
+    create_user_from_dict directly.
     """
-    if isinstance(workspaces, dict):
-        # TODO check this dict is valid?
-        workspaces_dict = workspaces
-    else:
-        if workspaces is None:
-            # default to usual workspace
-            workspaces = ["workspace"]
+    if workspaces is None:
+        # default to usual workspace
+        workspaces = ["workspace"]
 
-        workspaces_dict = {
-            workspace: {
-                "project_details": {"name": "project", "ongoing": True},
-                "archived": False,
-            }
-            for workspace in workspaces
+    workspaces_dict = {
+        workspace: {
+            "project_details": {"name": "project", "ongoing": True},
+            "archived": False,
         }
+        for workspace in workspaces
+    }
 
+    return create_user_from_dict(
+        username, workspaces_dict, output_checker, last_refresh
+    )
+
+
+def create_user_from_dict(
+    username, workspaces_dict, output_checker=False, last_refresh=None
+):
     if last_refresh is None:
         last_refresh = time.time()
+
     return User(username, workspaces_dict, output_checker, last_refresh)
 
 

--- a/tests/integration/test_old_api.py
+++ b/tests/integration/test_old_api.py
@@ -48,7 +48,7 @@ def test_old_api_create_release_with_error(responses, caplog):
 
 
 def test_old_api_upload_file(responses):
-    release_request = factories.create_release_request("workspace", id="request-id")
+    release_request = factories.create_release_request("workspace")
     relpath = Path("test/file.txt")
     release_request = factories.add_request_file(
         release_request, "group", relpath, "test"
@@ -68,7 +68,7 @@ def test_old_api_upload_file(responses):
 
 
 def test_old_api_upload_file_error(responses, caplog):
-    release_request = factories.create_release_request("workspace", id="request-id")
+    release_request = factories.create_release_request("workspace")
     relpath = Path("test/file.txt")
     release_request = factories.add_request_file(
         release_request, "group", relpath, "test"

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -672,6 +672,7 @@ def test_request_index_user_output_checker(airlock_client):
     other = factories.create_user(
         "other",
         workspaces=[
+            "test_workspace",
             "other_workspace",
             "other_other_workspace",
             "other_other1_workspace",
@@ -875,7 +876,7 @@ def test_request_withdraw_author(airlock_client):
 
 def test_request_withdraw_not_author(airlock_client):
     airlock_client.login(workspaces=["test1"])
-    other_author = factories.create_user("other", [], False)
+    other_author = factories.create_user("other", ["test1"], False)
     release_request = factories.create_release_request(
         "test1", user=other_author, status=RequestStatus.PENDING
     )
@@ -1508,7 +1509,7 @@ def test_request_release_files_success_htmx(
 
 
 def test_requests_release_workspace_403(airlock_client):
-    airlock_client.login("checker", output_checker=False)
+    airlock_client.login("checker", workspaces=[], output_checker=False)
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.SUBMITTED,

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -501,9 +501,11 @@ def test_request_view_redirects_to_file(airlock_client):
 
 def test_request_contents_file(airlock_client):
     airlock_client.login(output_checker=True)
-    release_request = factories.create_release_request("workspace", id="id")
+    release_request = factories.create_release_request("workspace")
     factories.add_request_file(release_request, "default", "file.txt", contents="test")
-    response = airlock_client.get("/requests/content/id/default/file.txt")
+    response = airlock_client.get(
+        f"/requests/content/{release_request.id}/default/file.txt"
+    )
     assert response.status_code == 200
     assert response.content == b'<pre class="txt">\ntest\n</pre>\n'
     audit_log = bll.get_request_audit_log(
@@ -517,42 +519,44 @@ def test_request_contents_file(airlock_client):
 
 def test_request_contents_dir(airlock_client):
     airlock_client.login(output_checker=True)
-    release_request = factories.create_release_request("workspace", id="id")
+    release_request = factories.create_release_request("workspace")
     factories.add_request_file(
         release_request, "default", "foo/file.txt", contents="test"
     )
-    response = airlock_client.get("/requests/content/id/default/foo")
+    response = airlock_client.get(f"/requests/content/{release_request.id}/default/foo")
     assert response.status_code == 404
 
 
 def test_request_contents_file_not_exists(airlock_client):
     airlock_client.login(output_checker=True)
-    release_request = factories.create_release_request("workspace", id="id")
+    release_request = factories.create_release_request("workspace")
     factories.add_request_file(
         release_request, "default", "foo/file.txt", contents="test"
     )
-    response = airlock_client.get("/requests/content/id/default/notexists.txt")
+    response = airlock_client.get(
+        f"/requests/content/{release_request.id}/default/notexists.txt"
+    )
     assert response.status_code == 404
 
 
 def test_request_contents_group_not_exists(airlock_client):
     airlock_client.login(output_checker=True)
-    release_request = factories.create_release_request("workspace", id="id")
+    release_request = factories.create_release_request("workspace")
     factories.add_request_file(
         release_request, "default", "foo/file.txt", contents="test"
     )
-    response = airlock_client.get("/requests/content/id/notexist/")
+    response = airlock_client.get(f"/requests/content/{release_request.id}/notexist/")
     assert response.status_code == 404
 
 
 def test_request_download_file(airlock_client):
     airlock_client.login("reviewer", output_checker=True)
     author = factories.create_user("author", ["workspace"])
-    release_request = factories.create_release_request(
-        "workspace", id="id", user=author
-    )
+    release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "default", "file.txt", contents="test")
-    response = airlock_client.get("/requests/content/id/default/file.txt?download")
+    response = airlock_client.get(
+        f"/requests/content/{release_request.id}/default/file.txt?download"
+    )
     assert response.status_code == 200
     assert response.as_attachment
     assert list(response.streaming_content) == [b"test"]
@@ -628,13 +632,13 @@ def test_request_download_file_permissions(
 ):
     airlock_client.login(**user)
     author = factories.create_user(**request_author)
-    release_request = factories.create_release_request(
-        "workspace", id="id", user=author
-    )
+    release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(
         release_request, "default", "file.txt", contents="test", user=author
     )
-    response = airlock_client.get("/requests/content/id/default/file.txt?download")
+    response = airlock_client.get(
+        f"/requests/content/{release_request.id}/default/file.txt?download"
+    )
     if can_download:
         assert response.status_code == 200
         assert response.as_attachment
@@ -1461,7 +1465,6 @@ def test_request_release_files_success(airlock_client, release_files_stubber, st
     airlock_client.login(username="checker", output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         status=status,
         files=[
             factories.request_file(path="file.txt", contents="test1", approved=True),
@@ -1470,8 +1473,8 @@ def test_request_release_files_success(airlock_client, release_files_stubber, st
     )
 
     api_responses = release_files_stubber(release_request)
-    response = airlock_client.post("/requests/release/request_id")
-    assert response.url == "/requests/view/request_id/"
+    response = airlock_client.post(f"/requests/release/{release_request.id}")
+    assert response.url == f"/requests/view/{release_request.id}/"
     assert response.status_code == 302
 
     assert api_responses.calls[1].request.body.read() == b"test1"
@@ -1485,7 +1488,6 @@ def test_request_release_files_success_htmx(
     airlock_client.login(username="checker", output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         status=status,
         files=[
             factories.request_file(path="file.txt", contents="test1", approved=True),
@@ -1494,11 +1496,11 @@ def test_request_release_files_success_htmx(
     )
     api_responses = release_files_stubber(release_request)
     response = airlock_client.post(
-        "/requests/release/request_id",
+        f"/requests/release/{release_request.id}",
         headers={"HX-Request": "true"},
     )
 
-    assert response.headers["HX-Redirect"] == "/requests/view/request_id/"
+    assert response.headers["HX-Redirect"] == f"/requests/view/{release_request.id}/"
     assert response.status_code == 200
 
     assert api_responses.calls[1].request.body.read() == b"test1"
@@ -1507,29 +1509,29 @@ def test_request_release_files_success_htmx(
 
 def test_requests_release_workspace_403(airlock_client):
     airlock_client.login("checker", output_checker=False)
-    factories.create_request_at_status(
+    release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         status=RequestStatus.SUBMITTED,
         files=[
             factories.request_file("group", "path/test.txt", approved=True),
         ],
     )
 
-    response = airlock_client.post("/requests/release/request_id")
+    response = airlock_client.post(f"/requests/release/{release_request.id}")
     assert response.status_code == 403
 
 
 def test_requests_release_author_403(airlock_client):
     airlock_client.login(output_checker=True, workspaces=["workspace"])
-    factories.create_request_at_status(
+    release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         author=airlock_client.user,
         status=RequestStatus.REVIEWED,
         files=[factories.request_file(approved=True)],
     )
-    response = airlock_client.post("/requests/release/request_id", follow=True)
+    response = airlock_client.post(
+        f"/requests/release/{release_request.id}", follow=True
+    )
     assert response.status_code == 200
     assert (
         list(response.context["messages"])[0].message
@@ -1539,13 +1541,14 @@ def test_requests_release_author_403(airlock_client):
 
 def test_requests_release_invalid_state_transition_403(airlock_client):
     airlock_client.login("checker", output_checker=True)
-    factories.create_request_at_status(
+    release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         status=RequestStatus.RETURNED,
         files=[factories.request_file(approved=True)],
     )
-    response = airlock_client.post("/requests/release/request_id", follow=True)
+    response = airlock_client.post(
+        f"/requests/release/{release_request.id}", follow=True
+    )
     assert response.status_code == 200
     assert (
         list(response.context["messages"])[0].message
@@ -1557,7 +1560,6 @@ def test_requests_release_jobserver_403(airlock_client, release_files_stubber):
     airlock_client.login("checker", output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         status=RequestStatus.REVIEWED,
         files=[factories.request_file(approved=True)],
     )
@@ -1568,7 +1570,9 @@ def test_requests_release_jobserver_403(airlock_client, release_files_stubber):
     release_files_stubber(release_request, body=api403)
 
     # test 403 is handled
-    response = airlock_client.post("/requests/release/request_id", follow=True)
+    response = airlock_client.post(
+        f"/requests/release/{release_request.id}", follow=True
+    )
     assert response.status_code == 200
     assert (
         list(response.context["messages"])[0].message
@@ -1595,7 +1599,6 @@ def test_requests_release_jobserver_403_with_debug(
     settings.DEBUG = True
     release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         status=RequestStatus.REVIEWED,
         files=[factories.request_file(approved=True)],
     )
@@ -1608,7 +1611,9 @@ def test_requests_release_jobserver_403_with_debug(
     release_files_stubber(release_request, body=api403)
 
     # test 403 is handled
-    response = airlock_client.post("/requests/release/request_id", follow=True)
+    response = airlock_client.post(
+        f"/requests/release/{release_request.id}", follow=True
+    )
     # DEBUG is on, so we return the job-server error
     assert response.status_code == 200
     error_message = list(response.context["messages"])[0].message
@@ -1620,7 +1625,6 @@ def test_requests_release_files_404(airlock_client, release_files_stubber):
     airlock_client.login("checker", output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         status=RequestStatus.REVIEWED,
         files=[factories.request_file(approved=True)],
     )
@@ -1630,7 +1634,9 @@ def test_requests_release_files_404(airlock_client, release_files_stubber):
     api404 = requests.HTTPError(response=response)
     release_files_stubber(release_request, body=api404)
 
-    response = airlock_client.post("/requests/release/request_id", follow=True)
+    response = airlock_client.post(
+        f"/requests/release/{release_request.id}", follow=True
+    )
     assert response.status_code == 200
     assert (
         list(response.context["messages"])[0].message
@@ -1642,36 +1648,36 @@ def test_requests_release_files_404(airlock_client, release_files_stubber):
     "urlpath,post_data,login_as,status,stub",
     [
         (
-            "/requests/view/request-id/default/",
+            "/requests/view/{request.id}/default/",
             None,
             "output_checker",
             RequestStatus.PENDING,
             False,
         ),
         (
-            "/requests/view/request-id/default/file.txt",
+            "/requests/view/{request.id}/default/file.txt",
             None,
             "output_checker",
             RequestStatus.PENDING,
             False,
         ),
         (
-            "/requests/content/request-id/default/file.txt",
+            "/requests/content/{request.id}/default/file.txt",
             None,
             "output_checker",
             RequestStatus.PENDING,
             False,
         ),
-        ("/requests/submit/request-id", {}, "author", RequestStatus.PENDING, False),
+        ("/requests/submit/{request.id}", {}, "author", RequestStatus.PENDING, False),
         (
-            "/requests/reject/request-id",
+            "/requests/reject/{request.id}",
             {},
             "output_checker",
             RequestStatus.REVIEWED,
             False,
         ),
         (
-            "/requests/release/request-id",
+            "/requests/release/{request.id}",
             {},
             "output_checker",
             RequestStatus.REVIEWED,
@@ -1690,7 +1696,6 @@ def test_request_view_tracing_with_request_attribute(
         "test-workspace",
         status=status,
         author=author,
-        id="request-id",
         files=[
             factories.request_file(
                 "default",
@@ -1701,16 +1706,19 @@ def test_request_view_tracing_with_request_attribute(
         ],
     )
 
+    # inject request id
+    url = urlpath.format(request=release_request)
+
     if stub:
         release_files_stubber(release_request)
 
     if post_data is not None:
-        airlock_client.post(urlpath, post_data)
+        airlock_client.post(url, post_data)
     else:
-        airlock_client.get(urlpath)
+        airlock_client.get(url)
     traces = get_trace()
     last_trace = traces[-1]
-    assert last_trace.attributes == {"release_request": "request-id"}
+    assert last_trace.attributes == {"release_request": release_request.id}
 
 
 def test_group_edit_success(airlock_client):

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -21,14 +21,17 @@ def test_home_redirects(airlock_client):
 
 
 def test_workspace_view_summary(airlock_client):
-    airlock_client.login(
-        workspaces={
+    user = factories.create_user_from_dict(
+        username="testuser",
+        workspaces_dict={
             "workspace": {
                 "project_details": {"name": "TESTPROJECT", "ongoing": True},
                 "archived": False,
             }
-        }
+        },
     )
+
+    airlock_client.login_with_user(user)
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, "file.txt")
 
@@ -39,14 +42,17 @@ def test_workspace_view_summary(airlock_client):
 
 
 def test_workspace_view_archived_inactive(airlock_client):
-    airlock_client.login(
-        workspaces={
+    user = factories.create_user_from_dict(
+        username="testuser",
+        workspaces_dict={
             "workspace-abc": {
                 "project_details": {"name": "TESTPROJECT", "ongoing": False},
                 "archived": True,
             }
-        }
+        },
     )
+
+    airlock_client.login_with_user(user)
     workspace = factories.create_workspace("workspace-abc")
     factories.write_workspace_file(workspace, "file.txt")
 
@@ -461,8 +467,9 @@ def test_workspaces_index_no_user(airlock_client):
 
 
 def test_workspaces_index_user_permitted_workspaces(airlock_client):
-    airlock_client.login(
-        workspaces={
+    user = factories.create_user_from_dict(
+        username="testuser",
+        workspaces_dict={
             "test1a": {
                 "project_details": {"name": "Project 1", "ongoing": True},
                 "archived": True,
@@ -487,8 +494,10 @@ def test_workspaces_index_user_permitted_workspaces(airlock_client):
                 "project_details": {"name": "Project 3", "ongoing": True},
                 "archived": False,
             },
-        }
+        },
     )
+
+    airlock_client.login_with_user(user)
     factories.create_workspace("test1a")
     factories.create_workspace("test1b")
     factories.create_workspace("test1c")

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -116,7 +116,7 @@ def test_workspace_directory_and_request_can_multiselect_add(
 ):
     users = {
         "author": factories.create_user("author", workspaces=["workspace"]),
-        "checker": factories.create_user("checker", output_checker=True),
+        "checker": factories.create_user("checker", workspaces=[], output_checker=True),
     }
     airlock_client.login_with_user(users[login_as])
     factories.create_request_at_status(

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -971,48 +971,6 @@ def test_provider_get_or_create_current_request_for_user(bll):
         bll.get_current_request("workspace", user)
 
 
-@pytest.mark.parametrize(
-    "workspaces,exception",
-    [
-        # no access
-        ({}, exceptions.WorkspacePermissionDenied),
-        # workspace archived
-        (
-            {
-                "workspace": {
-                    "project_details": {"name": "p1", "ongoing": True},
-                    "archived": True,
-                }
-            },
-            exceptions.RequestPermissionDenied,
-        ),
-        # project inactive
-        (
-            {
-                "workspace": {
-                    "project_details": {"name": "p1", "ongoing": False},
-                    "archived": False,
-                }
-            },
-            exceptions.RequestPermissionDenied,
-        ),
-    ],
-)
-def test_provider_get_or_create_current_request_for_user_no_permissions(
-    bll, workspaces, exception
-):
-    workspace = factories.create_workspace("workspace")
-    # create the request with a user who has permission
-    factories.create_release_request(
-        workspace, factories.create_user("testuser", ["workspace"])
-    )
-
-    # Duplicate user who has the test permissions/workspace status
-    user = factories.create_user_from_dict("testuser", workspaces, False)
-    with pytest.raises(exception):
-        bll.get_or_create_current_request("workspace", user)
-
-
 def test_provider_get_current_request_for_former_user(bll):
     factories.create_workspace("workspace")
     user = factories.create_user("testuser", ["workspace"], False)

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -173,9 +173,9 @@ def test_workspace_get_workspace_archived_ongoing(bll):
     factories.create_workspace("normal_workspace")
     factories.create_workspace("archived_workspace")
     factories.create_workspace("not_ongoing")
-    user = factories.create_user(
+    user = factories.create_user_from_dict(
         "user",
-        workspaces={
+        workspaces_dict={
             "normal_workspace": {
                 "project": "project-1",
                 "project_details": {"name": "project-1", "ongoing": True},
@@ -1008,7 +1008,7 @@ def test_provider_get_or_create_current_request_for_user_no_permissions(
     )
 
     # Duplicate user who has the test permissions/workspace status
-    user = factories.create_user("testuser", workspaces, False)
+    user = factories.create_user_from_dict("testuser", workspaces, False)
     with pytest.raises(exception):
         bll.get_or_create_current_request("workspace", user)
 
@@ -1585,7 +1585,7 @@ def test_add_file_to_request_no_permission(bll, workspaces, exception):
     )
 
     # create duplicate user with test workspaces
-    author = factories.create_user("author", workspaces, False)
+    author = factories.create_user_from_dict("author", workspaces, False)
     with pytest.raises(exception):
         bll.add_file_to_request(release_request, path, author)
 

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -381,22 +381,24 @@ def test_request_returned_author_get_workspace_file_status(bll):
 
 
 def test_request_container(mock_notifications):
-    release_request = factories.create_release_request("workspace", id="id")
+    release_request = factories.create_release_request("workspace")
     release_request = factories.add_request_file(release_request, "group", "bar.html")
+    rid = release_request.get_id()
 
-    assert release_request.root() == settings.REQUEST_DIR / "workspace/id"
-    assert release_request.get_id() == "id"
+    assert release_request.root() == settings.REQUEST_DIR / "workspace" / rid
+
     assert (
-        release_request.get_url("group/bar.html") == "/requests/view/id/group/bar.html"
+        release_request.get_url("group/bar.html")
+        == f"/requests/view/{rid}/group/bar.html"
     )
     assert (
-        "/requests/content/id/group/bar.html?cache_id="
+        f"/requests/content/{rid}/group/bar.html?cache_id="
         in release_request.get_contents_url(UrlPath("group/bar.html"))
     )
     plaintext_contents_url = release_request.get_contents_url(
         UrlPath("group/bar.html"), plaintext=True
     )
-    assert "/requests/content/id/group/bar.html?cache_id=" in plaintext_contents_url
+    assert f"/requests/content/{rid}/group/bar.html?cache_id=" in plaintext_contents_url
     assert "&plaintext=true" in plaintext_contents_url
 
     assert_no_notifications(mock_notifications)
@@ -522,7 +524,6 @@ def test_provider_request_release_files_request_not_approved(bll, mock_notificat
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
-        id="request_id",
         status=RequestStatus.SUBMITTED,
     )
 
@@ -540,7 +541,6 @@ def test_provider_request_release_files_invalid_file_type(bll, mock_notification
     with patch("airlock.utils.LEVEL4_FILE_TYPES", [".foo"]):
         release_request = factories.create_request_at_status(
             "workspace",
-            id="request_id",
             status=RequestStatus.APPROVED,
             files=[factories.request_file(path="test/file.foo", approved=True)],
         )
@@ -557,7 +557,6 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
     checkers = factories.get_default_output_checkers()
     release_request = factories.create_request_at_status(
         "workspace",
-        id="request_id",
         author=author,
         status=RequestStatus.RETURNED,
         files=[
@@ -626,7 +625,7 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
     }
 
     old_api.create_release.assert_called_once_with(
-        "workspace", "request_id", json.dumps(expected_json), checkers[0].username
+        "workspace", release_request.id, json.dumps(expected_json), checkers[0].username
     )
     old_api.upload_file.assert_called_once_with(
         "jobserver_id", relpath, abspath, checkers[0].username
@@ -686,21 +685,21 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
 def test_provider_get_requests_for_workspace(bll):
     user = factories.create_user("test", ["workspace", "workspace2"])
     other_user = factories.create_user("other", ["workspace"])
-    factories.create_release_request("workspace", user, id="r1")
-    factories.create_release_request("workspace2", user, id="r2")
-    factories.create_release_request("workspace", other_user, id="r3")
+    r1 = factories.create_release_request("workspace", user)
+    factories.create_release_request("workspace2", user)
+    r3 = factories.create_release_request("workspace", other_user)
 
     assert [r.id for r in bll.get_requests_for_workspace("workspace", user)] == [
-        "r1",
-        "r3",
+        r1.id,
+        r3.id,
     ]
 
 
 def test_provider_get_requests_for_workspace_bad_user(bll):
     user = factories.create_user("test", ["workspace"])
     other_user = factories.create_user("other", ["workspace_2"])
-    factories.create_release_request("workspace", user, id="r1")
-    factories.create_release_request("workspace_2", other_user, id="r2")
+    factories.create_release_request("workspace", user)
+    factories.create_release_request("workspace_2", other_user)
 
     with pytest.raises(exceptions.WorkspacePermissionDenied):
         bll.get_requests_for_workspace("workspace", other_user)
@@ -709,20 +708,20 @@ def test_provider_get_requests_for_workspace_bad_user(bll):
 def test_provider_get_requests_for_workspace_output_checker(bll):
     user = factories.create_user("test", ["workspace"])
     other_user = factories.create_user("other", [], True)
-    factories.create_release_request("workspace", user, id="r1")
+    r1 = factories.create_release_request("workspace", user)
 
     assert [r.id for r in bll.get_requests_for_workspace("workspace", other_user)] == [
-        "r1",
+        r1.id,
     ]
 
 
 def test_provider_get_requests_authored_by_user(bll):
     user = factories.create_user("test", ["workspace"])
     other_user = factories.create_user("other", ["workspace"])
-    factories.create_release_request("workspace", user, id="r1")
-    factories.create_release_request("workspace", other_user, id="r2")
+    r1 = factories.create_release_request("workspace", user)
+    factories.create_release_request("workspace", other_user)
 
-    assert [r.id for r in bll.get_requests_authored_by_user(user)] == ["r1"]
+    assert [r.id for r in bll.get_requests_authored_by_user(user)] == [r1.id]
 
 
 @pytest.mark.parametrize(
@@ -739,14 +738,14 @@ def test_provider_get_outstanding_requests_for_review(output_checker, bll):
     user = factories.create_user("test", ["workspace"], output_checker)
     other_user = factories.create_user("other", ["workspace"], False)
     # request created by another user, status submitted
-    factories.create_request_at_status(
-        "workspace", author=other_user, id="r1", status=RequestStatus.SUBMITTED
+    r1 = factories.create_request_at_status(
+        "workspace", author=other_user, status=RequestStatus.SUBMITTED
     )
 
     # requests not visible to output checker
     # status submitted, but authored by output checker
     factories.create_request_at_status(
-        "workspace", author=user, id="r2", status=RequestStatus.SUBMITTED
+        "workspace", author=user, status=RequestStatus.SUBMITTED
     )
     # requests authored by other users, status other than pending
     for i, status in enumerate(
@@ -770,7 +769,7 @@ def test_provider_get_outstanding_requests_for_review(output_checker, bll):
 
     if output_checker:
         assert set(r.id for r in bll.get_outstanding_requests_for_review(user)) == set(
-            ["r1"]
+            [r1.id]
         )
     else:
         with pytest.raises(exceptions.RequestPermissionDenied):
@@ -792,10 +791,9 @@ def test_provider_get_returned_requests(output_checker, bll):
     other_user = factories.create_user("other", ["workspace"], False)
 
     # request created by another user, status returned
-    factories.create_request_at_status(
+    r1 = factories.create_request_at_status(
         "workspace",
         author=other_user,
-        id="r1",
         status=RequestStatus.RETURNED,
         files=[factories.request_file(path="file.txt", approved=True)],
     )
@@ -805,7 +803,6 @@ def test_provider_get_returned_requests(output_checker, bll):
     factories.create_request_at_status(
         "workspace",
         author=user,
-        id="r2",
         status=RequestStatus.RETURNED,
         files=[factories.request_file(path="file.txt", approved=True)],
     )
@@ -832,7 +829,7 @@ def test_provider_get_returned_requests(output_checker, bll):
         )
 
     if output_checker:
-        assert set(r.id for r in bll.get_returned_requests(user)) == set(["r1"])
+        assert set(r.id for r in bll.get_returned_requests(user)) == set([r1.id])
     else:
         with pytest.raises(exceptions.RequestPermissionDenied):
             bll.get_returned_requests(user)
@@ -853,10 +850,9 @@ def test_provider_get_approved_requests(output_checker, bll):
     other_user = factories.create_user("other", ["workspace"], False)
 
     # request created by another user, status approved
-    factories.create_request_at_status(
+    r1 = factories.create_request_at_status(
         "workspace",
         author=other_user,
-        id="r1",
         status=RequestStatus.APPROVED,
         files=[factories.request_file(path="file.txt", approved=True)],
     )
@@ -866,7 +862,6 @@ def test_provider_get_approved_requests(output_checker, bll):
     factories.create_request_at_status(
         "workspace",
         author=user,
-        id="r2",
         status=RequestStatus.APPROVED,
         files=[factories.request_file(path="file.txt", approved=True)],
     )
@@ -893,7 +888,7 @@ def test_provider_get_approved_requests(output_checker, bll):
         )
 
     if output_checker:
-        assert set(r.id for r in bll.get_approved_requests(user)) == set(["r1"])
+        assert set(r.id for r in bll.get_approved_requests(user)) == set([r1.id])
     else:
         with pytest.raises(exceptions.RequestPermissionDenied):
             bll.get_approved_requests(user)
@@ -2164,7 +2159,6 @@ def test_request_release_get_request_file_from_urlpath(bll):
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.PENDING,
-        id="id",
         files=[
             factories.request_file(
                 group="default",
@@ -2191,7 +2185,6 @@ def test_request_release_abspath(bll):
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.PENDING,
-        id="id",
         files=[
             factories.request_file(
                 group="default",
@@ -2212,7 +2205,6 @@ def test_request_release_request_filetype(bll):
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.PENDING,
-        id="id",
         files=[
             factories.request_file(
                 group="default",

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -111,18 +111,18 @@ def test_session_user_can_action_request(
     "output_checker,author,workspaces,can_review",
     [
         # output checker with no access to workspace can review
-        (True, "other", {}, True),
+        (True, "other", [], True),
         # output checker who is also author cannot review
-        (True, "user", {"test": {}}, False),
+        (True, "user", ["test"], False),
         # non-output-checker cannot review
-        (False, "other", {"test": {}}, False),
+        (False, "other", ["test"], False),
     ],
 )
 def test_user_can_review_request(output_checker, author, workspaces, can_review):
     user = factories.create_user("user", workspaces, output_checker=output_checker)
     users = {
         "user": user,
-        "other": factories.create_user("other", {"test": {}}, output_checker=False),
+        "other": factories.create_user("other", ["test"], output_checker=False),
     }
     release_request = factories.create_request_at_status(
         "test", RequestStatus.SUBMITTED, author=users[author]

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -97,7 +97,9 @@ def _details(archived=False, ongoing=True):
 def test_session_user_can_action_request(
     output_checker, workspaces, can_action_request, expected_reason
 ):
-    user = factories.create_user("test", workspaces, output_checker=output_checker)
+    user = factories.create_user_from_dict(
+        "test", workspaces, output_checker=output_checker
+    )
     assert (
         permissions.user_can_action_request_for_workspace(user, "test")
         == can_action_request


### PR DESCRIPTION
- **Remove ability to customise the id of a request**
- **Remove bll._create_release_request**
- **Separate factories.create_user use cases**
