### PR TITLE
Stop double scrollbars appearing when displaying content

### DIFF
--- a/airlock/static/assets/file_browser/index.css
+++ b/airlock/static/assets/file_browser/index.css
@@ -1,30 +1,3 @@
-/* Page layout */
-.browser {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  min-height: 100%;
-  padding-inline: 1rem;
-}
-
-.browser__files {
-  background-color: white;
-  box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px,
-    rgba(0, 0, 0, 0.1) 0px 1px 3px 0px, rgba(0, 0, 0, 0.1) 0px 1px 2px -1px;
-  grid-column: 1 / 1;
-  overflow: scroll;
-}
-
-.browser__content {
-  grid-column: 2 / -1;
-}
-
-.browser__content > div {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
 /* File Card */
 #fileCard h2 {
   font-size: 1.1rem;

--- a/airlock/static/assets/file_browser/tree.css
+++ b/airlock/static/assets/file_browser/tree.css
@@ -95,7 +95,7 @@
   height: calc(var(--tree-line-height) + 1px);
   left: 0;
   position: absolute;
-  width: calc(100% + 1rem);
+  width: 100%;
   z-index: -2;
 }
 

--- a/airlock/templates/base.html
+++ b/airlock/templates/base.html
@@ -29,7 +29,7 @@
 
     {% include '_includes/header.html' %}
 
-    <main class="min-h-[66vh] flex-grow pb-12 bg-slate-100">
+    <main class="max-h-full bg-slate-100 flex flex-col flex-1">
       <div class="container xl:max-w-screen-xl pt-4 pb-4" id="content">
         {% alerts messages=messages %}
         {% block content %}{% endblock %}

--- a/airlock/templates/file_browser/_includes/file_content.html
+++ b/airlock/templates/file_browser/_includes/file_content.html
@@ -1,12 +1,12 @@
-{% #card id="fileCard" title=path_item.name container=True custom_button=buttons %}
-  <div class="content">
-    <iframe src="{{ path_item.contents_url }}"
-            title="{{ path_item.relpath }}"
-            frameborder=0
-            height=1000
-            style="width: 100%;"
-            sandbox="{{ path_item.iframe_sandbox }} allow-same-origin"
-            id="content-iframe"
-    ></iframe>
-  </div>
+{% #card id="fileCard" title=path_item.name container=False custom_button=buttons %}
+  <iframe
+    class="w-full h-full bg-white border-t border-slate-200 pl-4"
+    style="height: 400px;"
+    frameborder="0"
+    height="100"
+    id="content-iframe"
+    sandbox="{{ path_item.iframe_sandbox }} allow-same-origin"
+    src="{{ path_item.contents_url }}"
+    title="{{ path_item.relpath }}"
+  ></iframe>
 {% /card %}

--- a/airlock/templates/file_browser/contents.html
+++ b/airlock/templates/file_browser/contents.html
@@ -1,4 +1,4 @@
-<div id="selected-contents" class="min-h-screen">
+<div id="selected-contents" class="h-full">
   {% if path_item.type.name != "REPO" %}
     {% with template_dir|add:path_item.type.name.lower|add:".html" as template %}
       {% include template %}

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -14,8 +14,8 @@
 {% block content %}{% endblock content %}
 
 {% block full_width_content %}
-  <div class="browser">
-    <div class="browser__files">
+  <div class="grid grid-cols-4 gap-x-4 flex-1">
+    <div class="border-r border-t bg-white overflow-auto" id="tree-container">
       <ul
         class="tree root tree__root"
         hx-boost="true"
@@ -29,7 +29,7 @@
         {% include "file_browser/tree.html" with path=root.fake_parent %}
       </ul>
     </div>
-    <div class="browser__content">
+    <div class="col-span-3">
       {% include "file_browser/contents.html" %}
     </div>
   </div>

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -39,4 +39,5 @@
   <script type="text/javascript" src="{% static 'htmx-1.9.10.min.js' %}"></script>
   {% django_htmx_script %}
   <script src="{% static 'assets/file_browser/index.js' %}"></script>
+  {% vite_asset "assets/src/scripts/resizer.js" %}
 {% endblock %}

--- a/airlock/templates/file_browser/request/dir.html
+++ b/airlock/templates/file_browser/request/dir.html
@@ -18,7 +18,7 @@
 {% endfragment %}
 
 
-{% #card title=path_item.name container=True custom_button=buttons %}
+{% #card title=path_item.name container=False custom_button=buttons %}
   <form id="multiselect_form"
         method="POST"
         hx-post="{{ content_buttons.multiselect_withdraw.url }}"

--- a/airlock/templates/file_browser/workspace/dir.html
+++ b/airlock/templates/file_browser/workspace/dir.html
@@ -35,7 +35,7 @@
 {% endfragment %}
 
 
-{% #card title=path_item.name container=True custom_button=buttons %}
+{% #card title=path_item.name container=False custom_button=buttons %}
   {% if not path_item.children %}
     This directory is empty
   {% else %}

--- a/assets/src/scripts/resizer.js
+++ b/assets/src/scripts/resizer.js
@@ -1,0 +1,81 @@
+// Magic number for resizing
+const MAGIC_PIXELS = 8;
+
+/**
+ * Debounce a function to slow down how frequently it runs.
+ *
+ * @param {number} ms - Time to wait before running the function
+ * @param {function} fn - Function to run when being debounced
+ * @returns {function}
+ */
+function debouncer(ms, fn) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(fn.bind(fn, args), ms);
+  };
+}
+
+/**
+ * Set the content height for either iframes, or workspace/request content,
+ * so that it fills the available space.
+ */
+function setContentHeight() {
+  const iframe = document.querySelector("iframe");
+  if (iframe) {
+    const iframeTop = iframe.getBoundingClientRect().top;
+    iframe.style.height = `${window.innerHeight - iframeTop - MAGIC_PIXELS}px`;
+  }
+
+  const selectedContent = document.getElementById("selected-contents");
+  if (selectedContent) {
+    const contentTop = selectedContent.getBoundingClientRect().top;
+    selectedContent.style.height = `${window.innerHeight - contentTop - MAGIC_PIXELS}px`;
+    selectedContent.classList.add("overflow-auto");
+  }
+}
+
+/**
+ * Set the height of the tree container to fill the available space.
+ */
+function setTreeHeight() {
+  const iframe = document.getElementById("tree-container");
+  if (iframe) {
+    const iframeTop = iframe.getBoundingClientRect().top;
+    iframe.style.height = `${window.innerHeight - iframeTop - MAGIC_PIXELS}px`;
+  }
+}
+
+/**
+ * On page load, add and remove the relevant styling classes, so that the
+ * content can fill the page.
+ */
+document.documentElement.classList.remove("min-h-screen");
+document.documentElement.classList.add("h-screen");
+
+document.body.classList.remove("min-h-screen");
+document.body.classList.add("h-screen");
+
+document.querySelector("main")?.classList.add("overflow-hidden");
+
+/**
+ * On browser resize, change the height of the content and file tree.
+ *
+ * Use the debouncer function to make sure this only runs when a user stops
+ * dragging the window size.
+ */
+const ro = new ResizeObserver(
+  debouncer(100, () => {
+    setContentHeight();
+    setTreeHeight();
+  }),
+);
+
+ro.observe(document.documentElement);
+
+/**
+ * When the user selects a file from the tree, HTMX replaces the content.
+ * Listen for this change, and reset the content height after the file content
+ * has been loaded.
+ */
+document.body.addEventListener("htmx:afterSettle", () => setContentHeight());

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 export default {
   content: [
     "airlock/templates/**/*.html",
+    "assets/src/**/*.{css,js}",
     "assets/templates/**/*.html"
   ],
   theme: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         main: "assets/src/scripts/main.js",
+        resizer: "assets/src/scripts/resizer.js",
       },
     },
   },


### PR DESCRIPTION
Closes #223 

To remove double scrollbars we have:

- Set up the page so that the min-height is the full size of the viewport
- When the file browser pages are opened, we set the height to the full size of the viewport, and remove the min-height
- When loading a file, the iframe height is determined by checking the height of the screen from the top of the `<iframe>`
- This height is calculated on page load, on HTMX content change, and on browser window resize