### PR TITLE
Handle django control flow exceptions better in tracing.

### DIFF
--- a/services/tracing.py
+++ b/services/tracing.py
@@ -68,6 +68,7 @@ def instrument(
     _func=None,
     *,
     span_name: str = "",
+    set_status_on_exception=False,
     record_exception: bool = True,
     attributes: dict[str, str] = None,
     func_attributes: dict[str, str] = None,
@@ -77,6 +78,10 @@ def instrument(
     A decorator to instrument a function with an OTEL tracing span.
 
     span_name: custom name for the span, defaults to name of decorated functionvv
+    set_status_on_exception: passed to `start_as_current_span`. Whether to mark
+      this span as failed if an exception is raise. Note: Django uses exceptions
+      for control flow (e.g. Http404, PermissionDenied), so this is set to
+      False by default.
     record_exception: passed to `start_as_current_span`; whether to record
       exceptions when they happen.
     attributes: custom attributes to set on the span
@@ -145,7 +150,10 @@ def instrument(
             span.set_attributes(attributes_dict)
 
             with tracer.start_as_current_span(
-                name, record_exception=record_exception, attributes=attributes_dict
+                name,
+                set_status_on_exception=set_status_on_exception,
+                record_exception=record_exception,
+                attributes=attributes_dict,
             ):
                 return func(*args, **kwargs)
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -100,6 +100,19 @@ def test_instrument_decorator_parent_attributes(settings):
     }
 
 
+@pytest.mark.parametrize("set_status", [True, False])
+def test_instrument_decorator_exception_status(set_status):
+    @instrument(set_status_on_exception=set_status)
+    def test_exception():
+        raise Exception("test")
+
+    with pytest.raises(Exception):
+        test_exception()
+
+    spans = get_trace()
+    assert spans[0].status.is_ok is not set_status
+
+
 @pytest.mark.parametrize(
     "func_attributes,func_args,func_kwargs,expected_attributes",
     [


### PR DESCRIPTION
By default, if an exception is raised during an operation being measured
by an otel span, it will mark the span as being in an error state, as
well as record the exception details.

However, django uses exceptions for non-error control flows, such as
raising Http404, or PermissionDenied. This are not error, but due the
above defaults, they show up in our telemetry as errors, and we are
alerted to 404s and 403s, which we do not what.

Given that the `instrument` decorator's primary use case is decorating
django view methods, this changes the default behaviour to set
set_status_on_exception=False.  Actual error exceptions will continue
to bubble up, and the root span will have its status set to error, but
the child spans generated by `instrument` will not.
