### PR TITLE
Show uploaded file count with icons on request overview page

### DIFF
--- a/airlock/models.py
+++ b/airlock/models.py
@@ -841,13 +841,16 @@ class ReleaseRequest:
             if rfile.filetype == RequestFileType.OUTPUT
         }
 
+    def uploaded_files_count(self):
+        if self.status not in [RequestStatus.APPROVED, RequestStatus.RELEASED]:
+            return 0
+        return sum(1 for rfile in self.output_files().values() if rfile.uploaded)
+
     def supporting_files_count(self):
-        return len(
-            [
-                1
-                for rfile in self.all_files_by_name.values()
-                if rfile.filetype == RequestFileType.SUPPORTING
-            ]
+        return sum(
+            1
+            for rfile in self.all_files_by_name.values()
+            if rfile.filetype == RequestFileType.SUPPORTING
         )
 
     def request_filetype(self, urlpath: UrlPath):

--- a/airlock/templates/file_browser/request/request.html
+++ b/airlock/templates/file_browser/request/request.html
@@ -155,6 +155,18 @@
     {% #description_item title="Supporting files not for release" %}
       {{ release_request.supporting_files_count }}
     {% /description_item %}
+    {% #description_item title="Files released and uploaded" %}
+      <div class="flex flex-row flex-wrap gap-6" id="uploaded-files-count">
+        {{ release_request.uploaded_files_count }}
+        {% if release_request.status.value == "RELEASED" %}
+          {% icon_check_circle_solid class="h-5 w-5 text-green-700" %}
+        {% elif release_request.upload_in_progress %}
+          {% icon_custom_spinner class="h-5 w-5 text-bn-egg-500 animate-spin stroke-current stroke-2" %}
+        {% elif release_request.can_be_rereleased %}
+          {% icon_exclamation_triangle_solid class="h-5 w-5 text-red-800" %}
+        {% endif %}
+      </div>
+    {% /description_item %}
   {% /description_list %}
 {% /card %}
 


### PR DESCRIPTION
Fixes #773 

To give users visibility on the upload progress of their released requests, we now show the uploaded file count on the request overview page, with an icon to indicate status.

Released, all files uploaded:
![Screenshot from 2025-02-13 12-24-46](https://github.com/user-attachments/assets/7d3e7df7-992f-4c4f-ab37-2adea4f875a2)

Approved, upload in progress (release files button is disabled):
![image](https://github.com/user-attachments/assets/8db499fb-9a9e-47b2-bbed-fcb4710c7f43)

Approved, upload failed (release files button is enabled and release can be re-tried):
![Screenshot from 2025-02-13 12-21-55](https://github.com/user-attachments/assets/01b7ed7a-16f3-4733-90e8-15da8566e6de)


Note: haven't updated the docs yet, as I plan to do that next (#775)