### PR TITLE
Template refactoring part 2 plus bonus permissions updates

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -495,14 +495,6 @@ class BusinessLogicLayer:
                     f"Cannot set status to {to_status.name}; request has unapproved files."
                 )
 
-            if (
-                to_status == RequestStatus.APPROVED
-                and not release_request.output_files()
-            ):
-                raise exceptions.RequestPermissionDenied(
-                    f"Cannot set status to {to_status.name}; request contains no output files."
-                )
-
     def set_status(
         self, release_request: ReleaseRequest, to_status: RequestStatus, user: User
     ):

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -807,6 +807,7 @@ class BusinessLogicLayer:
         Change status to SUBMITTED. If the request is currently in
         RETURNED status, mark any changes-requested reviews as undecided.
         """
+        permissions.check_user_can_submit_request(user, request)
         self.check_status(request, RequestStatus.SUBMITTED, user)
 
         # reset any previous review data

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -731,9 +731,11 @@ class BusinessLogicLayer:
     ):
         relpath = UrlPath(*group_path.parts[1:])
         permissions.check_user_can_withdraw_file_from_request(
-            user, release_request, relpath
+            user,
+            release_request,
+            self.get_workspace(release_request.workspace, user),
+            relpath,
         )
-
         group_name = group_path.parts[0]
         audit = AuditEvent.from_request(
             request=release_request,

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -138,7 +138,7 @@ def user_can_review_request(user: User, request: "ReleaseRequest"):
 
 def check_user_can_currently_review_request(user: User, request: "ReleaseRequest"):
     """
-    This user can currently perform reviewer actions on the on this
+    This user can currently perform reviewer actions on this
     request (vote on files, return, release, reject)
     """
     check_user_can_review_request(user, request)

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -277,7 +277,7 @@ def user_can_reset_file_review(user: User, request: "ReleaseRequest", relpath: U
 
 
 def check_user_can_submit_review(user: User, request: "ReleaseRequest"):
-    policies.check_can_review_request(request)
+    policies.check_can_submit_review(request)
     check_user_can_review_request(user, request)
     if not request.all_files_reviewed_by_reviewer(user):
         raise exceptions.RequestReviewDenied(
@@ -290,12 +290,10 @@ def check_user_can_submit_review(user: User, request: "ReleaseRequest"):
         )
 
 
-def user_can_submit_review(
-    user: User, request: "ReleaseRequest"
-):  # pragma: no cover; not currently used
+def user_can_submit_review(user: User, request: "ReleaseRequest"):
     try:
         check_user_can_submit_review(user, request)
-    except exceptions.RequestReviewDenied:
+    except (exceptions.RequestReviewDenied, exceptions.RequestPermissionDenied):
         return False
     return True
 

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -176,6 +176,7 @@ def user_can_edit_request(user: User, request: "ReleaseRequest"):
 def check_user_can_add_file_to_request(
     user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
 ):
+    assert workspace.name == request.workspace
     check_user_can_edit_request(user, request)
     policies.check_can_add_file_to_request(workspace, relpath)
 
@@ -193,6 +194,7 @@ def user_can_add_file_to_request(
 def check_user_can_replace_file_in_request(
     user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
 ):
+    assert workspace.name == request.workspace
     check_user_can_edit_request(user, request)
     policies.check_can_replace_file_in_request(workspace, relpath)
 
@@ -210,6 +212,7 @@ def user_can_replace_file_in_request(
 def check_user_can_update_file_on_request(
     user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
 ):
+    assert workspace.name == request.workspace
     check_user_can_edit_request(user, request)
     policies.check_can_update_file_on_request(workspace, relpath)
 
@@ -227,6 +230,7 @@ def user_can_update_file_on_request(
 def check_user_can_withdraw_file_from_request(
     user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
 ):
+    assert workspace.name == request.workspace
     policies.check_can_withdraw_file_from_request(workspace, relpath)
     if not user_can_edit_request(user, request):
         raise exceptions.RequestPermissionDenied(

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -135,6 +135,23 @@ def user_can_review_request(user: User, request: "ReleaseRequest"):
     return True
 
 
+def check_user_can_currently_review_request(user: User, request: "ReleaseRequest"):
+    """
+    This user can currently perform reviewer actions on the on this
+    request (vote on files, return, release, reject)
+    """
+    check_user_can_review_request(user, request)
+    policies.check_can_review_request(request)
+
+
+def user_can_currently_review_request(user: User, request: "ReleaseRequest"):
+    try:
+        check_user_can_currently_review_request(user, request)
+    except (exceptions.RequestPermissionDenied, exceptions.RequestReviewDenied):
+        return False
+    return True
+
+
 def check_user_can_edit_request(user: User, request: "ReleaseRequest"):
     """
     This user has permission to edit the request, AND the request is in an

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -225,8 +225,9 @@ def user_can_update_file_on_request(
 
 
 def check_user_can_withdraw_file_from_request(
-    user: User, request: "ReleaseRequest", relpath: UrlPath
+    user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
 ):
+    policies.check_can_withdraw_file_from_request(workspace, relpath)
     if not user_can_edit_request(user, request):
         raise exceptions.RequestPermissionDenied(
             f"Cannot withdraw file {relpath} from request"
@@ -234,10 +235,10 @@ def check_user_can_withdraw_file_from_request(
 
 
 def user_can_withdraw_file_from_request(
-    user: User, request: "ReleaseRequest", relpath: UrlPath
-):  # pragma: no cover; not currently used
+    user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
+):
     try:
-        check_user_can_withdraw_file_from_request(user, request, relpath)
+        check_user_can_withdraw_file_from_request(user, request, workspace, relpath)
     except exceptions.RequestPermissionDenied:
         return False
     return True
@@ -251,9 +252,7 @@ def check_user_can_review_file(user: User, request: "ReleaseRequest", relpath: U
     policies.check_can_review_file_on_request(request, relpath)
 
 
-def user_can_review_file(
-    user: User, request: "ReleaseRequest", relpath: UrlPath
-):  # pragma: no cover; not currently used
+def user_can_review_file(user: User, request: "ReleaseRequest", relpath: UrlPath):
     try:
         check_user_can_review_file(user, request, relpath)
     except exceptions.RequestReviewDenied:
@@ -269,9 +268,7 @@ def check_user_can_reset_file_review(
         raise exceptions.RequestReviewDenied("cannot reset file from submitted review")
 
 
-def user_can_reset_file_review(
-    user: User, request: "ReleaseRequest", relpath: UrlPath
-):  # pragma: no cover; not currently used
+def user_can_reset_file_review(user: User, request: "ReleaseRequest", relpath: UrlPath):
     try:
         check_user_can_reset_file_review(user, request, relpath)
     except exceptions.RequestReviewDenied:

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -244,6 +244,21 @@ def user_can_withdraw_file_from_request(
     return True
 
 
+def check_user_can_submit_request(user: User, request: "ReleaseRequest"):
+    if not request.output_files():
+        raise exceptions.RequestPermissionDenied(
+            "Cannot submit request with no output files"
+        )
+
+
+def user_can_submit_request(user: User, request: "ReleaseRequest"):  # pragma: no cover
+    try:
+        check_user_can_submit_request(user, request)
+    except exceptions.RequestPermissionDenied:
+        return False
+    return True
+
+
 def check_user_can_review_file(user: User, request: "ReleaseRequest", relpath: UrlPath):
     try:
         check_user_can_review_request(user, request)
@@ -277,8 +292,7 @@ def user_can_reset_file_review(user: User, request: "ReleaseRequest", relpath: U
 
 
 def check_user_can_submit_review(user: User, request: "ReleaseRequest"):
-    policies.check_can_submit_review(request)
-    check_user_can_review_request(user, request)
+    check_user_can_currently_review_request(user, request)
     if not request.all_files_reviewed_by_reviewer(user):
         raise exceptions.RequestReviewDenied(
             "You must review all files to submit your review"

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -31,7 +31,12 @@ if TYPE_CHECKING:  # pragma: no cover
     # imports are not executed at runtime.
     # https://peps.python.org/pep-0484/#forward-references
     # https://mypy.readthedocs.io/en/stable/runtime_troubles.html#import-cycles`
-    from airlock.models import Comment, FileReview, ReleaseRequest, Workspace
+    from airlock.models import (
+        Comment,
+        FileReview,
+        ReleaseRequest,
+        Workspace,
+    )
 
 
 def check_can_edit_request(request: "ReleaseRequest"):
@@ -139,6 +144,17 @@ def check_can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):
     if status != WorkspaceFileStatus.CONTENT_UPDATED:
         raise exceptions.RequestPermissionDenied(
             "Cannot update file in request if it is not updated on disk"
+        )
+
+
+def check_can_withdraw_file_from_request(workspace: "Workspace", relpath: UrlPath):
+    """
+    This file is withdrawable; i.e. it has not already been withdrawn
+    """
+    status = workspace.get_workspace_file_status(relpath)
+    if status == WorkspaceFileStatus.WITHDRAWN:
+        raise exceptions.RequestPermissionDenied(
+            "file has already been withdrawn from request"
         )
 
 

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -168,6 +168,18 @@ def check_can_review_request(request: "ReleaseRequest"):
         )
 
 
+def check_can_submit_review(request: "ReleaseRequest"):
+    """
+    Independent review can be submitted for this request; i.e. it
+    is in a reviewable state and it has output files.
+    """
+    check_can_review_request(request)
+    if not request.output_files():
+        raise exceptions.RequestReviewDenied(
+            "cannot submit review for a request with no output files"
+        )
+
+
 def check_can_review_file_on_request(request: "ReleaseRequest", relpath: UrlPath):
     """
     This file is reviewable; i.e. it is on the request, and it is an output file.

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -168,18 +168,6 @@ def check_can_review_request(request: "ReleaseRequest"):
         )
 
 
-def check_can_submit_review(request: "ReleaseRequest"):
-    """
-    Independent review can be submitted for this request; i.e. it
-    is in a reviewable state and it has output files.
-    """
-    check_can_review_request(request)
-    if not request.output_files():
-        raise exceptions.RequestReviewDenied(
-            "cannot submit review for a request with no output files"
-        )
-
-
 def check_can_review_file_on_request(request: "ReleaseRequest", relpath: UrlPath):
     """
     This file is reviewable; i.e. it is on the request, and it is an output file.

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -147,17 +147,6 @@ def check_can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):
         )
 
 
-def check_can_withdraw_file_from_request(workspace: "Workspace", relpath: UrlPath):
-    """
-    This file is withdrawable; i.e. it has not already been withdrawn
-    """
-    status = workspace.get_workspace_file_status(relpath)
-    if status == WorkspaceFileStatus.WITHDRAWN:
-        raise exceptions.RequestPermissionDenied(
-            "file has already been withdrawn from request"
-        )
-
-
 def check_can_review_request(request: "ReleaseRequest"):
     """
     This request is in a reviewable state

--- a/airlock/templates/file_browser/request/dir.html
+++ b/airlock/templates/file_browser/request/dir.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% fragment as buttons %}
-  {% if multiselect_withdraw %}
+  {% if content_buttons.multiselect_withdraw.show %}
     <div class="div flex flex-col items-start gap-4">
       <div class="flex items-center gap-2">
         {% #button type="submit" name="action" value="withdraw_files" variant="warning" form="multiselect_form"%}Withdraw Files from Request{% /button %}
@@ -21,7 +21,7 @@
 {% #card title=path_item.name container=True custom_button=buttons %}
   <form id="multiselect_form"
         method="POST"
-        hx-post="{{ multiselect_url }}"
+        hx-post="{{ content_buttons.multiselect_withdraw.url }}"
         hx-target="#multiselect_modal"
         hx-swap="outerHtml"
   >
@@ -44,7 +44,7 @@
           <th>
             <div class="flex flex-row gap-2">Modified{% datatable_sort_icon %}</div>
           </th>
-          {% if multiselect_withdraw %}
+          {% if content_buttons.multiselect_withdraw.show %}
             <th data-searchable="false" data-sortable="false">
               <input class="selectall" type="checkbox" onchange="toggleSelectAll(this)" />
             </th>
@@ -58,7 +58,7 @@
             <td>{{ path.request_filetype.name|title }}</td>
             <td data-order="{{ path.size }}">{{ path.size_mb }}</td>
             <td>{{ path.modified_at|date:"Y-m-d H:i" }}</td>
-            {% if multiselect_withdraw %}
+            {% if content_buttons.multiselect_withdraw.show %}
               <td>
                 {% if not path.is_directory %}
                   {% form_checkbox name="selected" value=path.relpath custom_field=True %}

--- a/airlock/templates/file_browser/request/file.html
+++ b/airlock/templates/file_browser/request/file.html
@@ -26,75 +26,65 @@
       {% endwith %}
     {% endif %}
 
-    {% if is_author %}
-      {% if workspace.is_active %}
-        {% if path_item.is_output and file_withdraw_url %}
-          <form action="{{ file_withdraw_url }}" method="POST">
-            {% csrf_token %}
-            <input type=hidden name="path" value="{{ path_item.relpath }}"/>
-            {% #button type="submit" id="withdraw-file-button" tooltip="Withdraw this file from this request" variant="warning" %}Withdraw from Request{% /button %}
-          </form>
-        {% endif %}
-      {% endif %}
-    {% elif is_output_checker %}
-      {% if path_item.is_output %}
-        <div>
-          {% with vote=path_item.request_status.vote %}
-            {% if vote %}
-              <span>Your review:
-                <span class="file-status file-status--{{ vote.name.lower }}">
-                  {{ vote.description }}
-                </span>
-              </span>
-            {% endif %}
-          {% endwith %}
-        </div>
-      {% endif %}
+    {% if content_buttons.withdraw_file.show %}
+      <form action="{{ content_buttons.withdraw_file.url }}" method="POST">
+        {% csrf_token %}
+        <input type=hidden name="path" value="{{ path_item.relpath }}"/>
+        {% #button type="submit" id="withdraw-file-button" tooltip=content_buttons.withdraw_file.tooltip variant="warning" %}Withdraw from Request{% /button %}
+      </form>
+    {% endif %}
 
-      {% if voting_buttons.show %}
-        <div class="btn-group">
-          {% if voting_buttons.approve.disabled %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active whitespace-nowrap" id="file-approve-button" disabled="true">
+    {% if content_buttons.user_vote %}
+      <div>
+        <span>Your review:
+          <span class="file-status file-status--{{ content_buttons.user_vote.name.lower }}">
+            {{ content_buttons.user_vote.description }}
+          </span>
+        </span>
+      </div>
+    {% endif %}
+
+    {% if content_buttons.voting.approve.show %}
+      <div class="btn-group">
+        {% if content_buttons.voting.approve.disabled %}
+          <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active whitespace-nowrap" id="file-approve-button" disabled="true">
+            Approve file
+          </button>
+        {% else %}
+          <form action="{{ content_buttons.voting.approve.url }}" method="POST">
+            {% csrf_token %}
+            <button aria-pressed="false" class="btn-group__btn btn-group__btn--left whitespace-nowrap" id="file-approve-button" type="submit">
               Approve file
             </button>
-          {% else %}
-            <form action="{{ voting_buttons.approve.url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn btn-group__btn--left whitespace-nowrap" id="file-approve-button" type="submit">
-                Approve file
-              </button>
-            </form>
-          {% endif %}
+          </form>
+        {% endif %}
 
-
-          {% if voting_buttons.request_changes.disabled %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--active whitespace-nowrap" id="file-request-changes-button" disabled="true">
+        {% if content_buttons.voting.request_changes.disabled %}
+          <button aria-pressed="true" class="btn-group__btn btn-group__btn--active whitespace-nowrap" id="file-request-changes-button" disabled="true">
+            Request changes
+          </button>
+        {% else %}
+          <form action="{{ content_buttons.voting.request_changes.url }}" method="POST">
+            {% csrf_token %}
+            <button aria-pressed="false" class="btn-group__btn whitespace-nowrap" id="file-request-changes-button" type="submit">
               Request changes
             </button>
-          {% else %}
-            <form action="{{ voting_buttons.request_changes.url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn whitespace-nowrap" id="file-request-changes-button" type="submit">
-                Request changes
-              </button>
-            </form>
-          {% endif %}
+          </form>
+        {% endif %}
 
-          {% if voting_buttons.reset_review.disabled %}
-            <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
+        {% if content_buttons.voting.reset_review.disabled %}
+          <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
+            Undecided
+          </button>
+        {% else %}
+          <form action="{{ content_buttons.voting.reset_review.url }}" method="POST">
+            {% csrf_token %}
+            <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reset-button" type="submit">
               Undecided
             </button>
-          {% else %}
-            <form action="{{ voting_buttons.reset_review.url }}" method="POST">
-              {% csrf_token %}
-              <button aria-pressed="false" class="btn-group__btn btn-group__btn--right" id="file-reset-button" type="submit">
-                Undecided
-              </button>
-            </form>
-          {% endif %}
-
-        </div>
-      {% endif %}
+          </form>
+        {% endif %}
+      </div>
     {% endif %}
 
     {% #modal id="group-context" button_text="View&nbsp;Context" %}

--- a/airlock/templates/file_browser/request/request.html
+++ b/airlock/templates/file_browser/request/request.html
@@ -3,132 +3,129 @@
 
 {% fragment as buttons %}
   <div class="flex items-center gap-2">
-    {% if workspace.is_active %}
-      {% if is_author %}
-        {% if release_request.status_owner.name == "AUTHOR" %}
-          {% if release_request.status.name == "PENDING" %}
-              {% comment %} Initial submission requires confirmation modal {% endcomment %}
-            {% #modal id="submitRequest" button_small=True button_text="Submit for review" button_variant="success" %}
-              {% #card container=True title="Submit this request for review" %}
-                <form action="{{ request_submit_url }}" method="POST">
-                  {% csrf_token %}
-
-                  <div class="pb-8">
-                    Please confirm that you have read the OpenSAFELY
-                    documentation on data release. In particular note that:
-                    <blockquote style="margin-left: 1rem; margin-top: 1rem">
-                      <p>
-                        All outputs from the NHS England OpenSAFELY COVID-19 service must be
-                        aggregated data with small number suppression applied. The service operates as
-                        a trusted research platform where no patient record level data is permitted to
-                        be extracted from the platform. You MUST NOT request the release of any
-                        information (e.g. name, listsize) that identifies, or could identify, ICBs,
-                        Local Authorities (including MSOA identifiers), Primary Care Networks (PCNs)
-                        and individual GP practices from the Level 4 results server. Please confirm and
-                        that your results are in line with this policy.
-                      </p>
-                    </blockquote>
-                  </div>
-                  {% #button type="submit" variant="success" class="action-button" small=True id="submit-for-review-button" %}
-                    I confirm I have read the documentation
-                  {% /button %}
-                  {% #button variant="primary" class="action-button" small=True type="cancel" %}Cancel{% /button %}
-                </form>
-              {% /card %}
-            {% /modal %}
-          {% else %}
-              {% comment %} Subsequent re-submission requires just a button press {% endcomment %}
-            <form action="{{ request_submit_url }}" method="POST">
-              {% csrf_token %}
-              {% #button type="submit" tooltip="This request is ready to be reviewed" variant="success" class="action-button" small=True id="submit-for-review-button" %}Submit for review{% /button %}
-            </form>
-          {% endif %}
-          {% #modal id="withdrawRequest" button_small=True button_text="Withdraw this request" button_variant="warning" %}
-            {% #card container=True title="Withdraw this request" %}
-              <form action="{{ request_withdraw_url }}" method="POST">
-                {% csrf_token %}
-
-                <div class="pb-8">
-                  This will withdraw the entire request.
-                  Once a request is withdrawn, it cannot be resubmitted and must be
-                  recreated from scratch.
-                  Please confirm you wish to withdraw this request.
-                </div>
-                {% #button type="submit" variant="danger" class="action-button" small=True id="withdraw-request-confirm" %}Withdraw{% /button %}
-                {% #button variant="primary" type="cancel" small=True %}Cancel{% /button %}
-              </form>
-            {% /card %}
-          {% /modal %}
-        {% endif %}
-      {% elif is_output_checker %}
-        {% if release_request.status_owner.name == "REVIEWER" %}
-            {% comment %} User can submit review if they haven't already {% endcomment %}
-          {% if user_has_submitted_review %}
-            {% #button disabled=True class="relative group" small=True variant="secondary" id="submit-review-button" %}
-              Submit review
-              {% tooltip class="airlock-tooltip" content="You have already submitted your review" %}
-            {% /button %}
-          {% elif user_has_reviewed_all_files %}
-            <form action="{{ request_review_url }}" method="POST">
-              {% csrf_token %}
-              {% #button type="submit" small=True tooltip="Submit Review" variant="secondary" id="submit-review-button" %}Submit review{% /button %}
-            </form>
-          {% else %}
-            {% #button disabled=True class="relative group" small=True variant="secondary" id="submit-review-button" %}
-              Submit review
-              {% tooltip class="airlock-tooltip" content="You must review all files before you can submit your review" %}
-            {% /button %}
-          {% endif %}
-            {% comment %} A fully reviewed request can be returned or rejected {% endcomment %}
-          {% if release_request.status.name == "REVIEWED" %}
-            {% #modal id="rejectRequest" button_small=True button_text="Reject request" button_variant="danger" %}
-              {% #card container=True title="Reject this request" %}
-                <form action="{{ request_reject_url }}" method="POST">
-                  {% csrf_token %}
-
-                  <div class="pb-8">
-                    This will reject the entire request. Once a request is
-                    rejected, it cannot be resubmitted and must be recreated
-                    from scratch. Please confirm you wish to reject this
-                    request.
-                  </div>
-                  {% #button type="submit" variant="danger" class="action-button" small=True id="reject-request-button" %}Reject request{% /button %}
-                  {% #button variant="primary" type="cancel" %}Cancel{% /button %}
-                </form>
-              {% /card %}
-            {% /modal %}
-            <form action="{{ request_return_url }}" method="POST">
-              {% csrf_token %}
-              {% #button type="submit" small=True tooltip="Return request for changes/clarification" variant="secondary" id="return-request-button" %}Return request{% /button %}
-            </form>
-          {% else %}
-            {% #button disabled=True class="relative group" small=True variant="danger" id="reject-request-button" data-modal="rejectRequest" %}
-              Reject request
-              {% tooltip class="airlock-tooltip" content="Rejecting a request is disabled until review has been submitted by two reviewers" %}
-            {% /button %}
-            {% #button disabled=True class="relative group" small=True variant="secondary" id="return-request-button" %}
-              Return request
-              {% tooltip class="airlock-tooltip" content="Returning a request is disabled until review has been submitted by two reviewers" %}
-            {% /button %}
-          {% endif %}
-        {% endif %}
-          {% comment %} A fully reviewed or approved request can be released if all its files are also approved {% endcomment %}
-        {% if release_request.can_be_released %}
-          <form action="{{ release_files_url }}" method="POST" hx-post="{{ release_files_url }}" hx-disabled-elt="button">
+    {% if content_buttons.submit.show %}
+      {% #modal id="submitRequest" button_small=True button_text="Submit for review" button_variant="success" %}
+        {% #card container=True title="Submit this request for review" %}
+          <form action="{{ content_buttons.submit.url }}" method="POST">
             {% csrf_token %}
-            {% #button small=True type="submit" tooltip="Release files to jobs.opensafely.org" variant="warning" id="release-files-button" %}
-              Release files
-              <img height="16" width="16" class="icon icon--green-700 animate-spin htmx-indicator" src="{% static 'icons/progress_activity.svg' %}" alt="">
+
+            <div class="pb-8">
+              Please confirm that you have read the OpenSAFELY
+              documentation on data release. In particular note that:
+              <blockquote style="margin-left: 1rem; margin-top: 1rem">
+                <p>
+                  All outputs from the NHS England OpenSAFELY COVID-19 service must be
+                  aggregated data with small number suppression applied. The service operates as
+                  a trusted research platform where no patient record level data is permitted to
+                  be extracted from the platform. You MUST NOT request the release of any
+                  information (e.g. name, listsize) that identifies, or could identify, ICBs,
+                  Local Authorities (including MSOA identifiers), Primary Care Networks (PCNs)
+                  and individual GP practices from the Level 4 results server. Please confirm and
+                  that your results are in line with this policy.
+                </p>
+              </blockquote>
+            </div>
+            {% #button type="submit" variant="success" class="action-button" small=True id="submit-for-review-button" %}
+              I confirm I have read the documentation
             {% /button %}
+            {% #button variant="primary" class="action-button" small=True type="cancel" %}Cancel{% /button %}
           </form>
-        {% elif release_request.status_owner.name == "REVIEWER" %}
-          {% #button disabled=True class="relative group" small=True variant="warning" id="release-files-button" %}
-            Release files
-            {% tooltip class="airlock-tooltip" content="Releasing to jobs.opensafely.org is disabled until all files have been approved by by two reviewers" %}
-          {% /button %}
-        {% endif %}
+        {% /card %}
+      {% /modal %}
+    {% endif %}
+    {% if content_buttons.resubmit.show %}
+        {% comment %} Subsequent re-submission requires just a button press {% endcomment %}
+      <form action="{{ content_buttons.resubmit.url }}" method="POST">
+        {% csrf_token %}
+        {% #button type="submit" tooltip=content_buttons.resubmit.tooltip variant="success" class="action-button" small=True id="submit-for-review-button" %}Submit for review{% /button %}
+      </form>
+    {% endif %}
+    {% if content_buttons.withdraw.show %}
+      {% #modal id="withdrawRequest" button_small=True button_text="Withdraw this request" button_variant="warning" %}
+        {% #card container=True title="Withdraw this request" %}
+          <form action="{{ content_buttons.withdraw.url }}" method="POST">
+            {% csrf_token %}
+
+            <div class="pb-8">
+              This will withdraw the entire request.
+              Once a request is withdrawn, it cannot be resubmitted and must be
+              recreated from scratch.
+              Please confirm you wish to withdraw this request.
+            </div>
+            {% #button type="submit" variant="danger" class="action-button" small=True id="withdraw-request-confirm" %}Withdraw{% /button %}
+            {% #button variant="primary" type="cancel" small=True %}Cancel{% /button %}
+          </form>
+        {% /card %}
+      {% /modal %}
+    {% endif %}
+    {% if content_buttons.submit_review.show %}
+      {% if content_buttons.submit_review.disabled %}
+        {% #button disabled=True class="relative group" small=True variant="secondary" id="submit-review-button" %}
+          Submit review
+          {% tooltip class="airlock-tooltip" content=content_buttons.submit_review.tooltip %}
+        {% /button %}
+      {% else %}
+        <form action="{{ content_buttons.submit_review.url }}" method="POST">
+          {% csrf_token %}
+          {% #button type="submit" small=True tooltip=content_buttons.submit_review.tooltip variant="secondary" id="submit-review-button" %}Submit review{% /button %}
+        </form>
       {% endif %}
     {% endif %}
+    {% if content_buttons.reject.show %}
+      {% if content_buttons.reject.disabled %}
+        {% #button disabled=True class="relative group" small=True variant="danger" id="reject-request-button" data-modal="rejectRequest" %}
+          Reject request
+          {% tooltip class="airlock-tooltip" content=content_buttons.reject.tooltip %}
+        {% /button %}
+      {% else %}
+        {% #modal id="rejectRequest" button_small=True button_text="Reject request" button_variant="danger" %}
+          {% #card container=True title="Reject this request" %}
+            <form action="{{ content_buttons.reject.url }}" method="POST">
+              {% csrf_token %}
+
+              <div class="pb-8">
+                This will reject the entire request. Once a request is
+                rejected, it cannot be resubmitted and must be recreated
+                from scratch. Please confirm you wish to reject this
+                request.
+              </div>
+              {% #button type="submit" variant="danger" class="action-button" small=True id="reject-request-button" %}Reject request{% /button %}
+              {% #button variant="primary" type="cancel" %}Cancel{% /button %}
+            </form>
+          {% /card %}
+        {% /modal %}
+      {% endif %}
+    {% endif %}
+    {% if content_buttons.return.show %}
+      {% if content_buttons.return.disabled %}
+        {% #button disabled=True class="relative group" small=True variant="secondary" id="return-request-button" %}
+          Return request
+          {% tooltip class="airlock-tooltip" content=content_buttons.return.tooltip %}
+        {% /button %}
+      {% else %}
+        <form action="{{ content_buttons.return.url }}" method="POST">
+          {% csrf_token %}
+          {% #button type="submit" small=True tooltip=content_buttons.return.tooltip variant="secondary" id="return-request-button" %}Return request{% /button %}
+        </form>
+      {% endif %}
+    {% endif %}
+    {% if content_buttons.release_files.show %}
+      {% if content_buttons.release_files.disabled %}
+        {% #button disabled=True class="relative group" small=True variant="warning" id="release-files-button" %}
+          Release files
+          {% tooltip class="airlock-tooltip" content=content_buttons.release_files.tooltip %}
+        {% /button %}
+      {% else %}
+        <form action="{{ content_buttons.release_files.url }}" method="POST" hx-post="{{ content_buttons.release_files.url }}" hx-disabled-elt="button">
+          {% csrf_token %}
+          {% #button small=True type="submit" tooltip=content_buttons.release_files.tooltip variant="warning" id="release-files-button" %}
+            Release files
+            <img height="16" width="16" class="icon icon--green-700 animate-spin htmx-indicator" src="{% static 'icons/progress_activity.svg' %}" alt="">
+          {% /button %}
+        </form>
+      {% endif %}
+    {% endif %}
+
   </div>
 {% endfragment %}
 

--- a/airlock/templates/file_browser/request/request.html
+++ b/airlock/templates/file_browser/request/request.html
@@ -4,41 +4,55 @@
 {% fragment as buttons %}
   <div class="flex items-center gap-2">
     {% if content_buttons.submit.show %}
-      {% #modal id="submitRequest" button_small=True button_text="Submit for review" button_variant="success" %}
-        {% #card container=True title="Submit this request for review" %}
-          <form action="{{ content_buttons.submit.url }}" method="POST">
-            {% csrf_token %}
+      {% if content_buttons.submit.disabled %}
+        {% #button disabled=True class="relative group" small=True variant="success" id="submit-for-review-button" %}
+          Submit for review
+          {% tooltip class="airlock-tooltip" content=content_buttons.submit.tooltip %}
+        {% /button %}
+      {% else %}
+        {% #modal id="submitRequest" button_small=True button_text="Submit for review" button_variant="success" %}
+          {% #card container=True title="Submit this request for review" %}
+            <form action="{{ content_buttons.submit.url }}" method="POST">
+              {% csrf_token %}
 
-            <div class="pb-8">
-              Please confirm that you have read the OpenSAFELY
-              documentation on data release. In particular note that:
-              <blockquote style="margin-left: 1rem; margin-top: 1rem">
-                <p>
-                  All outputs from the NHS England OpenSAFELY COVID-19 service must be
-                  aggregated data with small number suppression applied. The service operates as
-                  a trusted research platform where no patient record level data is permitted to
-                  be extracted from the platform. You MUST NOT request the release of any
-                  information (e.g. name, listsize) that identifies, or could identify, ICBs,
-                  Local Authorities (including MSOA identifiers), Primary Care Networks (PCNs)
-                  and individual GP practices from the Level 4 results server. Please confirm and
-                  that your results are in line with this policy.
-                </p>
-              </blockquote>
-            </div>
-            {% #button type="submit" variant="success" class="action-button" small=True id="submit-for-review-button" %}
-              I confirm I have read the documentation
-            {% /button %}
-            {% #button variant="primary" class="action-button" small=True type="cancel" %}Cancel{% /button %}
-          </form>
-        {% /card %}
-      {% /modal %}
+              <div class="pb-8">
+                Please confirm that you have read the OpenSAFELY
+                documentation on data release. In particular note that:
+                <blockquote style="margin-left: 1rem; margin-top: 1rem">
+                  <p>
+                    All outputs from the NHS England OpenSAFELY COVID-19 service must be
+                    aggregated data with small number suppression applied. The service operates as
+                    a trusted research platform where no patient record level data is permitted to
+                    be extracted from the platform. You MUST NOT request the release of any
+                    information (e.g. name, listsize) that identifies, or could identify, ICBs,
+                    Local Authorities (including MSOA identifiers), Primary Care Networks (PCNs)
+                    and individual GP practices from the Level 4 results server. Please confirm and
+                    that your results are in line with this policy.
+                  </p>
+                </blockquote>
+              </div>
+              {% #button type="submit" variant="success" class="action-button" small=True id="submit-for-review-button" %}
+                I confirm I have read the documentation
+              {% /button %}
+              {% #button variant="primary" class="action-button" small=True type="cancel" %}Cancel{% /button %}
+            </form>
+          {% /card %}
+        {% /modal %}
+      {% endif %}
     {% endif %}
     {% if content_buttons.resubmit.show %}
+      {% if content_buttons.resubmit.disabled %}
+        {% #button disabled=True class="relative group" small=True variant="success" id="resubmit-for-review-button" %}
+          Submit for review
+          {% tooltip class="airlock-tooltip" content=content_buttons.resubmit.tooltip %}
+        {% /button %}
+      {% else %}
         {% comment %} Subsequent re-submission requires just a button press {% endcomment %}
-      <form action="{{ content_buttons.resubmit.url }}" method="POST">
-        {% csrf_token %}
-        {% #button type="submit" tooltip=content_buttons.resubmit.tooltip variant="success" class="action-button" small=True id="submit-for-review-button" %}Submit for review{% /button %}
-      </form>
+        <form action="{{ content_buttons.resubmit.url }}" method="POST">
+          {% csrf_token %}
+          {% #button type="submit" tooltip=content_buttons.resubmit.tooltip variant="success" class="action-button" small=True id="resubmit-for-review-button" %}Submit for review{% /button %}
+        </form>
+      {% endif %}
     {% endif %}
     {% if content_buttons.withdraw.show %}
       {% #modal id="withdrawRequest" button_small=True button_text="Withdraw this request" button_variant="warning" %}

--- a/airlock/views/helpers.py
+++ b/airlock/views/helpers.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from email.utils import parsedate
 
 from django.contrib import messages
@@ -13,6 +14,16 @@ from airlock.types import UrlPath
 
 class ServeFileException(Exception):
     pass
+
+
+@dataclass
+class ButtonContext:
+    """Holds information about the status of a button for template context"""
+
+    show: bool = False
+    disabled: bool = True
+    url: str = ""
+    tooltip: str = ""
 
 
 def login_exempt(view):

--- a/airlock/views/helpers.py
+++ b/airlock/views/helpers.py
@@ -4,6 +4,7 @@ from email.utils import parsedate
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.http import FileResponse, Http404, HttpResponseNotModified
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from airlock import exceptions
@@ -24,6 +25,14 @@ class ButtonContext:
     disabled: bool = True
     url: str = ""
     tooltip: str = ""
+
+    @classmethod
+    def with_request_defaults(cls, release_request_id, url_name, **extra_kwargs):
+        return cls(
+            url=reverse(
+                url_name, kwargs={"request_id": release_request_id, **extra_kwargs}
+            ),
+        )
 
 
 def login_exempt(view):

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -109,12 +109,23 @@ def get_button_context(path_item, user, release_request, workspace):
             # Buttons shown to authors for requests in editable state
             if permissions.user_can_edit_request(user, release_request):
                 withdraw_btn.show = True
+
                 # we show the submit modal for initial submissions and
                 # just a submit button for re-submission
                 if release_request.status == RequestStatus.PENDING:
                     submit_btn.show = True
                 else:
                     resubmit_btn.show = True
+
+                try:
+                    permissions.check_user_can_submit_request(user, release_request)
+                except exceptions.RequestPermissionDenied as err:
+                    for button in submit_btn, resubmit_btn:
+                        button.tooltip = str(err)
+                else:
+                    for button in submit_btn, resubmit_btn:
+                        button.disabled = False
+
             # Buttons shown to output-checkers for requests in reviewable state
             elif permissions.user_can_currently_review_request(user, release_request):
                 # All output-checker actions are visible (but not necessarily enabled)

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -300,23 +300,7 @@ def request_view(request, request_id: str, path: str = ""):
     else:
         group_context = group_presenter(release_request, relpath, request)
 
-    if not is_author:
-        user_has_submitted_review = (
-            request.user.username in release_request.submitted_reviews
-        )
-        user_has_reviewed_all_files = (
-            release_request.output_files()
-            and release_request.all_files_reviewed_by_reviewer(request.user)
-        )
-    else:
-        user_has_submitted_review = False
-        user_has_reviewed_all_files = False
-
-    if (
-        release_request.is_under_review()
-        and user_has_reviewed_all_files
-        and not user_has_submitted_review
-    ):
+    if permissions.user_can_submit_review(request.user, release_request):
         request_action_required = (
             "You have reviewed all files. You can now submit your review."
         )
@@ -338,9 +322,6 @@ def request_view(request, request_id: str, path: str = ""):
         "root": tree,
         "path_item": path_item,
         "title": f"Request for {release_request.workspace} by {release_request.author}",
-        # TODO file these in from user/models
-        "is_author": is_author,
-        "is_output_checker": request.user.output_checker,
         "content_buttons": button_context,
         "activity": activity,
         "group": group_context,

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -229,7 +229,11 @@ def get_button_context(path_item, user, release_request, workspace):
                 "voting": voting_buttons,
             }
         case PathType.DIR:
-            ...
+            multiselect_withdraw_btn = get_default_context("request_multiselect")
+            if permissions.user_can_edit_request(user, release_request):
+                multiselect_withdraw_btn.show = True
+                multiselect_withdraw_btn.disabled = False
+            return {"multiselect_withdraw": multiselect_withdraw_btn}
         case _:
             return {}
 
@@ -326,10 +330,6 @@ def request_view(request, request_id: str, path: str = ""):
         "activity": activity,
         "group": group_context,
         "request_action_required": request_action_required,
-        "multiselect_url": reverse(
-            "request_multiselect", kwargs={"request_id": request_id}
-        ),
-        "multiselect_withdraw": release_request.is_editing(),
         "code_url": code_url,
         "include_code": code_url is not None,
         "include_download": not is_author,

--- a/tests/functional/test_docs_screenshots.py
+++ b/tests/functional/test_docs_screenshots.py
@@ -313,7 +313,7 @@ def test_screenshot_from_creation_to_release(
 
     # resubmit
     page.goto(live_server.url + release_request.get_url())
-    page.locator("#submit-for-review-button").click()
+    page.locator("#resubmit-for-review-button").click()
 
     # checker 1 and 2 review, approve and release
     def do_review_and_approve(username):

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -141,6 +141,7 @@ def test_request_view_cannot_have_empty_directory(airlock_client):
 
     # Withdrawing the only file from a directory removes the directory as well as
     # the file from the request
+    release_request = factories.refresh_release_request(release_request)
     bll.withdraw_file_from_request(
         release_request, UrlPath("group/some_dir/file.txt"), author
     )

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -191,7 +191,7 @@ def test_request_view_with_file_htmx(airlock_client):
 def test_request_view_with_submitted_request(airlock_client):
     airlock_client.login(output_checker=True)
     release_request = factories.create_request_at_status(
-        "workspace", status=RequestStatus.SUBMITTED
+        "workspace", status=RequestStatus.SUBMITTED, files=[factories.request_file()]
     )
     response = airlock_client.get(f"/requests/view/{release_request.id}", follow=True)
     assert "Rejecting a request is disabled" in response.rendered_content
@@ -203,9 +203,7 @@ def test_request_view_with_submitted_request(airlock_client):
 @pytest.mark.parametrize(
     "files,has_message",
     [
-        ([], False),
         ([factories.request_file()], False),
-        ([factories.request_file(filetype=RequestFileType.SUPPORTING)], False),
         (
             [
                 factories.request_file(approved=True),
@@ -405,26 +403,6 @@ def test_request_view_with_submitted_file(airlock_client):
     assert "Remove this file" not in response.rendered_content
     assert "Approve file" in response.rendered_content
     assert "Request changes" in response.rendered_content
-
-
-def test_request_view_with_submitted_supporting_file(airlock_client):
-    airlock_client.login("checker", output_checker=True)
-    release_request = factories.create_request_at_status(
-        "workspace",
-        status=RequestStatus.SUBMITTED,
-        files=[
-            factories.request_file(
-                "group", "supporting_file.txt", filetype=RequestFileType.SUPPORTING
-            ),
-        ],
-    )
-    response = airlock_client.get(
-        f"/requests/view/{release_request.id}/group/supporting_file.txt", follow=True
-    )
-    assert "Remove this file" not in response.rendered_content
-    # these buttons currently exist but are both disabled
-    assert "Approve file" not in response.rendered_content
-    assert "Request changes" not in response.rendered_content
 
 
 def test_request_view_with_submitted_file_approved(airlock_client):
@@ -704,10 +682,16 @@ def test_request_index_user_output_checker(airlock_client):
         ],
     )
     r1 = factories.create_request_at_status(
-        "test_workspace", author=airlock_client.user, status=RequestStatus.SUBMITTED
+        "test_workspace",
+        author=airlock_client.user,
+        status=RequestStatus.SUBMITTED,
+        files=[factories.request_file()],
     )
     r2 = factories.create_request_at_status(
-        "other_workspace", author=other, status=RequestStatus.SUBMITTED
+        "other_workspace",
+        author=other,
+        status=RequestStatus.SUBMITTED,
+        files=[factories.request_file()],
     )
     r3 = factories.create_request_at_status(
         "other_other_workspace",

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -347,7 +347,9 @@ def test_request_view_with_reviewed_request(airlock_client):
     # Login as 1st default output-checker
     airlock_client.login("output-checker-0", output_checker=True)
     release_request = factories.create_request_at_status(
-        "workspace", status=RequestStatus.REVIEWED
+        "workspace",
+        status=RequestStatus.REVIEWED,
+        files=[factories.request_file(approved=True)],
     )
     response = airlock_client.get(f"/requests/view/{release_request.id}", follow=True)
 

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -87,7 +87,10 @@ def test_get_audit_log(test_audits, kwargs, expected_audits):
 def test_delete_file_from_request_bad_state():
     author = factories.create_user()
     release_request = factories.create_request_at_status(
-        "workspace", status=RequestStatus.SUBMITTED, author=author
+        "workspace",
+        status=RequestStatus.SUBMITTED,
+        author=author,
+        files=[factories.request_file()],
     )
     audit = AuditEvent.from_request(
         release_request,

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -140,7 +140,7 @@ def test_withdraw_file_from_request_file_does_not_exist():
         files=[factories.request_file(changes_requested=True, path="foo.txt")],
     )
 
-    # foo.txt does not exist and can't be withdrawn
+    # bar.txt does not exist and can't be withdrawn
     with pytest.raises(exceptions.FileNotFound):
         dal.withdraw_file_from_request(
             release_request.id,

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -128,6 +128,34 @@ def test_withdraw_file_from_request_bad_state(status):
         )
 
 
+def test_withdraw_file_from_request_file_does_not_exist():
+    author = factories.create_user(username="author", workspaces=["workspace"])
+    release_request = factories.create_request_at_status(
+        "workspace",
+        author=author,
+        status=RequestStatus.RETURNED,
+        files=[factories.request_file(changes_requested=True, path="foo.txt")],
+    )
+
+    # foo.txt does not exist and can't be withdrawn
+    with pytest.raises(exceptions.FileNotFound):
+        dal.withdraw_file_from_request(
+            release_request.id,
+            UrlPath("bar.txt"),
+            AuditEvent.from_request(
+                release_request, AuditEventType.REQUEST_FILE_WITHDRAW, user=author
+            ),
+        )
+    # foo.txt can be withdrawn
+    dal.withdraw_file_from_request(
+        release_request.id,
+        UrlPath("foo.txt"),
+        AuditEvent.from_request(
+            release_request, AuditEventType.REQUEST_FILE_WITHDRAW, user=author
+        ),
+    )
+
+
 def test_add_file_to_request_bad_state():
     workspace = factories.create_workspace("workspace")
     author = factories.create_user(username="author", workspaces=["workspace"])

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1656,6 +1656,28 @@ def test_withdraw_file_from_request_not_author(bll, status):
         )
 
 
+def test_withdraw_file_from_request_already_withdrawn(bll):
+    author = factories.create_user(username="author", workspaces=["workspace"])
+    release_request = factories.create_request_at_status(
+        "workspace",
+        author=author,
+        status=RequestStatus.RETURNED,
+        files=[
+            factories.request_file(group="group", path="foo.txt", approved=True),
+            factories.request_file(
+                group="group", path="withdrawn.txt", filetype=RequestFileType.WITHDRAWN
+            ),
+        ],
+    )
+
+    with pytest.raises(
+        exceptions.RequestPermissionDenied, match="already been withdrawn"
+    ):
+        bll.withdraw_file_from_request(
+            release_request, UrlPath("group/withdrawn.txt"), user=author
+        )
+
+
 def _get_request_file(release_request, path):
     """Syntactic sugar to make the tests a little more readable"""
     # refresh

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -127,7 +127,10 @@ def test_user_can_review_request(output_checker, author, workspaces, can_review)
         "other": factories.create_user("other", ["test"], output_checker=False),
     }
     release_request = factories.create_request_at_status(
-        "test", RequestStatus.SUBMITTED, author=users[author]
+        "test",
+        RequestStatus.SUBMITTED,
+        author=users[author],
+        files=[factories.request_file()],
     )
     assert permissions.user_can_review_request(user, release_request) == can_review
 


### PR DESCRIPTION
The main aim of this PR was to move the logic about which buttons to show at the top of the request content (and whether to enable/disable them, show tooltips etc) out of the template and into the views.

We now build a `content_buttons` dict for each type of content that needs to display buttons (request, file, dir) and the template just needs to use that to determine whether to show buttons.

However, I also refactored the logic to make use of the permissions in permissions.py, and in doing so came across the odd permission that was only enforced at the view/template level, and the odd one that was missing - the main ones being:
- a user can't submit a review if there are no output files on the request (this was enforced in the view only, by disabling the submit-review button)
- a user can't submit a request with no output files (this was missing, we previously allowed requests with no output files, a leftover from the pre-turns era when users were able to withdraw files from a submitted request. This meant that a user could create a request with no files, or only supporting files, and it would be stuck in an un-reviewable, un-rejectable/returnable state)