### PR TITLE
Add a renderer for log files that can render ansi colours

### DIFF
--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -1,3 +1,4 @@
+ansi2html
 Django
 django-vite
 slippers

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --strip-extras requirements.prod.in
 #
+ansi2html==1.9.2 \
+    --hash=sha256:3453bf87535d37b827b05245faaa756dbab4ec3d69925e352b6319c3c955c0a5 \
+    --hash=sha256:dccb75aa95fb018e5d299be2b45f802952377abfdce0504c17a6ee6ef0a420c5
+    # via -r requirements.prod.in
 asgiref==3.8.1 \
     --hash=sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47 \
     --hash=sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590


### PR DESCRIPTION
Convert the text of the log file to HTML using ansi2html, which converts ANSI colour codes to css classes so we get the colour formatting from the original log.

It produces a full HTML file, which isn't what we want to display. We just extract the `<pre>` tag which contains the log content, and the `<style>` tag which contains the relevant inline css.

Before:
![Screenshot from 2024-09-25 18-08-11](https://github.com/user-attachments/assets/924d3857-d56b-434b-9e5f-61c678993b44)

After:
![Screenshot from 2024-09-25 18-07-32](https://github.com/user-attachments/assets/068025d8-64ed-4c5e-9491-c57d1abc0b19)
