### PR TITLE
Update to create_user changes in job-server

### DIFF
--- a/.github/workflows/job-server.yml
+++ b/.github/workflows/job-server.yml
@@ -24,15 +24,3 @@ jobs:
           just _dotenv  # we don't need a full devenv
           just job-server/configure username
           just job-server/create-workspace test-workspace
-
-      - name: "Notify Slack on Failure"
-        # TODO: 2024-08-27 this does not work, gives the error "not_in_channel", despite all our bots being in the channel
-        if: failure() && github.ref_name == 'main'
-        uses: zuplo/github-action-slack-notify-build@cf8e7e66a21d76a8125ea9648979c30920195552 # v2
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-        with:
-          channel_id: "C069YDR4NCA"
-          status: "Airlock local job-server integration test failure"
-          color: danger
-

--- a/job-server/local-setup.sh
+++ b/job-server/local-setup.sh
@@ -61,7 +61,7 @@ else
 fi
 
 # ensure user exists
-docker compose exec job-server ./manage.py create_user "$ghusername" --output-checker --core-developer
+docker compose exec job-server ./manage.py create_user "$ghusername" --output-checker --staff-area-administrator
 
 # create backend and store token
 echo "Getting AIRLOCK_API_TOKEN for $backend backend"


### PR DESCRIPTION
Also, remove the defunct slack notification on failure, which didn't
work, and has been superseeded by the workflows dashboard
