### PR TITLE
Upgrade pipeline library automatically

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -24,4 +24,6 @@ jobs:
     - uses: bennettoxford/update-dependencies-action@v1
       with:
         token: ${{ steps.generate-token.outputs.token }}
-        update_command: "just compile-reqs -U"
+        update_command: |
+          just compile-reqs -U
+          just upgrade-pipeline 

--- a/justfile
+++ b/justfile
@@ -41,6 +41,9 @@ compile-reqs *ARGS: devenv
       $BIN/$command "$req_file" "$@"
     done
 
+# update to the latest version of the internal pipeline library
+upgrade-pipeline:
+    ./scripts/upgrade-pipeline.sh requirements.prod.in
 
 # create a valid .env if none exists
 _dotenv:

--- a/scripts/upgrade-pipeline.sh
+++ b/scripts/upgrade-pipeline.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+
+file=$1
+github_package_url="opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/"
+latest=$(git ls-remote -h --refs --tags --heads https://github.com/opensafely-core/pipeline | grep -o "v20.*$" | sort | tail -1)
+echo "Latest version of pipeline is $latest"
+
+# exit early if we are at the latest version
+if grep -q "$latest" "$file"; then
+    echo "$file already contains latest version"
+    exit
+fi
+
+sed -i "s#$github_package_url.*\.zip#$github_package_url$latest.zip#" "$file"
+echo "Updated $file to pipline $latest"


### PR DESCRIPTION
Because we don't publish it to pypi, we can't use the pip workflow