### PR TITLE
Disable the release files button until all files have attempted to upload the max number of times

### DIFF
--- a/airlock/enums.py
+++ b/airlock/enums.py
@@ -35,6 +35,8 @@ class RequestStatus(Enum):
             return "ONE REVIEW SUBMITTED"
         if self == RequestStatus.REVIEWED:
             return "ALL REVIEWS SUBMITTED"
+        if self == RequestStatus.APPROVED:
+            return "APPROVED - FILES UPLOADING"
         return self.name
 
 

--- a/airlock/templates/file_browser/request/request.html
+++ b/airlock/templates/file_browser/request/request.html
@@ -126,14 +126,14 @@
     {% if content_buttons.release_files.show %}
       {% if content_buttons.release_files.disabled %}
         {% #button disabled=True class="relative group" small=True variant="warning" id="release-files-button" %}
-          Release files
+          {{ content_buttons.release_files.display_label }}
           {% tooltip class="airlock-tooltip" content=content_buttons.release_files.tooltip %}
         {% /button %}
       {% else %}
         <form action="{{ content_buttons.release_files.url }}" method="POST" hx-post="{{ content_buttons.release_files.url }}" hx-disabled-elt="button">
           {% csrf_token %}
           {% #button small=True type="submit" tooltip=content_buttons.release_files.tooltip variant="warning" id="release-files-button" %}
-            Release files
+            {{ content_buttons.release_files.display_label }}
             <img height="16" width="16" class="icon icon--green-700 animate-spin htmx-indicator" src="{% static 'icons/progress_activity.svg' %}" alt="">
           {% /button %}
         </form>

--- a/airlock/views/helpers.py
+++ b/airlock/views/helpers.py
@@ -25,6 +25,7 @@ class ButtonContext:
     disabled: bool = True
     url: str = ""
     tooltip: str = ""
+    display_label: str = ""
 
     @classmethod
     def with_request_defaults(cls, release_request_id, url_name, **extra_kwargs):

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -458,10 +458,19 @@ def test_e2e_release_files(
     expect(page.locator("body")).to_contain_text(
         "Files have been released and will be uploaded to jobs.opensafely.org"
     )
+    # Request is approved; header contains additional status description
+    expect(page.locator("body")).to_contain_text("APPROVED - FILES UPLOADING")
 
-    # Requests view does not show released request
-    find_and_click(page.get_by_test_id("nav-requests"))
-    expect(page.locator("body")).not_to_contain_text("test-workspace by researcher")
+    # Reviews page still shows approved request
+    find_and_click(page.get_by_test_id("nav-reviews"))
+    expect(page.locator("body")).to_contain_text("test-workspace")
+    expect(page.locator("body")).to_contain_text("APPROVED - FILES UPLOADING")
+
+    # change status to released (mock state once files have been uploaded)
+    release_request = factories.refresh_release_request(release_request)
+    bll.set_status(release_request, RequestStatus.RELEASED, admin_user)
+    page.reload()
+    expect(page.locator("body")).not_to_contain_text("test-workspace")
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -2,6 +2,7 @@ from io import BytesIO
 
 import pytest
 import requests
+from django.conf import settings
 from django.contrib.messages import get_messages
 from django.template.response import TemplateResponse
 
@@ -363,6 +364,89 @@ def test_request_view_with_reviewed_request(airlock_client):
 
     assert "Submit review" in response.rendered_content
     assert "You have already submitted your review" in response.rendered_content
+
+
+@pytest.mark.parametrize(
+    "files,button_label,button_tooltip",
+    [
+        (  # one file uploaded, one still uploading
+            {
+                "test1.txt": {"uploaded": True, "attempts": 1, "content": "1"},
+                "test2.txt": {"uploaded": False, "attempts": 1, "content": "2"},
+            },
+            "Re-release files",
+            "Files are uploading to jobs.opensafely.org",
+        ),
+        (
+            # one file uploaded, one past max attempts
+            {
+                "test1.txt": {"uploaded": True, "attempts": 1, "content": "1"},
+                "test2.txt": {
+                    "uploaded": False,
+                    "attempts": settings.UPLOAD_MAX_ATTEMPTS,
+                    "content": "2",
+                },
+            },
+            "Re-release files",
+            "Some files failed to upload; re-attempt release to jobs.opensafely.org",
+        ),
+        (
+            # neither file uploaded, one past max attempts
+            {
+                "test1.txt": {"uploaded": False, "attempts": 1, "content": "1"},
+                "test2.txt": {
+                    "uploaded": False,
+                    "attempts": settings.UPLOAD_MAX_ATTEMPTS,
+                    "content": "2",
+                },
+            },
+            "Re-release files",
+            "Files are uploading to jobs.opensafely.org",
+        ),
+        (
+            # one file uploaded on the max attempt, one still uploading
+            {
+                "test1.txt": {"uploaded": False, "attempts": 1, "content": "1"},
+                "test2.txt": {
+                    "uploaded": True,
+                    "attempts": settings.UPLOAD_MAX_ATTEMPTS,
+                    "content": "2",
+                },
+            },
+            "Re-release files",
+            "Files are uploading to jobs.opensafely.org",
+        ),
+    ],
+)
+def test_request_view_with_approved_request(
+    mock_old_api,
+    mock_notifications,
+    airlock_client,
+    files,
+    button_label,
+    button_tooltip,
+):
+    airlock_client.login(username="output-checker-0", output_checker=True)
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.APPROVED,
+        files=[
+            factories.request_file(approved=True, path=path, contents=file["content"])
+            for path, file in files.items()
+        ],
+    )
+    for path, file in files.items():
+        for _ in range(file["attempts"]):
+            bll.register_file_upload_attempt(release_request, UrlPath(path))
+            if file["uploaded"]:
+                bll.register_file_upload(
+                    release_request, UrlPath(path), airlock_client.user
+                )
+
+    response = airlock_client.get(f"/requests/view/{release_request.id}/", follow=True)
+
+    assert button_label in response.rendered_content
+    assert button_tooltip in response.rendered_content
 
 
 @pytest.mark.parametrize("status", list(RequestStatus))


### PR DESCRIPTION
Fixes #771 

Change the displayed status for "Approved" in the status pills to "Approved - Files uploading"
![image](https://github.com/user-attachments/assets/23519dea-05a5-4b96-9201-2f5506fd3a87)

(Note that I haven't changed it in the main request overview panel, which is consistent with how we dislay other statuses that have a custom label (i.e. partially reviewed/reviewed))

When the request is approved, but files are still uploading, the "Release files" button is disabled, and changes to "Re-release files" (as in screenshot above).

When all files have been attempted 3x, and some are still not uploaded, the "Re-release files" button is enabled so that the user can re-try the release. 
![image](https://github.com/user-attachments/assets/334be882-1227-40bf-abae-d23db3027cce)
Tooltips when files are uploading (disabled re-release button):
![image](https://github.com/user-attachments/assets/b4e8e991-2863-4b53-bcf8-3b726fcb0409)

And when uploads have tried and failed (enabled re-release button):
![image](https://github.com/user-attachments/assets/7db9240a-8cf4-4ac6-9292-adfb3c0fa11f)

Note: tooltip placement is a bit wonky, but this is the case already and not something for this ticket.

Currently the page needs to be manually refreshed to see changes to the file upload status - I'm deliberately not handling this in this PR, there will be a follow up one to poll via htmx for upload status changes.

Preventing the user from re-trying the release is done in the frontend only. The BLL doesn't prohibit re-tries in the release_files() method. This was a conscious decision; nothing terrible happens if a user was to re-try unnecessarily - the audit log will register it, but if the file is already uploaded - and registered as such in the RequestFile, we won't attempt to re-upload it, and it a file was uploaded but not registered, we'd re-attempt it, but we handle already uploaded file errors from job-server.

