### PR TITLE
Remove last vestiges of naked "project" field in user API

### DIFF
--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -142,17 +142,14 @@ def test_workspace_get_workspace_archived_ongoing(bll):
         "user",
         workspaces={
             "normal_workspace": {
-                "project": "project-1",
                 "project_details": {"name": "project-1", "ongoing": True},
                 "archived": False,
             },
             "archived_workspace": {
-                "project": "project-1",
                 "project_details": {"name": "project-1", "ongoing": True},
                 "archived": True,
             },
             "not_ongoing": {
-                "project": "project-2",
                 "project_details": {"name": "project-2", "ongoing": False},
                 "archived": False,
             },

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -10,12 +10,10 @@ def test_session_user_from_session():
             "username": "test",
             "workspaces": {
                 "test-workspace-1": {
-                    "project": "Project 1",
                     "project_details": {"name": "Project 1", "ongoing": True},
                     "archived": False,
                 },
                 "test_workspace2": {
-                    "project": "Project 2",
                     "project_details": {"name": "Project 2", "ongoing": True},
                     "archived": True,
                 },
@@ -25,8 +23,6 @@ def test_session_user_from_session():
     }
     user = User.from_session(mock_session)
     assert set(user.workspaces) == {"test-workspace-1", "test_workspace2"}
-    assert user.workspaces["test-workspace-1"]["project"] == "Project 1"
-    assert user.workspaces["test_workspace2"]["project"] == "Project 2"
     assert user.workspaces["test-workspace-1"]["project_details"] == {
         "name": "Project 1",
         "ongoing": True,


### PR DESCRIPTION
AFAICS, we do not use this in production code at all, but there were a few places where it was used in tests, which this cleans up.

The default create_user test factory does not set it, just some hand created tests.

The motivation is to clean up the API, as there is a note in job-server side that we need it for b/w compat, which I think is no longer true.

https://github.com/opensafely-core/job-server/blob/main/jobserver/api/releases.py#L588