### PR TITLE
Fix bug in CSV filtering

### DIFF
--- a/airlock/templates/_components/datatable.html
+++ b/airlock/templates/_components/datatable.html
@@ -1,13 +1,15 @@
 <div class="table-container">
   <p class="spinner p-4" data-datatable-spinner>Loading table data...</p>
-  <table
-    class="{{ class }} hidden"
-    data-datatable
-    {% if per_page %}
-      data-per-page="{{ per_page }}"
-    {% endif %}
-    {% attrs id data-column-filter=column_filter data-sortable=sortable data-searchable=searchable %}
-  >
-    {{ children }}
-  </table>
+  <div class="hidden" data-datatable-wrapper >
+    <table
+      class="{{ class }}"
+      data-datatable
+      {% if per_page %}
+        data-per-page="{{ per_page }}"
+      {% endif %}
+      {% attrs id data-column-filter=column_filter data-sortable=sortable data-searchable=searchable %}
+    >
+      {{ children }}
+    </table>
+  </div>
 </div>

--- a/assets/src/scripts/datatable.js
+++ b/assets/src/scripts/datatable.js
@@ -101,8 +101,9 @@ function buildTables() {
 
       if (container) {
         const spinner = container.querySelector("[data-datatable-spinner]");
+        const wrapper = container.querySelector("[data-datatable-wrapper]");
         spinner?.classList.toggle("hidden");
-        table.classList.toggle("hidden");
+        wrapper.classList.toggle("hidden");
       }
     });
   });


### PR DESCRIPTION
Previously, our datatable `<table>` started out with a "hidden" class, which was removed when the datatable was initialised. This prevented the appearance of unformatted tables before the nicely formatted datatable was ready.

However, when a filter matches nothing and is then reset, simple datatables refreshes the original table element, which was reinstating its hidden attribute, so we ended up with a blank page.

We now wrap the table in another containing div, and apply the hidden class to that instead. It has the same effect in hiding the table until it's initialised, but isn't affected by the refresh after a removed unmatching filter.

Fixes #680 