### PR TITLE
Replace dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,6 @@
 version: 2
 
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 20
-    ignore:
-      - dependency-name: "pydantic"
-        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -6,9 +6,9 @@ django-extensions
 django-htmx
 whitenoise
 gunicorn
-opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.07.25.105509.zip
+opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.10.11.170331.zip
 requests
-pydantic<2.0
+pydantic<2
 ulid
 opentelemetry-exporter-otlp-proto-http
 opentelemetry-instrumentation-django

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -291,8 +291,8 @@ mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
     --hash=sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31
     # via mkdocs-material
-opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.07.25.105509.zip \
-    --hash=sha256:285dc3ebee1acfcc9505860f24451a0b9f928181d75c1c20fa93f666fcf2e766
+opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2024.10.11.170331.zip \
+    --hash=sha256:62439268076be091abac17578ce6e2d3da7e98ff2480f70fb246b338f273db57
     # via -r requirements.prod.in
 opentelemetry-api==1.27.0 \
     --hash=sha256:953d5871815e7c30c81b56d910c707588000fff7a3ca1c73e6531911d53065e7 \
@@ -449,9 +449,7 @@ pydantic==1.10.18 \
     --hash=sha256:efbc8a7f9cb5fe26122acba1852d8dcd1e125e723727c59dcd244da7bdaa54f2 \
     --hash=sha256:fcb20d4cb355195c75000a49bb4a31d75e4295200df620f454bbc6bdf60ca890 \
     --hash=sha256:fe734914977eed33033b70bfc097e1baaffb589517863955430bf2e0846ac30f
-    # via
-    #   -r requirements.prod.in
-    #   opensafely-pipeline
+    # via -r requirements.prod.in
 pygments==2.18.0 \
     --hash=sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199 \
     --hash=sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a


### PR DESCRIPTION
Replace dependabot for everything except GitHub Action updates.

Python dependencies are now updated by our [update-dependencies-action](https://github.com/opensafely-core/update-dependencies-action/)

Also upgrades opensafely-pipeline.