### PR TITLE
Omit docs screenshot tests from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ plugins = ["django_coverage_plugin"]
 omit = [
   "*/assets/*",
   "airlock/lib/git.py",
+  "tests/functional/test_docs_screenshots.py",
 ]
 
 

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -3,7 +3,7 @@ from django.conf import settings
 
 def screenshot_element_with_padding(
     page, element_locator, filename, extra=None, crop=None
-):
+):  # pragma: no cover
     """
     Take a screenshot with 10px padding around an element.
 


### PR DESCRIPTION
We only run the tests that generate the docs screenshots when we need them (and not by default with just test-all). Omit them from coverage so we don't get spurious coverage failures locally because of the skipped tests. There's nothing critical in these tests (or the helper functions that only they use) that we need to ensure coverage for.