### PR TITLE
Add a workflow to update dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
         app-id: 1031449  # opensafely-core Create PR app
         private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
-    - uses: opensafely-core/update-dependencies-action@main
+    - uses: opensafely-core/update-dependencies-action@v1
       with:
         token: ${{ steps.generate-token.outputs.token }}
         update_command: "just compile-reqs -U"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron:  "0 23 * * *"
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
@@ -13,13 +14,14 @@ jobs:
       with:
         python-version: "3.11"
         install-just: true 
-    - uses: actions/setup-node@v4
+    
+    - uses: actions/create-github-app-token@v1
+      id: generate-token
       with:
-        node-version-file: ".node-version"
-        cache: "npm"
-        cache-dependency-path: package-lock.json
+        app-id: 1031449  # opensafely-core Create PR app
+        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
     - uses: opensafely-core/update-dependencies-action@main
       with:
+        token: ${{ steps.generate-token.outputs.token }}
         update_command: "just compile-reqs -U"
-        on_changes_command: "just assets && just docs-build && just test --ignore=tests/functional"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,19 @@
+name: Update python dependencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  "0 23 * * *"
+jobs:
+  update-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: "opensafely-core/setup-action@v1"
+      with:
+        python-version: "3.11"
+        install-just: true
+    - uses: opensafely-core/update-dependencies-action@main
+      with:
+        update_command: "just compile-reqs -U"
+        on_changes_command: "just test-all"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -12,8 +12,14 @@ jobs:
     - uses: "opensafely-core/setup-action@v1"
       with:
         python-version: "3.11"
-        install-just: true
+        install-just: true 
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: ".node-version"
+        cache: "npm"
+        cache-dependency-path: package-lock.json
+
     - uses: opensafely-core/update-dependencies-action@main
       with:
         update_command: "just compile-reqs -U"
-        on_changes_command: "just test-all"
+        on_changes_command: "just assets && just docs-build && just test --ignore=tests/functional"


### PR DESCRIPTION
This uses the new [update-dependencies-action](https://github.com/opensafely-core/update-dependencies-action).

Instead of the default GITHUB_TOKEN, it is using a token created by an installed app, `opensafely-core Create PR`,
which has the following repository permissions:
- contents: read and write
- pull-requests: read and write
This means it will trigger the usual workflows (checks/tests etc) that any other PR triggers.

[This PR](https://github.com/opensafely-core/airlock/pull/699) was created by this workflow (with a temporary commit that made it [run](https://github.com/opensafely-core/airlock/actions/runs/11440006463) on pushes to this branch)