### PR TITLE
Handle re-releases and re-uploads

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -802,7 +802,11 @@ class BusinessLogicLayer:
 
             if upload:
                 old_api.upload_file(
-                    jobserver_release_id, relpath, abspath, user.username
+                    jobserver_release_id,
+                    release_request.workspace,
+                    relpath,
+                    abspath,
+                    user.username,
                 )
 
         self.set_status(release_request, RequestStatus.RELEASED, user)

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -779,7 +779,10 @@ class BusinessLogicLayer:
         filelist = old_api.create_filelist(file_paths, release_request)
 
         if upload:
-            jobserver_release_id = old_api.create_release(
+            # Get or create the release
+            # If this is a re-release attempt, the id for the existing
+            # release will be returned
+            jobserver_release_id = old_api.get_or_create_release(
                 release_request.workspace,
                 release_request.id,
                 filelist.json(),

--- a/old_api/__init__.py
+++ b/old_api/__init__.py
@@ -79,15 +79,19 @@ def upload_file(release_id, relpath, abspath, username):
     )
 
     if response.status_code != 201:
-        logger.error(
-            "%s Error uploading file - %s - %s - %s",
-            response.status_code,
-            relpath,
-            release_id,
-            response.content.decode(),
-        )
-
-    response.raise_for_status()
+        response_content = response.content.decode()
+        if "has already been uploaded" in response_content:
+            # Ignore attempted re-uploads
+            logger.info("File already uploaded - %s - %s", relpath, release_id)
+        else:
+            logger.error(
+                "%s Error uploading file - %s - %s - %s",
+                response.status_code,
+                relpath,
+                release_id,
+                response_content,
+            )
+            response.raise_for_status()
 
     return response
 

--- a/old_api/__init__.py
+++ b/old_api/__init__.py
@@ -64,7 +64,7 @@ def get_or_create_release(workspace_name, release_request_id, release_json, user
     return response.headers["Release-Id"]
 
 
-def upload_file(release_id, relpath, abspath, username):
+def upload_file(release_id, workspace, relpath, abspath, username):
     """Upload file to job server."""
     response = session.post(
         url=f"{settings.AIRLOCK_API_ENDPOINT}/releases/release/{release_id}",
@@ -80,9 +80,14 @@ def upload_file(release_id, relpath, abspath, username):
 
     if response.status_code != 201:
         response_content = response.content.decode()
-        if "has already been uploaded" in response_content:
+        if (
+            f"This version of '{relpath}' has already been uploaded"
+            in response.json()["detail"]
+        ):
             # Ignore attempted re-uploads
-            logger.info("File already uploaded - %s - %s", relpath, release_id)
+            logger.info(
+                "File already uploaded - %s - %s - %s", workspace, relpath, release_id
+            )
         else:
             logger.error(
                 "%s Error uploading file - %s - %s - %s",

--- a/old_api/__init__.py
+++ b/old_api/__init__.py
@@ -38,8 +38,8 @@ def create_filelist(paths, release_request):
     )
 
 
-def create_release(workspace_name, release_request_id, release_json, username):
-    """API call to job server to create a release."""
+def get_or_create_release(workspace_name, release_request_id, release_json, username):
+    """API call to job server to get or create a release."""
     response = session.post(
         url=f"{settings.AIRLOCK_API_ENDPOINT}/releases/workspace/{workspace_name}",
         data=release_json,

--- a/tests/integration/test_old_api.py
+++ b/tests/integration/test_old_api.py
@@ -11,7 +11,7 @@ from tests import factories
 pytestmark = pytest.mark.django_db
 
 
-def test_old_api_create_release(responses):
+def test_old_api_get_or_create_release(responses):
     responses.post(
         f"{settings.AIRLOCK_API_ENDPOINT}/releases/workspace/workspace_name",
         status=201,
@@ -19,7 +19,7 @@ def test_old_api_create_release(responses):
     )
 
     assert (
-        old_api.create_release(
+        old_api.get_or_create_release(
             "workspace_name", "jobserver-id", {"airlock_id": "jobserver-id"}, "testuser"
         )
         == "jobserver-id"
@@ -30,7 +30,7 @@ def test_old_api_create_release(responses):
     assert request.body == "airlock_id=jobserver-id"
 
 
-def test_old_api_create_release_with_error(responses, caplog):
+def test_old_api_get_or_create_release_with_error(responses, caplog):
     responses.post(
         f"{settings.AIRLOCK_API_ENDPOINT}/releases/workspace/workspace_name",
         status=403,
@@ -38,7 +38,7 @@ def test_old_api_create_release_with_error(responses, caplog):
         body="job-server error",
     )
     with pytest.raises(requests.exceptions.HTTPError):
-        old_api.create_release(
+        old_api.get_or_create_release(
             "workspace_name", "jobserver-id", {"airlock_id": "jobserver-id"}, "testuser"
         )
     assert len(caplog.messages) == 1

--- a/tests/integration/test_old_api.py
+++ b/tests/integration/test_old_api.py
@@ -61,7 +61,7 @@ def test_old_api_upload_file(responses):
         status=201,
     )
 
-    old_api.upload_file("release-id", relpath, abspath, "testuser")
+    old_api.upload_file("release-id", "workspace", relpath, abspath, "testuser")
     request = responses.calls[0].request
     assert request.body == b"test"
     assert request.headers["Content-Disposition"] == f'attachment; filename="{relpath}"'
@@ -82,7 +82,7 @@ def test_old_api_upload_file_error(responses, caplog):
         json={"detail": "job-server error"},
     )
     with pytest.raises(requests.exceptions.HTTPError):
-        old_api.upload_file("release-id", relpath, abspath, "testuser")
+        old_api.upload_file("release-id", "workspace", relpath, abspath, "testuser")
 
     assert len(caplog.messages) == 1
     log = caplog.messages[0]
@@ -102,9 +102,9 @@ def test_old_api_upload_file_already_uploaded_error(responses, caplog):
     responses.post(
         f"{settings.AIRLOCK_API_ENDPOINT}/releases/release/release-id",
         status=400,
-        json={"detail": "This version of '{relpath}' has already been uploaded"},
+        json={"detail": f"This version of '{relpath}' has already been uploaded"},
     )
-    old_api.upload_file("release-id", relpath, abspath, "testuser")
+    old_api.upload_file("release-id", "workspace", relpath, abspath, "testuser")
 
     assert len(caplog.messages) == 1
     log = caplog.messages[0]

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -94,7 +94,9 @@ def test_provider_get_workspaces_for_user(bll, output_checker):
 @pytest.fixture
 def mock_old_api(monkeypatch):
     monkeypatch.setattr(
-        old_api, "create_release", MagicMock(autospec=old_api.create_release)
+        old_api,
+        "get_or_create_release",
+        MagicMock(autospec=old_api.get_or_create_release),
     )
     monkeypatch.setattr(old_api, "upload_file", MagicMock(autospec=old_api.upload_file))
 
@@ -134,7 +136,7 @@ def test_provider_request_release_files_invalid_file_type(bll, mock_notification
 
 
 def test_provider_request_release_files(mock_old_api, mock_notifications, bll, freezer):
-    old_api.create_release.return_value = "jobserver_id"  # type: ignore
+    old_api.get_or_create_release.return_value = "jobserver_id"  # type: ignore
     author = factories.create_user("author", workspaces=["workspace"])
     checkers = factories.get_default_output_checkers()
     release_request = factories.create_request_at_status(
@@ -206,7 +208,7 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
         "review": None,
     }
 
-    old_api.create_release.assert_called_once_with(  # type: ignore
+    old_api.get_or_create_release.assert_called_once_with(  # type: ignore
         "workspace", release_request.id, json.dumps(expected_json), checkers[0].username
     )
     old_api.upload_file.assert_called_once_with(  # type: ignore

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -212,7 +212,7 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
         "workspace", release_request.id, json.dumps(expected_json), checkers[0].username
     )
     old_api.upload_file.assert_called_once_with(  # type: ignore
-        "jobserver_id", relpath, abspath, checkers[0].username
+        "jobserver_id", "workspace", relpath, abspath, checkers[0].username
     )
 
     notification_responses = parse_notification_responses(mock_notifications)


### PR DESCRIPTION
Note: depends on https://github.com/opensafely-core/job-server/pull/4810

Changes `old_api.create_release` to `old_api.get_or_create_release` to reflect the job-server change above.

Catches the "already uploaded" error from job-server on a re-release attempt, so a re-release will continue to upload files that failed before.

Fixes #742 