### PR TITLE
Refactory

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -45,7 +45,7 @@ def login_as_user(live_server, context, user_dict):
     Creates a session with relevant user data and
     sets the session cookie.
     """
-    user = factories.create_user_from_dict(**user_dict)
+    user = factories.create_airlock_user(**user_dict)
     session_store = Session.get_session_store_class()()  # type: ignore
     session_store["user"] = user.to_dict()
     session_store.save()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -66,16 +66,13 @@ def output_checker_user(live_server, context):
     login_as_user(
         live_server,
         context,
-        {
-            "username": "test_output_checker",
-            "workspaces": {
-                "test-dir2": {
-                    "project_details": {"name": "Project 2", "ongoing": True},
-                    "archived": False,
-                }
+        factories.create_api_user(
+            username="test_output_checker",
+            workspaces={
+                "test-dir2": factories.create_api_workspace(project="Project 2")
             },
-            "output_checker": True,
-        },
+            output_checker=True,
+        ),
     )
 
 
@@ -84,16 +81,13 @@ def researcher_user(live_server, context):
     login_as_user(
         live_server,
         context,
-        {
-            "username": "test_researcher",
-            "workspaces": {
-                "test-dir1": {
-                    "project_details": {"name": "Test Project", "ongoing": True},
-                    "archived": False,
-                }
+        factories.create_api_user(
+            username="test_researcher",
+            workspaces={
+                "test-dir1": factories.create_api_workspace(project="Test Project")
             },
-            "output_checker": False,
-        },
+            output_checker=False,
+        ),
     )
 
 
@@ -105,41 +99,31 @@ def dev_users(tmp_path, settings):
             {
                 "output_checker": {
                     "token": "output_checker",
-                    "details": {
-                        "username": "output_checker",
-                        "fullname": "Output Checker",
-                        "output_checker": True,
-                        "staff": True,
-                        "workspaces": {},
-                    },
+                    "details": factories.create_api_user(
+                        username="output_checker",
+                        output_checker=True,
+                        workspaces={},
+                    ),
                 },
                 "output_checker_1": {
                     "token": "output_checker_1",
-                    "details": {
-                        "username": "output_checker_1",
-                        "fullname": "Output Checker 1",
-                        "output_checker": True,
-                        "staff": True,
-                        "workspaces": {},
-                    },
+                    "details": factories.create_api_user(
+                        username="output_checker_1",
+                        output_checker=True,
+                        workspaces={},
+                    ),
                 },
                 "researcher": {
                     "token": "researcher",
-                    "details": {
-                        "username": "researcher",
-                        "fullname": "Researcher",
-                        "output_checker": False,
-                        "staff": False,
-                        "workspaces": {
-                            "test-workspace": {
-                                "project_details": {
-                                    "name": "Test Project",
-                                    "ongoing": True,
-                                },
-                                "archived": False,
-                            }
+                    "details": factories.create_api_user(
+                        username="researcher",
+                        output_checker=False,
+                        workspaces={
+                            "test-workspace": factories.create_api_workspace(
+                                project="Test Project"
+                            )
                         },
-                    },
+                    ),
                 },
             }
         )

--- a/tests/functional/test_docs_screenshots.py
+++ b/tests/functional/test_docs_screenshots.py
@@ -33,7 +33,7 @@ def get_user_data():
         "checker2": dict(username="checker2", workspaces=[], output_checker=True),
     }
 
-    author = factories.create_user(
+    author = factories.create_airlock_user(
         username=author_username,
         workspaces=author_workspaces,
         output_checker=False,
@@ -459,7 +459,7 @@ def test_screenshot_withdraw_request(page, context, live_server):
 )
 def test_screenshot_request_partially_reviewed_icons(page, context, live_server):
     author, user_dicts = get_user_data()
-    checker1 = factories.create_user(
+    checker1 = factories.create_airlock_user(
         username="checker1",
         workspaces=[],
         output_checker=True,
@@ -524,12 +524,12 @@ def test_screenshot_request_partially_reviewed_icons(page, context, live_server)
 )
 def test_screenshot_request_reviewed_icons(page, context, live_server):
     author, user_dicts = get_user_data()
-    checker1 = factories.create_user(
+    checker1 = factories.create_airlock_user(
         username="checker1",
         workspaces=[],
         output_checker=True,
     )
-    checker2 = factories.create_user(
+    checker2 = factories.create_airlock_user(
         username="checker2",
         workspaces=[],
         output_checker=True,
@@ -593,12 +593,12 @@ def test_screenshot_request_reviewed_icons(page, context, live_server):
 )
 def test_screenshot_workspace_icons(page, context, live_server, mock_old_api):
     author, user_dicts = get_user_data()
-    checker1 = factories.create_user(
+    checker1 = factories.create_airlock_user(
         username="checker1",
         workspaces=[],
         output_checker=True,
     )
-    checker2 = factories.create_user(
+    checker2 = factories.create_airlock_user(
         username="checker2",
         workspaces=[],
         output_checker=True,

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -9,7 +9,7 @@ from airlock.types import UrlPath
 from tests import factories
 
 
-admin_user = factories.create_user("admin", output_checker=True)
+admin_user = factories.create_airlock_user("admin", output_checker=True)
 
 
 def find_and_click(locator):
@@ -482,7 +482,7 @@ def test_e2e_update_file(page, live_server, dev_users, multiselect):
     Test researcher updates a modified file in a returned request
     """
     # set up a returned file & request
-    author = factories.create_user("researcher", ["test-workspace"], False)
+    author = factories.create_airlock_user("researcher", ["test-workspace"], False)
 
     path = "subdir/file.txt"
 
@@ -527,7 +527,7 @@ def test_e2e_withdraw_and_readd_file(page, live_server, dev_users):
     Test researcher updates a modified file in a returned request
     """
     # Set up a returned request with an approved file
-    author = factories.create_user("researcher", ["test-workspace"], False)
+    author = factories.create_airlock_user("researcher", ["test-workspace"], False)
     path1 = "subdir/file1.txt"
     path2 = "subdir/file2.txt"
 
@@ -591,7 +591,7 @@ def test_e2e_reject_request(page, live_server, dev_users):
     # set up a reviewed request
     release_request = factories.create_request_at_status(
         "test-workspace",
-        author=factories.create_user("author", workspaces=["test-workspace"]),
+        author=factories.create_airlock_user("author", workspaces=["test-workspace"]),
         status=RequestStatus.REVIEWED,
         files=[factories.request_file(changes_requested=True)],
     )
@@ -617,7 +617,7 @@ def test_e2e_withdraw_request(page, live_server, dev_users):
     Request author withdraws their request
     """
     # set up a submitted request
-    user = factories.create_user("researcher", ["test-workspace"], False)
+    user = factories.create_airlock_user("researcher", ["test-workspace"], False)
     release_request = factories.create_request_at_status(
         "test-workspace",
         author=user,

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -12,16 +12,7 @@ def test_request_file_withdraw(live_server, context, page, bll):
     author = login_as_user(
         live_server,
         context,
-        user_dict={
-            "username": "author",
-            "workspaces": {
-                "workspace": {
-                    "project_details": {"name": "Project 2", "ongoing": True},
-                    "archived": False,
-                }
-            },
-            "output_checker": False,
-        },
+        user_dict=factories.create_api_user(username="author"),
     )
 
     release_request = factories.create_request_at_status(
@@ -56,10 +47,7 @@ def test_request_file_group_context_modal(live_server, context, page):
     author = login_as_user(
         live_server,
         context,
-        user_dict={
-            "username": "author",
-            "workspaces": ["workspace"],
-        },
+        user_dict=factories.create_api_user(username="author"),
     )
 
     release_request = factories.create_request_at_status(
@@ -93,20 +81,13 @@ def test_request_group_edit_comment_for_author(live_server, context, page, bll):
     author = login_as_user(
         live_server,
         context,
-        user_dict={
-            "username": "author",
-            "workspaces": {
-                "workspace": {
-                    "project_details": {"name": "Project 2", "ongoing": True},
-                    "archived": False,
-                },
-                "pending": {
-                    "project_details": {"name": "Project 2", "ongoing": True},
-                    "archived": False,
-                },
+        user_dict=factories.create_api_user(
+            username="author",
+            workspaces={
+                "workspace": factories.create_api_workspace(),
+                "pending": factories.create_api_workspace(),
             },
-            "output_checker": False,
-        },
+        ),
     )
 
     pending_release_request = factories.create_request_at_status(
@@ -170,11 +151,7 @@ def test_request_group_edit_comment_for_checker(
     login_as_user(
         live_server,
         context,
-        user_dict={
-            "username": "checker",
-            "workspaces": {},
-            "output_checker": True,
-        },
+        user_dict=factories.create_api_user(username="checker", output_checker=True),
     )
 
     submitted_release_request = factories.create_request_at_status(
@@ -221,11 +198,7 @@ def test_request_group_comment_visibility_public_for_checker(
     login_as_user(
         live_server,
         context,
-        user_dict={
-            "username": "checker",
-            "workspaces": {},
-            "output_checker": True,
-        },
+        user_dict=factories.create_api_user(username="checker", output_checker=True),
     )
     checker = factories.create_airlock_user("checker", [], True)
 
@@ -250,10 +223,7 @@ def test_request_group_comment_visibility_public_for_checker(
 
 def _workspace_dict():
     return {
-        "workspace": {
-            "project_details": {"name": "Project 2", "ongoing": True},
-            "archived": False,
-        }
+        "workspace": factories.create_api_workspace(project="Project 2"),
     }
 
 
@@ -291,10 +261,10 @@ def test_request_buttons(
     file_review_buttons_visible,
 ):
     user_data = {
-        "researcher": dict(
+        "researcher": factories.create_api_user(
             username="researcher", workspaces=_workspace_dict(), output_checker=False
         ),
-        "checker": dict(
+        "checker": factories.create_api_user(
             username="checker", workspaces=_workspace_dict(), output_checker=True
         ),
     }

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -227,7 +227,7 @@ def test_request_group_comment_visibility_public_for_checker(
             "output_checker": True,
         },
     )
-    checker = factories.create_user("checker", [], True)
+    checker = factories.create_airlock_user("checker", [], True)
 
     submitted_release_request = factories.create_request_at_status(
         "workspace",
@@ -301,7 +301,7 @@ def test_request_buttons(
 
     release_request = factories.create_request_at_status(
         "workspace",
-        author=factories.create_user(**user_data[author]),
+        author=factories.create_airlock_user(**user_data[author]),
         status=status,
         withdrawn_after=RequestStatus.PENDING,
         files=[
@@ -388,7 +388,7 @@ def test_submit_button_visibility(
     )
     release_request = factories.create_request_at_status(
         "workspace",
-        author=factories.create_user(**user_data),
+        author=factories.create_airlock_user(**user_data),
         status=RequestStatus.PENDING,
         files=files,
     )
@@ -425,7 +425,7 @@ def test_resubmit_button_visibility(
     user_data = dict(
         username="researcher", workspaces=_workspace_dict(), output_checker=False
     )
-    author = factories.create_user(**user_data)
+    author = factories.create_airlock_user(**user_data)
     # Create a returned release request with one output file
     release_request = factories.create_request_at_status(
         "workspace",
@@ -483,9 +483,11 @@ def test_request_returnable(
             username="checker2", workspaces=_workspace_dict(), output_checker=True
         ),
     }
-    author = factories.create_user(**user_data["author"])
+    author = factories.create_airlock_user(**user_data["author"])
     if checkers is not None:
-        checkers = [factories.create_user(**user_data[user]) for user in checkers]
+        checkers = [
+            factories.create_airlock_user(**user_data[user]) for user in checkers
+        ]
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -533,9 +535,10 @@ def test_returned_request(live_server, context, page, bll):
             username="checker2", workspaces=_workspace_dict(), output_checker=True
         ),
     }
-    author = factories.create_user(**user_data["author"])
+    author = factories.create_airlock_user(**user_data["author"])
     checkers = [
-        factories.create_user(**user_data[user]) for user in ["checker1", "checker2"]
+        factories.create_airlock_user(**user_data[user])
+        for user in ["checker1", "checker2"]
     ]
     release_request = factories.create_request_at_status(
         "workspace",

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -78,14 +78,15 @@ def test_content_buttons(
         "researcher": dict(
             username="researcher",
             workspaces={
-                "workspace": {
-                    "project_details": {"name": "Project 1", "ongoing": ongoing},
-                    "archived": archived,
-                }
+                "workspace": factories.create_api_workspace(
+                    project="Project 1", ongoing=ongoing, archived=archived
+                )
             },
             output_checker=False,
         ),
-        "checker": dict(username="checker", workspaces={}, output_checker=True),
+        "checker": factories.create_api_user(
+            username="checker", workspaces={}, output_checker=True
+        ),
     }
     user = login_as_user(live_server, context, user_data[login_as])
     workspace = factories.create_workspace("workspace", user)
@@ -223,14 +224,9 @@ def test_file_content_buttons(
     is_enabled,
     tooltip,
 ):
-    user_data = dict(
+    user_data = factories.create_api_user(
         username="author",
-        workspaces={
-            "workspace": {
-                "project_details": {"name": "Project 1", "ongoing": True},
-                "archived": False,
-            }
-        },
+        workspaces={"workspace": factories.create_api_workspace(project="Project 1")},
         output_checker=False,
     )
     user = login_as_user(live_server, context, user_data)
@@ -338,15 +334,12 @@ def test_csv_filtering(live_server, page, context, bll):
     login_as_user(
         live_server,
         context,
-        user_dict={
-            "username": "author",
-            "workspaces": {
-                "my-workspace": {
-                    "project_details": {"name": "Project 2", "ongoing": True},
-                    "archived": False,
-                },
+        user_dict=factories.create_api_user(
+            username="author",
+            workspaces={
+                "my-workspace": factories.create_api_workspace(project="Project 2"),
             },
-        },
+        ),
     )
 
     page.goto(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,7 @@ class AirlockClient(Client):
         username = credentials.get("username", "testuser")
         workspaces = credentials.get("workspaces")
         output_checker = credentials.get("output_checker", False)
-        user = factories.create_user(username, workspaces, output_checker)
+        user = factories.create_airlock_user(username, workspaces, output_checker)
         self.login_with_user(user)
 
     def login_with_user(self, user):

--- a/tests/integration/management/commands/test_backpopulate_file_manifest_data.py
+++ b/tests/integration/management/commands/test_backpopulate_file_manifest_data.py
@@ -25,7 +25,7 @@ def test_command(bll):
     file_meta.save()
 
     workspace = bll.get_workspace(
-        "workspace", factories.create_user(workspaces=["workspace"])
+        "workspace", factories.create_airlock_user(workspaces=["workspace"])
     )
     manifest = workspace.get_manifest_for_file(UrlPath(file_meta.relpath))
     for attr in ["commit", "size", "job_id", "timestamp", "repo"]:

--- a/tests/integration/management/commands/test_run_file_uploader.py
+++ b/tests/integration/management/commands/test_run_file_uploader.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.django_db
 def setup_release_request(upload_files_stubber, bll, response_statuses=None):
     # create an approved released request, with files waiting for upload
     workspace = factories.create_workspace("workspace")
-    author = factories.create_user("author", workspaces=["workspace"])
+    author = factories.create_airlock_user("author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         workspace,
         author=author,

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -2,6 +2,8 @@ from unittest import mock
 
 import pytest
 
+from tests import factories
+
 
 pytestmark = pytest.mark.django_db
 
@@ -28,16 +30,7 @@ def test_login(requests_post, client, settings):
 
     api_response = requests_post.return_value
     api_response.status_code = 200
-    api_response.json.return_value = {
-        "username": "test_user",
-        "output_checker": False,
-        "workspaces": {
-            "workspace": {
-                "project_details": {"name": "project1", "ongoing": True},
-                "archived": False,
-            },
-        },
-    }
+    api_response.json.return_value = factories.create_api_user()
 
     assert "user" not in client.session
 
@@ -52,11 +45,11 @@ def test_login(requests_post, client, settings):
         json={"user": "test_user", "token": "foo bar baz"},
     )
 
-    assert client.session["user"]["username"] == "test_user"
+    assert client.session["user"]["username"] == "testuser"
     assert client.session["user"]["output_checker"] is False
     assert client.session["user"]["workspaces"] == {
         "workspace": {
-            "project_details": {"name": "project1", "ongoing": True},
+            "project_details": {"name": "project", "ongoing": True},
             "archived": False,
         },
     }

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -10,7 +10,7 @@ from tests.conftest import get_trace
 
 @pytest.mark.django_db
 def test_middleware_expired_user(airlock_client, responses):
-    user = factories.create_user()
+    user = factories.create_airlock_user()
     airlock_client.login_with_user(user)
     factories.create_workspace("new_workspace")
 
@@ -45,7 +45,7 @@ def test_middleware_expired_user(airlock_client, responses):
 @pytest.mark.django_db
 def test_middleware_expired_error(airlock_client, responses):
     last_refresh = time.time() - (2 * settings.AIRLOCK_AUTHZ_TIMEOUT)
-    user = factories.create_user(last_refresh=last_refresh)
+    user = factories.create_airlock_user(last_refresh=last_refresh)
     airlock_client.login_with_user(user)
     factories.create_workspace("new_workspace")
 
@@ -60,7 +60,7 @@ def test_middleware_expired_error(airlock_client, responses):
 
 @pytest.mark.django_db
 def test_middleware_user_trace(airlock_client, responses):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     airlock_client.login_with_user(user)
     factories.create_workspace("workspace")
 

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -23,10 +23,9 @@ def test_middleware_expired_user(airlock_client, responses):
     session.save()
 
     new_workspaces = user.workspaces.copy()
-    new_workspaces["new_workspace"] = {
-        "project_details": {"name": "other_project", "ongoing": True},
-        "archived": False,
-    }
+    new_workspaces["new_workspace"] = factories.create_api_workspace(
+        project="other_project"
+    )
 
     responses.post(
         f"{settings.AIRLOCK_API_ENDPOINT}/releases/authorise",

--- a/tests/integration/test_visibility.py
+++ b/tests/integration/test_visibility.py
@@ -83,7 +83,7 @@ def test_request_comment_and_audit_visibility(bll):
     # validating that the comments that are visibile to various users at
     # different points in the process are correct.
     #
-    author = factories.create_user("author1", workspaces=["workspace"])
+    author = factories.create_airlock_user("author1", workspaces=["workspace"])
     checkers = factories.get_default_output_checkers()
 
     release_request = factories.create_request_at_status(

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -56,7 +56,7 @@ def test_request_id_does_not_exist(airlock_client):
 
 def test_request_view_root_summary(airlock_client):
     airlock_client.login(output_checker=True)
-    audit_user = factories.create_user("audit_user", workspaces=["workspace"])
+    audit_user = factories.create_airlock_user("audit_user", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=audit_user,
@@ -88,7 +88,7 @@ def test_request_view_root_summary(airlock_client):
 
 def test_request_view_root_group(airlock_client):
     airlock_client.login(output_checker=True)
-    audit_user = factories.create_user("audit_user", workspaces=["workspace"])
+    audit_user = factories.create_airlock_user("audit_user", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=audit_user,
@@ -130,7 +130,7 @@ def test_request_view_with_directory(airlock_client):
 
 
 def test_request_view_cannot_have_empty_directory(airlock_client):
-    author = factories.create_user("author", workspaces=["workspace"])
+    author = factories.create_airlock_user("author", workspaces=["workspace"])
     release_request = factories.create_release_request("workspace", author)
     factories.add_request_file(release_request, "group", "some_dir/file.txt")
 
@@ -315,9 +315,13 @@ def test_request_view_complete_turn_alert(
     can now be progressed by returning/rejecting/releasing
     """
     users = {
-        "researcher": factories.create_user("researcher", workspaces=["workspace"]),
-        "researcher1": factories.create_user("researcher", output_checker=False),
-        "checker": factories.create_user(
+        "researcher": factories.create_airlock_user(
+            "researcher", workspaces=["workspace"]
+        ),
+        "researcher1": factories.create_airlock_user(
+            "researcher", output_checker=False
+        ),
+        "checker": factories.create_airlock_user(
             "checker", output_checker=True, workspaces=["workspace"]
         ),
     }
@@ -638,7 +642,7 @@ def test_request_contents_group_not_exists(airlock_client):
 
 def test_request_download_file(airlock_client):
     airlock_client.login(username="reviewer", output_checker=True)
-    author = factories.create_user("author", ["workspace"])
+    author = factories.create_airlock_user("author", ["workspace"])
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "default", "file.txt", contents="test")
     response = airlock_client.get(
@@ -718,7 +722,7 @@ def test_request_download_file_permissions(
     airlock_client, request_author, user, can_download
 ):
     airlock_client.login(**user)
-    author = factories.create_user(**request_author)
+    author = factories.create_airlock_user(**request_author)
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(
         release_request, "default", "file.txt", contents="test", user=author
@@ -752,7 +756,7 @@ def test_request_index_user_permitted_requests(airlock_client):
 # reviews page
 def test_review_user_output_checker(airlock_client, mock_old_api):
     airlock_client.login(workspaces=["test_workspace"], output_checker=True)
-    other = factories.create_user(
+    other = factories.create_airlock_user(
         "other",
         workspaces=[
             "test_workspace",
@@ -816,7 +820,7 @@ def test_no_outstanding_request_output_checker(airlock_client):
 
 def test_request_index_user_request_progress(airlock_client):
     airlock_client.login(workspaces=["test_workspace"], output_checker=True)
-    other = factories.create_user(
+    other = factories.create_airlock_user(
         "other",
         workspaces=[
             "other_workspace",
@@ -936,7 +940,7 @@ def test_request_submit_author(airlock_client):
 
 def test_request_submit_not_author(airlock_client):
     airlock_client.login(workspaces=["test1"])
-    other_author = factories.create_user("other", ["test1"], False)
+    other_author = factories.create_airlock_user("other", ["test1"], False)
     release_request = factories.create_release_request(
         "test1", user=other_author, status=RequestStatus.PENDING
     )
@@ -981,7 +985,7 @@ def test_request_withdraw_author(airlock_client):
 
 def test_request_withdraw_not_author(airlock_client):
     airlock_client.login(workspaces=["test1"])
-    other_author = factories.create_user("other", ["test1"], False)
+    other_author = factories.create_airlock_user("other", ["test1"], False)
     release_request = factories.create_release_request(
         "test1", user=other_author, status=RequestStatus.PENDING
     )
@@ -1015,7 +1019,7 @@ def test_request_return_author(airlock_client):
 
 def test_request_return_output_checker(airlock_client):
     airlock_client.login(workspaces=["test1"], output_checker=True)
-    other_author = factories.create_user("other", ["test1"], False)
+    other_author = factories.create_airlock_user("other", ["test1"], False)
     release_request = factories.create_request_at_status(
         "test1",
         author=other_author,
@@ -1124,8 +1128,8 @@ def test_empty_requests_for_workspace(airlock_client):
 
 def test_requests_for_workspace(airlock_client):
     airlock_client.login(workspaces=["test1"])
-    author1 = factories.create_user("author1", ["test1"], False)
-    author2 = factories.create_user("author2", ["test1"], False)
+    author1 = factories.create_airlock_user("author1", ["test1"], False)
+    author2 = factories.create_airlock_user("author2", ["test1"], False)
 
     release_request1 = factories.create_release_request(
         "test1", user=author1, status=RequestStatus.PENDING
@@ -1151,7 +1155,7 @@ def test_requests_for_workspace(airlock_client):
 def test_file_review_bad_user(airlock_client, review):
     workspace = "test1"
     airlock_client.login(workspaces=[workspace], output_checker=False)
-    author = factories.create_user("author", [workspace], False)
+    author = factories.create_airlock_user("author", [workspace], False)
     path = "path/test.txt"
     release_request = factories.create_request_at_status(
         "test1",
@@ -1181,7 +1185,7 @@ def test_file_review_bad_user(airlock_client, review):
 @pytest.mark.parametrize("review", [("approve"), ("request_changes"), ("reset_review")])
 def test_file_review_bad_file(airlock_client, review):
     airlock_client.login(output_checker=True)
-    author = factories.create_user("author", ["test1"], False)
+    author = factories.create_airlock_user("author", ["test1"], False)
     path = "path/test.txt"
     release_request = factories.create_request_at_status(
         "test1",
@@ -1211,7 +1215,7 @@ def test_file_review_bad_file(airlock_client, review):
 
 def test_file_approve(airlock_client):
     airlock_client.login(output_checker=True)
-    author = factories.create_user("author", ["test1"], False)
+    author = factories.create_airlock_user("author", ["test1"], False)
     path = "path/test.txt"
     release_request = factories.create_request_at_status(
         "test1",
@@ -1238,7 +1242,7 @@ def test_file_approve(airlock_client):
 
 def test_file_request_changes(airlock_client):
     airlock_client.login(output_checker=True)
-    author = factories.create_user("author", ["test1"], False)
+    author = factories.create_airlock_user("author", ["test1"], False)
     path = "path/test.txt"
     release_request = factories.create_request_at_status(
         "test1",
@@ -1265,7 +1269,7 @@ def test_file_request_changes(airlock_client):
 
 def test_file_reset_review(airlock_client):
     airlock_client.login(output_checker=True)
-    author = factories.create_user("author", ["test1"], False)
+    author = factories.create_airlock_user("author", ["test1"], False)
     path = "path/test.txt"
     release_request = factories.create_request_at_status(
         "test1",
@@ -1307,7 +1311,7 @@ def test_file_reset_review(airlock_client):
 
 def test_request_reject_output_checker(airlock_client):
     airlock_client.login(output_checker=True)
-    author = factories.create_user("author", ["test1"], False)
+    author = factories.create_airlock_user("author", ["test1"], False)
     release_request = factories.create_request_at_status(
         "test1",
         author=author,
@@ -1326,7 +1330,7 @@ def test_request_reject_output_checker(airlock_client):
 def test_request_reject_not_output_checker(airlock_client):
     release_request = factories.create_request_at_status(
         "test1",
-        author=factories.create_user("author1", workspaces=["test1"]),
+        author=factories.create_airlock_user("author1", workspaces=["test1"]),
         status=RequestStatus.REVIEWED,
         files=[
             factories.request_file(changes_requested=True),
@@ -1452,7 +1456,7 @@ def test_file_withdraw_file_bad_request(airlock_client):
 
 
 def test_request_multiselect_withdraw_files(airlock_client):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         list(user.workspaces)[0],
         author=user,
@@ -1485,7 +1489,7 @@ def test_request_multiselect_withdraw_files(airlock_client):
 
 
 def test_request_multiselect_withdraw_files_not_permitted(airlock_client):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         list(user.workspaces)[0],
         author=user,
@@ -1518,7 +1522,7 @@ def test_request_multiselect_withdraw_files_not_permitted(airlock_client):
 
 
 def test_request_multiselect_withdraw_files_none_selected(airlock_client):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         list(user.workspaces)[0],
         author=user,
@@ -1541,7 +1545,7 @@ def test_request_multiselect_withdraw_files_none_selected(airlock_client):
 
 
 def test_request_multiselect_withdraw_files_invalid_action(airlock_client):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         list(user.workspaces)[0],
         author=user,
@@ -1802,8 +1806,8 @@ def test_requests_release_files_404(airlock_client, release_files_stubber):
 def test_request_view_tracing_with_request_attribute(
     airlock_client, release_files_stubber, urlpath, post_data, login_as, status, stub
 ):
-    author = factories.create_user("author", ["test-workspace"])
-    checker = factories.create_user("output_checker", output_checker=True)
+    author = factories.create_airlock_user("author", ["test-workspace"])
+    checker = factories.create_airlock_user("output_checker", output_checker=True)
     airlock_client.login(username=login_as, output_checker=True)
 
     release_request = factories.create_request_at_status(
@@ -1815,7 +1819,7 @@ def test_request_view_tracing_with_request_attribute(
                 "default",
                 "file.txt",
                 approved=status in [RequestStatus.REVIEWED, RequestStatus.RELEASED],
-                checkers=[checker, factories.create_user(output_checker=True)],
+                checkers=[checker, factories.create_airlock_user(output_checker=True)],
             ),
         ],
     )
@@ -1904,8 +1908,8 @@ def test_group_edit_no_change(airlock_client, bll):
 
 
 def test_group_edit_bad_user(airlock_client):
-    author = factories.create_user("author", ["workspace"], False)
-    other = factories.create_user("other", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
@@ -1925,7 +1929,7 @@ def test_group_edit_bad_user(airlock_client):
 
 
 def test_group_edit_bad_group(airlock_client):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
@@ -1956,12 +1960,12 @@ def test_group_edit_bad_group(airlock_client):
 def test_group_comment_create_success(
     airlock_client, output_checker, visibility, allowed
 ):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
 
-    user = factories.create_user(
+    user = factories.create_airlock_user(
         output_checker=output_checker, workspaces=["workspace"]
     )
     airlock_client.login_with_user(user)
@@ -1987,8 +1991,8 @@ def test_group_comment_create_success(
 
 
 def test_group_comment_create_bad_user(airlock_client):
-    author = factories.create_user("author", ["workspace"], False)
-    other = factories.create_user("other", ["other"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["other"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
@@ -2005,7 +2009,7 @@ def test_group_comment_create_bad_user(airlock_client):
 
 
 def test_group_comment_create_bad_form(airlock_client):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
@@ -2025,7 +2029,7 @@ def test_group_comment_create_bad_form(airlock_client):
 
 
 def test_group_comment_create_bad_group(airlock_client):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
@@ -2042,7 +2046,7 @@ def test_group_comment_create_bad_group(airlock_client):
 
 
 def test_group_comment_delete(airlock_client):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
@@ -2078,7 +2082,7 @@ def test_group_comment_delete(airlock_client):
 
 
 def test_group_comment_visibility_public(airlock_client):
-    checker = factories.create_user("checker", [], True)
+    checker = factories.create_airlock_user("checker", [], True)
 
     release_request = factories.create_request_at_status(
         "workspace",
@@ -2114,7 +2118,7 @@ def test_group_comment_visibility_public(airlock_client):
 
 @pytest.mark.parametrize("endpoint,", ["delete", "visibility_public"])
 def test_group_comment_modify_bad_form(airlock_client, endpoint):
-    checker = factories.create_user("checker", [], True)
+    checker = factories.create_airlock_user("checker", [], True)
 
     release_request = factories.create_request_at_status(
         "workspace",
@@ -2150,7 +2154,7 @@ def test_group_comment_modify_bad_form(airlock_client, endpoint):
 
 @pytest.mark.parametrize("endpoint,", ["delete", "visibility_public"])
 def test_group_comment_modify_bad_group(airlock_client, endpoint):
-    checker = factories.create_user("checker", [], True)
+    checker = factories.create_airlock_user("checker", [], True)
 
     release_request = factories.create_request_at_status(
         "workspace",
@@ -2183,7 +2187,7 @@ def test_group_comment_modify_bad_group(airlock_client, endpoint):
 
 @pytest.mark.parametrize("endpoint,", ["delete", "visibility_public"])
 def test_group_comment_modify_missing_comment(airlock_client, endpoint):
-    checker = factories.create_user("checker", [], True)
+    checker = factories.create_airlock_user("checker", [], True)
 
     release_request = factories.create_request_at_status(
         "workspace",

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -23,13 +23,7 @@ def test_home_redirects(airlock_client):
 
 def test_workspace_view_summary(airlock_client):
     user = factories.create_airlock_user(
-        username="testuser",
-        workspaces={
-            "workspace": {
-                "project_details": {"name": "TESTPROJECT", "ongoing": True},
-                "archived": False,
-            }
-        },
+        workspaces={"workspace": factories.create_api_workspace(project="TESTPROJECT")}
     )
 
     airlock_client.login_with_user(user)
@@ -44,13 +38,13 @@ def test_workspace_view_summary(airlock_client):
 
 def test_workspace_view_archived_inactive(airlock_client):
     user = factories.create_airlock_user(
-        username="testuser",
         workspaces={
-            "workspace-abc": {
-                "project_details": {"name": "TESTPROJECT", "ongoing": False},
-                "archived": True,
-            }
-        },
+            "workspace-abc": factories.create_api_workspace(
+                project="TESTPROJECT",
+                archived=True,
+                ongoing=False,
+            )
+        }
     )
 
     airlock_client.login_with_user(user)
@@ -488,30 +482,18 @@ def test_workspaces_index_user_permitted_workspaces(airlock_client):
     user = factories.create_airlock_user(
         username="testuser",
         workspaces={
-            "test1a": {
-                "project_details": {"name": "Project 1", "ongoing": True},
-                "archived": True,
-            },
-            "test1b": {
-                "project_details": {"name": "Project 1", "ongoing": True},
-                "archived": False,
-            },
-            "test1c": {
-                "project_details": {"name": "Project 1", "ongoing": True},
-                "archived": False,
-            },
-            "test2b": {
-                "project_details": {"name": "Project 2", "ongoing": False},
-                "archived": False,
-            },
-            "test2a": {
-                "project_details": {"name": "Project 2", "ongoing": False},
-                "archived": False,
-            },
-            "test3": {
-                "project_details": {"name": "Project 3", "ongoing": True},
-                "archived": False,
-            },
+            "test1a": factories.create_api_workspace(
+                project="Project 1", archived=True
+            ),
+            "test1b": factories.create_api_workspace(project="Project 1"),
+            "test1c": factories.create_api_workspace(project="Project 1"),
+            "test2b": factories.create_api_workspace(
+                project="Project 2", ongoing=False
+            ),
+            "test2a": factories.create_api_workspace(
+                project="Project 2", ongoing=False
+            ),
+            "test3": factories.create_api_workspace(project="Project 3"),
         },
     )
 

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -22,7 +22,7 @@ def test_home_redirects(airlock_client):
 
 
 def test_workspace_view_summary(airlock_client):
-    user = factories.create_user_from_dict(
+    user = factories.create_airlock_user(
         username="testuser",
         workspaces={
             "workspace": {
@@ -43,7 +43,7 @@ def test_workspace_view_summary(airlock_client):
 
 
 def test_workspace_view_archived_inactive(airlock_client):
-    user = factories.create_user_from_dict(
+    user = factories.create_airlock_user(
         username="testuser",
         workspaces={
             "workspace-abc": {
@@ -63,7 +63,7 @@ def test_workspace_view_archived_inactive(airlock_client):
 
 
 def test_workspace_view_with_existing_request_for_user(airlock_client):
-    user = factories.create_user(output_checker=True)
+    user = factories.create_airlock_user(output_checker=True)
     airlock_client.login_with_user(user)
     factories.write_workspace_file("workspace", "file.txt")
     release_request = factories.create_release_request("workspace", user=user)
@@ -122,8 +122,10 @@ def test_workspace_directory_and_request_can_multiselect_add(
     airlock_client, bll, mock_old_api, login_as, status, can_multiselect_add
 ):
     users = {
-        "author": factories.create_user("author", workspaces=["workspace"]),
-        "checker": factories.create_user("checker", workspaces=[], output_checker=True),
+        "author": factories.create_airlock_user("author", workspaces=["workspace"]),
+        "checker": factories.create_airlock_user(
+            "checker", workspaces=[], output_checker=True
+        ),
     }
     airlock_client.login_with_user(users[login_as])
     factories.create_request_at_status(
@@ -168,7 +170,7 @@ def test_workspace_view_with_file(airlock_client):
     ],
 )
 def test_workspace_view_with_updated_file(bll, airlock_client, request_status):
-    author = factories.create_user("author", workspaces=["test-workspace"])
+    author = factories.create_airlock_user("author", workspaces=["test-workspace"])
 
     airlock_client.login_with_user(author)
     # set up a returned file & request
@@ -309,9 +311,19 @@ def test_workspace_view_redirects_to_file(airlock_client):
 @pytest.mark.parametrize(
     "user,can_see_form",
     [
-        (factories.create_user(workspaces=["workspace"], output_checker=True), True),
-        (factories.create_user(workspaces=["workspace"], output_checker=False), True),
-        (factories.create_user(workspaces=[], output_checker=True), False),
+        (
+            factories.create_airlock_user(
+                workspaces=["workspace"], output_checker=True
+            ),
+            True,
+        ),
+        (
+            factories.create_airlock_user(
+                workspaces=["workspace"], output_checker=False
+            ),
+            True,
+        ),
+        (factories.create_airlock_user(workspaces=[], output_checker=True), False),
     ],
 )
 def test_workspace_view_file_add_to_request(airlock_client, user, can_see_form):
@@ -394,7 +406,7 @@ def test_workspace_view_file_add_to_request(airlock_client, user, can_see_form):
 def test_workspace_view_file_add_to_current_request(
     mock_old_api, airlock_client, status, is_current, files, can_see_form
 ):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     airlock_client.login_with_user(user)
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file("workspace", "file.txt", "foo")
@@ -473,7 +485,7 @@ def test_workspaces_index_no_user(airlock_client):
 
 
 def test_workspaces_index_user_permitted_workspaces(airlock_client):
-    user = factories.create_user_from_dict(
+    user = factories.create_airlock_user(
         username="testuser",
         workspaces={
             "test1a": {
@@ -666,7 +678,7 @@ def test_workspace_multiselect_add_files_updated_file(airlock_client, bll):
 def test_workspace_multiselect_update_files(
     airlock_client, bll, path1_updated, path2_updated, ignored_count
 ):
-    author = factories.create_user("author", workspaces=["test1"])
+    author = factories.create_airlock_user("author", workspaces=["test1"])
     airlock_client.login_with_user(author)
 
     workspace = factories.create_workspace("test1")

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -85,7 +85,7 @@ def test_get_audit_log(test_audits, kwargs, expected_audits):
 
 
 def test_delete_file_from_request_bad_state():
-    author = factories.create_user()
+    author = factories.create_airlock_user()
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.SUBMITTED,
@@ -112,7 +112,7 @@ def test_delete_file_from_request_bad_state():
     ],
 )
 def test_withdraw_file_from_request_bad_state(status, mock_old_api):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -132,7 +132,7 @@ def test_withdraw_file_from_request_bad_state(status, mock_old_api):
 
 
 def test_withdraw_file_from_request_file_does_not_exist():
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -161,7 +161,7 @@ def test_withdraw_file_from_request_file_does_not_exist():
 
 def test_add_file_to_request_bad_state():
     workspace = factories.create_workspace("workspace")
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     request_file = factories.request_file()
     relpath = UrlPath(request_file.path)
     factories.write_workspace_file(workspace, relpath, contents="1234")
@@ -197,7 +197,7 @@ def test_add_file_to_request_bad_state():
 
 
 def test_delete_file_from_request_bad_path():
-    author = factories.create_user()
+    author = factories.create_airlock_user()
     release_request = factories.create_release_request(
         "workspace",
         status=RequestStatus.PENDING,
@@ -225,8 +225,8 @@ def test_delete_file_from_request_bad_path():
     ],
 )
 def test_group_comment_modify_bad_params(comment_modify_function, audit_event):
-    author = factories.create_user("author", ["workspace"], False)
-    other = factories.create_user("other", ["other-workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["other-workspace"], False)
 
     release_request = factories.create_request_at_status(
         "workspace",

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -69,18 +69,9 @@ def test_provider_get_workspaces_for_user(bll, output_checker):
     factories.create_workspace("bar")
     factories.create_workspace("not-allowed")
     workspaces = {
-        "foo": {
-            "project_details": {"name": "project 1", "ongoing": True},
-            "archived": False,
-        },
-        "bar": {
-            "project_details": {"name": "project 2", "ongoing": True},
-            "archived": True,
-        },
-        "not-exists": {
-            "project_details": {"name": "project 2", "ongoing": True},
-            "archived": False,
-        },
+        "foo": factories.create_api_workspace(project="project 1", archived=False),
+        "bar": factories.create_api_workspace(project="project 2", archived=True),
+        "not-exists": factories.create_api_workspace(project="project 3"),
     }
     user = factories.create_airlock_user(
         username="testuser", workspaces=workspaces, output_checker=output_checker
@@ -1308,20 +1299,18 @@ def test_add_file_to_request_not_author(bll):
         # workspace archived
         (
             {
-                "workspace": {
-                    "project_details": {"name": "p1", "ongoing": True},
-                    "archived": True,
-                }
+                "workspace": factories.create_api_workspace(
+                    project="p1", archived=True
+                ),
             },
             exceptions.RequestPermissionDenied,
         ),
         # project inactive
         (
             {
-                "workspace": {
-                    "project_details": {"name": "p1", "ongoing": False},
-                    "archived": False,
-                }
+                "workspace": factories.create_api_workspace(
+                    project="p1", ongoing=False
+                ),
             },
             exceptions.RequestPermissionDenied,
         ),

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -52,7 +52,7 @@ def assert_last_notification(mock_notifications, event_type):
 
 
 def setup_empty_release_request():
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     path = UrlPath("path/file.txt")
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, path)
@@ -82,7 +82,7 @@ def test_provider_get_workspaces_for_user(bll, output_checker):
             "archived": False,
         },
     }
-    user = factories.create_user_from_dict(
+    user = factories.create_airlock_user(
         username="testuser", workspaces=workspaces, output_checker=output_checker
     )
 
@@ -93,8 +93,8 @@ def test_provider_get_workspaces_for_user(bll, output_checker):
 
 
 def test_provider_request_release_files_request_not_approved(bll, mock_notifications):
-    author = factories.create_user("author", ["workspace"])
-    checker = factories.create_user("checker", output_checker=True)
+    author = factories.create_airlock_user("author", ["workspace"])
+    checker = factories.create_airlock_user("checker", output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -120,14 +120,14 @@ def test_provider_request_release_files_invalid_file_type(bll, mock_notification
             files=[factories.request_file(path="test/file.foo", approved=True)],
         )
 
-    checker = factories.create_user("checker", [], output_checker=True)
+    checker = factories.create_airlock_user("checker", [], output_checker=True)
     with pytest.raises(exceptions.RequestPermissionDenied):
         bll.release_files(release_request, checker)
     assert_last_notification(mock_notifications, "request_reviewed")
 
 
 def test_provider_request_release_files(mock_old_api, mock_notifications, bll, freezer):
-    author = factories.create_user("author", workspaces=["workspace"])
+    author = factories.create_airlock_user("author", workspaces=["workspace"])
     checkers = factories.get_default_output_checkers()
     release_request = factories.create_request_at_status(
         "workspace",
@@ -257,7 +257,7 @@ def test_provider_request_release_files(mock_old_api, mock_notifications, bll, f
 
 
 def test_provider_request_release_files_retry(mock_old_api, bll, freezer):
-    author = factories.create_user("author", workspaces=["workspace"])
+    author = factories.create_airlock_user("author", workspaces=["workspace"])
     checkers = factories.get_default_output_checkers()
     release_request = factories.create_request_at_status(
         "workspace",
@@ -363,7 +363,7 @@ def test_provider_request_release_files_retry(mock_old_api, bll, freezer):
 
 
 def test_provider_register_file_upload(mock_old_api, bll, freezer):
-    author = factories.create_user("author", workspaces=["workspace"])
+    author = factories.create_airlock_user("author", workspaces=["workspace"])
     checkers = factories.get_default_output_checkers()
     release_request = factories.create_request_at_status(
         "workspace",
@@ -446,7 +446,7 @@ def test_provider_register_file_upload(mock_old_api, bll, freezer):
 
 
 def test_provider_register_and_reset_file_upload_attempt(mock_old_api, bll, freezer):
-    author = factories.create_user("author", workspaces=["workspace"])
+    author = factories.create_airlock_user("author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -481,8 +481,8 @@ def test_provider_register_and_reset_file_upload_attempt(mock_old_api, bll, free
 
 
 def test_provider_get_requests_for_workspace(bll):
-    user = factories.create_user("test", ["workspace", "workspace2"])
-    other_user = factories.create_user("other", ["workspace"])
+    user = factories.create_airlock_user("test", ["workspace", "workspace2"])
+    other_user = factories.create_airlock_user("other", ["workspace"])
     r1 = factories.create_release_request("workspace", user)
     factories.create_release_request("workspace2", user)
     r3 = factories.create_release_request("workspace", other_user)
@@ -494,8 +494,8 @@ def test_provider_get_requests_for_workspace(bll):
 
 
 def test_provider_get_requests_for_workspace_bad_user(bll):
-    user = factories.create_user("test", ["workspace"])
-    other_user = factories.create_user("other", ["workspace_2"])
+    user = factories.create_airlock_user("test", ["workspace"])
+    other_user = factories.create_airlock_user("other", ["workspace_2"])
     factories.create_release_request("workspace", user)
     factories.create_release_request("workspace_2", other_user)
 
@@ -504,8 +504,8 @@ def test_provider_get_requests_for_workspace_bad_user(bll):
 
 
 def test_provider_get_requests_for_workspace_output_checker(bll):
-    user = factories.create_user("test", ["workspace"])
-    other_user = factories.create_user("other", [], True)
+    user = factories.create_airlock_user("test", ["workspace"])
+    other_user = factories.create_airlock_user("other", [], True)
     r1 = factories.create_release_request("workspace", user)
 
     assert [r.id for r in bll.get_requests_for_workspace("workspace", other_user)] == [
@@ -514,8 +514,8 @@ def test_provider_get_requests_for_workspace_output_checker(bll):
 
 
 def test_provider_get_requests_authored_by_user(bll):
-    user = factories.create_user("test", ["workspace"])
-    other_user = factories.create_user("other", ["workspace"])
+    user = factories.create_airlock_user("test", ["workspace"])
+    other_user = factories.create_airlock_user("other", ["workspace"])
     r1 = factories.create_release_request("workspace", user)
     factories.create_release_request("workspace", other_user)
 
@@ -535,8 +535,8 @@ def test_provider_get_requests_authored_by_user(bll):
 def test_provider_get_outstanding_requests_for_review(
     mock_old_api, output_checker, bll
 ):
-    user = factories.create_user("test", ["workspace"], output_checker)
-    other_user = factories.create_user("other", ["workspace"], False)
+    user = factories.create_airlock_user("test", ["workspace"], output_checker)
+    other_user = factories.create_airlock_user("other", ["workspace"], False)
     # request created by another user, status submitted
     r1 = factories.create_request_at_status(
         "workspace",
@@ -564,7 +564,7 @@ def test_provider_get_outstanding_requests_for_review(
         ]
     ):
         ws = f"workspace{i}"
-        user_n = factories.create_user(f"test_{i}", [ws])
+        user_n = factories.create_airlock_user(f"test_{i}", [ws])
         factories.create_request_at_status(
             ws,
             author=user_n,
@@ -593,8 +593,8 @@ def test_provider_get_outstanding_requests_for_review(
     ],
 )
 def test_provider_get_returned_requests(mock_old_api, output_checker, bll):
-    user = factories.create_user("test", ["workspace"], output_checker)
-    other_user = factories.create_user("other", ["workspace"], False)
+    user = factories.create_airlock_user("test", ["workspace"], output_checker)
+    other_user = factories.create_airlock_user("other", ["workspace"], False)
 
     # request created by another user, status returned
     r1 = factories.create_request_at_status(
@@ -625,7 +625,7 @@ def test_provider_get_returned_requests(mock_old_api, output_checker, bll):
         ]
     ):
         ws = f"workspace{i}"
-        user_n = factories.create_user(f"test_{i}", [ws])
+        user_n = factories.create_airlock_user(f"test_{i}", [ws])
         factories.create_request_at_status(
             ws,
             author=user_n,
@@ -652,8 +652,8 @@ def test_provider_get_returned_requests(mock_old_api, output_checker, bll):
     ],
 )
 def test_provider_get_approved_requests(mock_old_api, output_checker, bll):
-    user = factories.create_user("test", ["workspace"], output_checker)
-    other_user = factories.create_user("other", ["workspace"], False)
+    user = factories.create_airlock_user("test", ["workspace"], output_checker)
+    other_user = factories.create_airlock_user("other", ["workspace"], False)
 
     # request created by another user, status approved
     r1 = factories.create_request_at_status(
@@ -686,7 +686,7 @@ def test_provider_get_approved_requests(mock_old_api, output_checker, bll):
         ]
     ):
         ws = f"workspace{i}"
-        user_n = factories.create_user(f"test_{i}", [ws])
+        user_n = factories.create_airlock_user(f"test_{i}", [ws])
         factories.create_request_at_status(
             ws,
             author=user_n,
@@ -723,7 +723,7 @@ def test_provider_get_approved_requests(mock_old_api, output_checker, bll):
     ],
 )
 def test_provider_get_current_request_for_user(mock_old_api, bll, status, is_current):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=user,
@@ -741,8 +741,8 @@ def test_provider_get_current_request_for_user(mock_old_api, bll, status, is_cur
 
 def test_provider_get_or_create_current_request_for_user(bll):
     workspace = factories.create_workspace("workspace")
-    user = factories.create_user("testuser", ["workspace"], False)
-    other_user = factories.create_user("otheruser", ["workspace"], False)
+    user = factories.create_airlock_user("testuser", ["workspace"], False)
+    other_user = factories.create_airlock_user("otheruser", ["workspace"], False)
 
     assert bll.get_current_request("workspace", user) is None
 
@@ -781,7 +781,7 @@ def test_provider_get_or_create_current_request_for_user(bll):
 
 def test_provider_get_current_request_for_former_user(bll):
     factories.create_workspace("workspace")
-    user = factories.create_user("testuser", ["workspace"], False)
+    user = factories.create_airlock_user("testuser", ["workspace"], False)
 
     assert bll.get_current_request("workspace", user) is None
 
@@ -800,7 +800,7 @@ def test_provider_get_current_request_for_former_user(bll):
     ]
 
     # let's pretend the user no longer has permission to access the workspace
-    former_user = factories.create_user("testuser", [], False)
+    former_user = factories.create_airlock_user("testuser", [], False)
 
     with pytest.raises(Exception):
         bll.get_current_request("workspace", former_user)
@@ -809,7 +809,7 @@ def test_provider_get_current_request_for_former_user(bll):
 def test_provider_get_current_request_for_user_output_checker(bll):
     """Output checker must have explict workspace permissions to create requests."""
     factories.create_workspace("workspace")
-    user = factories.create_user("output_checker", [], True)
+    user = factories.create_airlock_user("output_checker", [], True)
 
     with pytest.raises(exceptions.RequestPermissionDenied):
         bll.get_or_create_current_request("workspace", user)
@@ -980,9 +980,11 @@ def test_provider_get_current_request_for_user_output_checker(bll):
 def test_set_status(
     current, future, valid_author, valid_checker, withdrawn_after, bll, mock_old_api
 ):
-    author = factories.create_user("author", ["workspace1", "workspace2"], False)
-    checker = factories.create_user(output_checker=True)
-    file_reviewers = [checker, factories.create_user("checker1", [], True)]
+    author = factories.create_airlock_user(
+        "author", ["workspace1", "workspace2"], False
+    )
+    checker = factories.create_airlock_user(output_checker=True)
+    file_reviewers = [checker, factories.create_airlock_user("checker1", [], True)]
     audit_type = bll.STATUS_AUDIT_EVENT[future]
 
     release_request1 = factories.create_request_at_status(
@@ -1091,8 +1093,8 @@ def test_set_status_notifications(
     mock_old_api,
 ):
     users = {
-        "author": factories.create_user("author", ["workspace"], False),
-        "checker": factories.create_user(output_checker=True),
+        "author": factories.create_airlock_user("author", ["workspace"], False),
+        "checker": factories.create_airlock_user(output_checker=True),
     }
     release_request = factories.create_request_at_status(
         "workspace",
@@ -1133,7 +1135,7 @@ def test_set_status_notifications(
 def test_notification_updates(
     bll, mock_notifications, updates, success, expected_error
 ):
-    author = factories.create_user()
+    author = factories.create_airlock_user()
     release_request = factories.create_release_request("workspace", author)
     if success:
         bll.send_notification(
@@ -1153,7 +1155,7 @@ def test_notification_error(bll, notifications_stubber, caplog):
     mock_notifications = notifications_stubber(
         json={"status": "error", "message": "something went wrong"}
     )
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "test/file.txt")
     bll.group_edit(release_request, "group", "foo", "bar", author)
@@ -1170,8 +1172,8 @@ def test_notification_error(bll, notifications_stubber, caplog):
 
 @pytest.mark.parametrize("all_files_approved", (True, False))
 def test_set_status_approved(all_files_approved, bll, mock_notifications):
-    author = factories.create_user("author", ["workspace"], False)
-    checker = factories.create_user(output_checker=True)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    checker = factories.create_airlock_user(output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -1194,7 +1196,7 @@ def test_set_status_approved(all_files_approved, bll, mock_notifications):
 
 
 def test_set_status_cannot_action_own_request(bll, mock_old_api):
-    user = factories.create_user(
+    user = factories.create_airlock_user(
         workspaces=["workspace", "workspace1"], output_checker=True
     )
     release_request1 = factories.create_request_at_status(
@@ -1222,7 +1224,7 @@ def test_submit_request(bll, mock_notifications):
     """
     From pending
     """
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     release_request = factories.create_release_request(
         "workspace", user=author, status=RequestStatus.PENDING
     )
@@ -1239,7 +1241,7 @@ def test_resubmit_request(bll, mock_notifications):
     From returned
     Files with changes requested status are moved to undecided
     """
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     # Returned request with two files, one is approved by both reviewers, one has changes requested
     release_request = factories.create_request_at_status(
         "workspace",
@@ -1260,7 +1262,7 @@ def test_resubmit_request(bll, mock_notifications):
     assert release_request.status == RequestStatus.SUBMITTED
     assert_last_notification(mock_notifications, "request_resubmitted")
     for i in range(2):
-        user = factories.create_user(f"output-checker-{i}", output_checker=True)
+        user = factories.create_airlock_user(f"output-checker-{i}", output_checker=True)
         # approved file review is still approved
         approved_file = release_request.get_request_file_from_output_path(
             UrlPath("file.txt")
@@ -1281,8 +1283,8 @@ def test_resubmit_request(bll, mock_notifications):
 
 
 def test_add_file_to_request_not_author(bll):
-    author = factories.create_user("author", ["workspace"], False)
-    other = factories.create_user("other", ["workspace"], True)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["workspace"], True)
 
     path = UrlPath("path/file.txt")
     workspace = factories.create_workspace("workspace")
@@ -1331,17 +1333,17 @@ def test_add_file_to_request_no_permission(bll, workspaces, exception):
     factories.write_workspace_file(workspace, path)
     release_request = factories.create_release_request(
         "workspace",
-        user=factories.create_user("author", ["workspace"], False),
+        user=factories.create_airlock_user("author", ["workspace"], False),
     )
 
     # create duplicate user with test workspaces
-    author = factories.create_user_from_dict("author", workspaces, False)
+    author = factories.create_airlock_user("author", workspaces, False)
     with pytest.raises(exception):
         bll.add_file_to_request(release_request, path, author)
 
 
 def test_add_file_to_request_invalid_file_type(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     path = UrlPath("path/file.foo")
     workspace = factories.create_workspace("workspace")
@@ -1370,7 +1372,7 @@ def test_add_file_to_request_invalid_file_type(bll):
     ],
 )
 def test_add_file_to_request_states(status, success, bll, mock_old_api):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     path = UrlPath("path/file.txt")
     workspace = factories.create_workspace("workspace")
@@ -1405,7 +1407,7 @@ def test_add_file_to_request_states(status, success, bll, mock_old_api):
 
 
 def test_add_file_to_request_default_filetype(bll):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     path = UrlPath("path/file.txt")
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, path)
@@ -1427,7 +1429,7 @@ def test_add_file_to_request_default_filetype(bll):
     ],
 )
 def test_add_file_to_request_with_filetype(bll, filetype, success):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     path = UrlPath("path/file.txt")
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, path)
@@ -1446,7 +1448,7 @@ def test_add_file_to_request_with_filetype(bll, filetype, success):
 
 
 def test_add_file_to_request_already_released(bll, mock_old_api):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     # release one file, include one supporting file
     factories.create_request_at_status(
         "workspace",
@@ -1480,7 +1482,7 @@ def test_add_file_to_request_already_released(bll, mock_old_api):
 
 
 def test_update_file_in_request_invalid_file_type(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     relpath = UrlPath("path/file.foo")
     workspace = factories.create_workspace("workspace")
@@ -1500,7 +1502,7 @@ def test_update_file_in_request_invalid_file_type(bll):
 
 
 def test_update_file_in_request_not_updated(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     relpath = UrlPath("path/file.txt")
     workspace = factories.create_workspace("workspace")
@@ -1539,7 +1541,7 @@ def test_update_file_to_request_states(
     mock_notifications,
     mock_old_api,
 ):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     checkers = factories.get_default_output_checkers()
     workspace = factories.create_workspace("workspace")
     path = UrlPath("path/file.txt")
@@ -1648,7 +1650,7 @@ def test_update_file_to_request_states(
 
 
 def test_withdraw_file_from_request_pending(bll):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     path1 = UrlPath("path/file1.txt")
     path2 = UrlPath("path/file2.txt")
     release_request = factories.create_request_at_status(
@@ -1694,7 +1696,7 @@ def test_withdraw_file_from_request_pending(bll):
 
 
 def test_withdraw_file_from_request_returned(bll):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     path1 = UrlPath("path/file1.txt")
     release_request = factories.create_request_at_status(
         "workspace",
@@ -1734,7 +1736,7 @@ def test_withdraw_file_from_request_returned(bll):
 
 
 def test_readd_withdrawn_file_to_request_returned(bll):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     path = UrlPath("path/file1.txt")
     release_request = factories.create_request_at_status(
         "workspace",
@@ -1765,7 +1767,7 @@ def test_readd_withdrawn_file_to_request_returned(bll):
 
 
 def test_readd_withdrawn_file_to_request_returned_new_group(bll):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     path = UrlPath("path/file1.txt")
     release_request = factories.create_request_at_status(
         "workspace",
@@ -1823,7 +1825,7 @@ def test_readd_withdrawn_file_to_request_returned_new_group(bll):
     ],
 )
 def test_withdraw_file_from_request_not_editable_state(bll, mock_old_api, status):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -1846,7 +1848,7 @@ def test_withdraw_file_from_request_not_editable_state(bll, mock_old_api, status
 
 @pytest.mark.parametrize("status", [RequestStatus.PENDING, RequestStatus.RETURNED])
 def test_withdraw_file_from_request_bad_file(bll, status):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -1866,7 +1868,7 @@ def test_withdraw_file_from_request_bad_file(bll, status):
 
 @pytest.mark.parametrize("status", [RequestStatus.PENDING, RequestStatus.SUBMITTED])
 def test_withdraw_file_from_request_not_author(bll, status):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -1878,7 +1880,7 @@ def test_withdraw_file_from_request_not_author(bll, status):
         ],
     )
 
-    other = factories.create_user(username="other", workspaces=["workspace"])
+    other = factories.create_airlock_user(username="other", workspaces=["workspace"])
 
     with pytest.raises(exceptions.RequestPermissionDenied):
         bll.withdraw_file_from_request(
@@ -1887,7 +1889,7 @@ def test_withdraw_file_from_request_not_author(bll, status):
 
 
 def test_withdraw_file_from_request_already_withdrawn(bll):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -1917,7 +1919,7 @@ def _get_request_file(release_request, path):
 
 def test_approve_file_not_submitted(bll):
     release_request, path, author = setup_empty_release_request()
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
 
     bll.add_file_to_request(release_request, path, author)
     request_file = release_request.get_request_file_from_output_path(path)
@@ -1958,7 +1960,7 @@ def test_approve_file_not_your_own(bll):
 
 def test_approve_file_not_checker(bll):
     release_request, path, author = setup_empty_release_request()
-    author2 = factories.create_user("author2", [], False)
+    author2 = factories.create_airlock_user("author2", [], False)
 
     bll.add_file_to_request(release_request, path, author)
     bll.group_edit(release_request, "default", "foo", "bar", author)
@@ -1987,7 +1989,7 @@ def test_approve_file_not_part_of_request(bll):
         status=RequestStatus.SUBMITTED,
         files=[factories.request_file(path=path)],
     )
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
     request_file = release_request.get_request_file_from_output_path(path)
     bad_path = UrlPath("path/file2.txt")
     bad_request_file = factories.create_request_file_bad_path(request_file, bad_path)
@@ -2013,7 +2015,7 @@ def test_approve_supporting_file(bll):
             factories.request_file(path=path, filetype=RequestFileType.SUPPORTING),
         ],
     )
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
     request_file = release_request.get_request_file_from_output_path(path)
 
     with pytest.raises(exceptions.RequestReviewDenied):
@@ -2036,7 +2038,7 @@ def test_approve_file(bll):
     )
     assert "group" in release_request.filegroups
 
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
     request_file = release_request.get_request_file_from_output_path(path)
 
     rfile = _get_request_file(release_request, path)
@@ -2072,9 +2074,9 @@ def test_approve_file_requires_two_plus_submitted_reviews(bll):
         status=RequestStatus.SUBMITTED,
         files=[factories.request_file(path=path)],
     )
-    checker1 = factories.create_user("checker1", [], True)
-    checker2 = factories.create_user("checker2", [], True)
-    checker3 = factories.create_user("checker3", [], True)
+    checker1 = factories.create_airlock_user("checker1", [], True)
+    checker2 = factories.create_airlock_user("checker2", [], True)
+    checker3 = factories.create_airlock_user("checker3", [], True)
 
     request_file = release_request.get_request_file_from_output_path(path)
 
@@ -2116,7 +2118,7 @@ def test_request_changes_to_file(bll):
     )
     assert "group" in release_request.filegroups
 
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
     request_file = release_request.get_request_file_from_output_path(path)
 
     rfile = _get_request_file(release_request, path)
@@ -2152,7 +2154,7 @@ def test_approve_then_request_changes_to_file(bll):
         status=RequestStatus.SUBMITTED,
         files=[factories.request_file(path=path)],
     )
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
     request_file = release_request.get_request_file_from_output_path(path)
 
     rfile = _get_request_file(release_request, path)
@@ -2191,7 +2193,7 @@ def test_review_then_reset_review_file(bll, review):
         status=RequestStatus.SUBMITTED,
         files=[factories.request_file(path=path)],
     )
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
     request_file = release_request.get_request_file_from_output_path(path)
 
     rfile = _get_request_file(release_request, path)
@@ -2232,7 +2234,7 @@ def test_reset_review_file_no_reviews(bll):
         status=RequestStatus.SUBMITTED,
         files=[factories.request_file(path=path)],
     )
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
 
     rfile = _get_request_file(release_request, path)
     assert rfile.get_file_vote_for_user(checker) is None
@@ -2259,7 +2261,7 @@ def test_reset_review_file_after_review_submitted(bll):
         status=RequestStatus.SUBMITTED,
         files=[factories.request_file(path=path)],
     )
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
 
     rfile = _get_request_file(release_request, path)
     assert rfile.get_file_vote_for_user(checker) is None
@@ -2303,7 +2305,7 @@ def test_request_file_status_decision(bll, votes, decision):
     )
 
     for i, vote in enumerate(votes):
-        checker = factories.create_user(f"checker{i}", [], True)
+        checker = factories.create_airlock_user(f"checker{i}", [], True)
         request_file = release_request.get_request_file_from_output_path(path)
 
         if vote == "APPROVED":
@@ -2344,7 +2346,7 @@ def test_mark_file_undecided(bll):
     )
 
     # first default output-checker
-    checker = factories.create_user("output-checker-0")
+    checker = factories.create_airlock_user("output-checker-0")
 
     # mark file review as undecided
     review = release_request.get_request_file_from_output_path("file.txt").reviews[
@@ -2400,7 +2402,7 @@ def test_mark_file_undecided_permission_errors(
 
 
 def test_review_request(bll):
-    checker = factories.create_user("checker", output_checker=True)
+    checker = factories.create_airlock_user("checker", output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.SUBMITTED,
@@ -2438,7 +2440,7 @@ def test_review_request(bll):
 
 
 def test_submit_request_no_output_files(bll):
-    checker = factories.create_user("checker", output_checker=True)
+    checker = factories.create_airlock_user("checker", output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.PENDING,
@@ -2457,7 +2459,7 @@ def test_submit_request_no_output_files(bll):
 
 
 def test_review_request_non_submitted_status(bll):
-    checker = factories.create_user(output_checker=True)
+    checker = factories.create_airlock_user(output_checker=True)
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.WITHDRAWN,
@@ -2465,7 +2467,7 @@ def test_review_request_non_submitted_status(bll):
         files=[
             factories.request_file(
                 path="test.txt",
-                checkers=[checker, factories.create_user(output_checker=True)],
+                checkers=[checker, factories.create_airlock_user(output_checker=True)],
                 approved=True,
             ),
         ],
@@ -2478,7 +2480,7 @@ def test_review_request_non_submitted_status(bll):
 
 
 def test_review_request_non_output_checker(bll):
-    user = factories.create_user("non-output-checker")
+    user = factories.create_airlock_user("non-output-checker")
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.SUBMITTED,
@@ -2494,7 +2496,9 @@ def test_review_request_non_output_checker(bll):
 
 
 def test_review_request_more_than_2_checkers(bll):
-    checkers = [factories.create_user(f"checker_{i}", [], True) for i in range(3)]
+    checkers = [
+        factories.create_airlock_user(f"checker_{i}", [], True) for i in range(3)
+    ]
     release_request = factories.create_request_at_status(
         "workspace",
         status=RequestStatus.SUBMITTED,
@@ -2521,10 +2525,10 @@ def test_review_request_race_condition(bll):
     In a potential race condition, a
     """
     checkers = [
-        factories.create_user("checker", output_checker=True),
-        factories.create_user("checker1", output_checker=True),
-        factories.create_user("checker2", output_checker=True),
-        factories.create_user("checker3", output_checker=True),
+        factories.create_airlock_user("checker", output_checker=True),
+        factories.create_airlock_user("checker1", output_checker=True),
+        factories.create_airlock_user("checker2", output_checker=True),
+        factories.create_airlock_user("checker3", output_checker=True),
     ]
     release_request = factories.create_request_at_status(
         "workspace",
@@ -2615,7 +2619,7 @@ def test_dal_methods_have_audit_event_parameter():
 
 
 def test_group_edit_author(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(
         release_request,
@@ -2650,7 +2654,7 @@ def test_notifications_org_repo(
 ):
     settings.AIRLOCK_OUTPUT_CHECKING_ORG = org
     settings.AIRLOCK_OUTPUT_CHECKING_REPO = repo
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -2676,8 +2680,8 @@ def test_notifications_org_repo(
 
 
 def test_group_edit_not_author(bll):
-    author = factories.create_user("author", ["workspace"], False)
-    other = factories.create_user("other", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["workspace"], False)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -2701,7 +2705,7 @@ def test_group_edit_not_author(bll):
     ],
 )
 def test_group_edit_not_editable_by_author(bll, status, mock_old_api):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -2715,7 +2719,7 @@ def test_group_edit_not_editable_by_author(bll, status, mock_old_api):
 
 
 def test_group_edit_bad_group(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -2739,8 +2743,8 @@ def test_group_edit_bad_group(bll):
 def test_group_comment_create_success(
     bll, mock_notifications, status, notification_count
 ):
-    author = factories.create_user("author", ["workspace"], False)
-    checker = factories.create_user("checker", ["workspace"], True)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    checker = factories.create_airlock_user("checker", ["workspace"], True)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -2805,11 +2809,11 @@ def test_group_comment_create_success(
 
 
 def test_group_comment_create_permissions_pending_request(bll):
-    author = factories.create_user("author", ["workspace"], False)
-    collaborator = factories.create_user("collaborator", ["workspace"], False)
-    other = factories.create_user("other", ["other"], False)
-    checker = factories.create_user("checker", ["other"], True)
-    collaborator_checker = factories.create_user(
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    collaborator = factories.create_airlock_user("collaborator", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["other"], False)
+    checker = factories.create_airlock_user("checker", ["other"], True)
+    collaborator_checker = factories.create_airlock_user(
         "collaborator_checker", ["workspace"], True
     )
 
@@ -2868,8 +2872,8 @@ def test_group_comment_create_permissions_pending_request(bll):
 
 
 def test_group_comment_delete_success(bll):
-    author = factories.create_user("author", ["workspace"], False)
-    other = factories.create_user("other", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["workspace"], False)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -2925,8 +2929,8 @@ def test_group_comment_delete_success(bll):
 
 
 def test_group_comment_visibility_public_success(bll):
-    author = factories.create_user("author", ["workspace"], False)
-    output_checker = factories.create_user("checker", [], True)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    output_checker = factories.create_airlock_user("checker", [], True)
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -2990,9 +2994,9 @@ def test_group_comment_visibility_public_success(bll):
 
 
 def test_group_comment_visibility_public_bad_user(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     # checker who does not have access to workspace
-    checker = factories.create_user("checker1", [], True)
+    checker = factories.create_airlock_user("checker1", [], True)
 
     release_request = factories.create_request_at_status(
         "workspace",
@@ -3012,9 +3016,9 @@ def test_group_comment_visibility_public_bad_user(bll):
 
 
 def test_group_comment_visibility_public_bad_round(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     # checker who does not have access to workspace
-    checker = factories.create_user("checker1", [], True)
+    checker = factories.create_airlock_user("checker1", [], True)
 
     release_request = factories.create_request_at_status(
         "workspace",
@@ -3056,9 +3060,9 @@ def test_group_comment_visibility_public_bad_round(bll):
 def test_group_comment_visibility_public_permissions(
     bll, mock_old_api, status, checker_can_change_visibility
 ):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     # checker who does not have access to workspace
-    checker = factories.create_user("checker1", [], True)
+    checker = factories.create_airlock_user("checker1", [], True)
 
     release_request = factories.create_request_at_status(
         "workspace",
@@ -3111,11 +3115,11 @@ def test_group_comment_visibility_public_permissions(
 def test_group_comment_delete_permissions(
     bll, mock_old_api, status, author_can_delete, checker_can_delete
 ):
-    author = factories.create_user("author", ["workspace"], False)
-    collaborator = factories.create_user("collaborator", ["workspace"], False)
-    other = factories.create_user("other", ["other"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
+    collaborator = factories.create_airlock_user("collaborator", ["workspace"], False)
+    other = factories.create_airlock_user("other", ["other"], False)
     # checker who does not have access to workspace
-    checker = factories.create_user("checker", [], True)
+    checker = factories.create_airlock_user("checker", [], True)
 
     # users can never delete someone else's comment
     not_permitted_to_delete_author = [collaborator, other, checker]
@@ -3172,7 +3176,7 @@ def test_group_comment_delete_permissions(
 
 
 def test_group_comment_delete_invalid_params(bll):
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
 
     release_request = factories.create_request_at_status(
         "workspace",

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -132,7 +132,9 @@ def test_get_workspace_tree_general(release_request):
 @pytest.mark.django_db
 def test_get_request_tree_general(release_request):
     selected_path = UrlPath("group1/some_dir/file_a.txt")
-    tree = get_request_tree(release_request, factories.create_user(), selected_path)
+    tree = get_request_tree(
+        release_request, factories.create_airlock_user(), selected_path
+    )
 
     # simple way to express the entire tree structure, including selected
     expected = textwrap.dedent(
@@ -167,11 +169,11 @@ def test_get_request_tree_general(release_request):
 
 
 def test_get_request_tree_status(bll):
-    author = factories.create_user(
+    author = factories.create_airlock_user(
         "author", output_checker=True, workspaces=["workspace"]
     )
-    checker1 = factories.create_user("checker1", [], True)
-    checker2 = factories.create_user("checker2", [], True)
+    checker1 = factories.create_airlock_user("checker1", [], True)
+    checker2 = factories.create_airlock_user("checker2", [], True)
 
     path = UrlPath("some_dir/file_a.txt")
     release_request = factories.create_request_at_status(
@@ -315,7 +317,10 @@ def test_get_workspace_tree_selected_is_empty_dir(workspace):
 def test_get_request_tree_selected_only_file(release_request):
     selected_path = UrlPath("group1/some_dir/file_a.txt")
     tree = get_request_tree(
-        release_request, factories.create_user(), selected_path, selected_only=True
+        release_request,
+        factories.create_airlock_user(),
+        selected_path,
+        selected_only=True,
     )
 
     # only the selected path should be in the tree, and all groups
@@ -337,7 +342,10 @@ def test_get_request_tree_selected_only_file(release_request):
 def test_get_request_tree_selected_only_group(release_request):
     selected_path = UrlPath("group1")
     tree = get_request_tree(
-        release_request, factories.create_user(), selected_path, selected_only=True
+        release_request,
+        factories.create_airlock_user(),
+        selected_path,
+        selected_only=True,
     )
 
     # only the selected path should be in the tree, and all groups
@@ -387,7 +395,7 @@ def test_workspace_tree_get_path(workspace, path, exists):
 )
 @pytest.mark.django_db
 def test_request_tree_get_path(release_request, path, exists):
-    tree = get_request_tree(release_request, factories.create_user())
+    tree = get_request_tree(release_request, factories.create_airlock_user())
 
     if exists:
         tree.get_path(path)
@@ -427,13 +435,13 @@ def test_workspace_tree_content_urls(workspace):
 )
 @pytest.mark.django_db
 def test_request_tree_urls(release_request, path, url):
-    tree = get_request_tree(release_request, factories.create_user())
+    tree = get_request_tree(release_request, factories.create_airlock_user())
     assert tree.get_path(path).url().endswith(url)
 
 
 @pytest.mark.django_db
 def test_request_tree_download_url(release_request):
-    tree = get_request_tree(release_request, factories.create_user())
+    tree = get_request_tree(release_request, factories.create_airlock_user())
     assert (
         tree.get_path("group1/some_dir/file_a.txt")
         .download_url()
@@ -456,7 +464,7 @@ def test_workspace_tree_breadcrumbs(workspace):
 
 @pytest.mark.django_db
 def test_request_tree_breadcrumbs(release_request):
-    tree = get_request_tree(release_request, factories.create_user())
+    tree = get_request_tree(release_request, factories.create_airlock_user())
     path = tree.get_path("group1/some_dir/file_a.txt")
     assert [c.name() for c in path.breadcrumbs()] == [
         release_request.id,
@@ -508,14 +516,16 @@ def test_workspace_tree_selection_bad_path(workspace):
 @pytest.mark.django_db
 def test_request_tree_selection_root(release_request):
     # selected root by default
-    tree = get_request_tree(release_request, factories.create_user())
+    tree = get_request_tree(release_request, factories.create_airlock_user())
     assert tree.get_selected() == tree
 
 
 @pytest.mark.django_db
 def test_request_tree_selection_path(release_request):
     selected_path = UrlPath("group1/some_dir/file_a.txt")
-    tree = get_request_tree(release_request, factories.create_user(), selected_path)
+    tree = get_request_tree(
+        release_request, factories.create_airlock_user(), selected_path
+    )
 
     selected_item = tree.get_path(selected_path)
     assert selected_item.selected
@@ -533,7 +543,9 @@ def test_request_tree_selection_path(release_request):
 @pytest.mark.django_db
 def test_request_tree_selection_not_path(release_request):
     selected_path = UrlPath("bad/path")
-    tree = get_request_tree(release_request, factories.create_user(), selected_path)
+    tree = get_request_tree(
+        release_request, factories.create_airlock_user(), selected_path
+    )
     with pytest.raises(tree.PathNotFound):
         tree.get_selected()
 
@@ -558,7 +570,7 @@ def test_workspace_tree_siblings(workspace):
 
 @pytest.mark.django_db
 def test_request_tree_siblings(release_request):
-    tree = get_request_tree(release_request, factories.create_user())
+    tree = get_request_tree(release_request, factories.create_airlock_user())
 
     assert tree.siblings() == []
     assert {s.name() for s in tree.get_path("group1").siblings()} == {
@@ -581,7 +593,7 @@ def test_get_workspace_tree_tracing(workspace):
 
 @pytest.mark.django_db
 def test_get_request_tree_tracing(release_request):
-    get_request_tree(release_request, factories.create_user())
+    get_request_tree(release_request, factories.create_airlock_user())
     traces = get_trace()
     assert len(traces) == 1
     trace = traces[0]

--- a/tests/unit/test_login_api.py
+++ b/tests/unit/test_login_api.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from airlock import login_api
+from tests import factories
 
 
 def test_get_user_data_with_dev_users(settings, tmp_path):
@@ -14,20 +15,14 @@ def test_get_user_data_with_dev_users(settings, tmp_path):
             {
                 "test_user": {
                     "token": "foo bar baz",
-                    "details": {
-                        "output_checker": True,
-                        "workspaces": {
-                            "test1": {
-                                "project_details": {
-                                    "name": "project1",
-                                    "ongoing": True,
-                                },
-                                "archived": False,
-                            },
+                    "details": factories.create_api_user(
+                        output_checker=True,
+                        workspaces={
+                            "test1": factories.create_api_workspace(project="project1")
                         },
-                    },
+                    ),
                 },
-            }
+            },
         )
     )
 
@@ -50,14 +45,7 @@ def test_get_user_data_with_dev_users_invalid(settings, tmp_path):
         json.dumps(
             {
                 "test_user": {"token": "foo bar baz"},
-                "details": {
-                    "workspaces": {
-                        "test1": {
-                            "project_details": {"name": "project1", "ongoing": True},
-                            "archived": False,
-                        },
-                    }
-                },
+                "details": factories.create_api_user(),
             }
         )
     )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -89,7 +89,7 @@ def test_workspace_manifest_for_file_not_found(bll):
     manifest_path.write_text(json.dumps(manifest_data))
 
     workspace = bll.get_workspace(
-        "workspace", factories.create_user(workspaces=["workspace"])
+        "workspace", factories.create_airlock_user(workspaces=["workspace"])
     )
     with pytest.raises(exceptions.ManifestFileError):
         workspace.get_manifest_for_file(UrlPath("foo/bar.txt"))
@@ -138,24 +138,19 @@ def test_workspace_get_workspace_archived_ongoing(bll):
     factories.create_workspace("normal_workspace")
     factories.create_workspace("archived_workspace")
     factories.create_workspace("not_ongoing")
-    user = factories.create_user_from_dict(
+    user = factories.create_airlock_user(
         "user",
         workspaces={
-            "normal_workspace": {
-                "project_details": {"name": "project-1", "ongoing": True},
-                "archived": False,
-            },
-            "archived_workspace": {
-                "project_details": {"name": "project-1", "ongoing": True},
-                "archived": True,
-            },
-            "not_ongoing": {
-                "project_details": {"name": "project-2", "ongoing": False},
-                "archived": False,
-            },
+            "normal_workspace": factories.create_api_workspace(project="project-1"),
+            "archived_workspace": factories.create_api_workspace(
+                project="project-1", archived=True
+            ),
+            "not_ongoing": factories.create_api_workspace(
+                project="project-2", ongoing=False
+            ),
         },
     )
-    checker = factories.create_user("checker", output_checker=True)
+    checker = factories.create_airlock_user("checker", output_checker=True)
 
     active_workspace = bll.get_workspace("normal_workspace", user)
     archived_workspace = bll.get_workspace("archived_workspace", user)
@@ -189,7 +184,7 @@ def test_workspace_get_workspace_archived_ongoing(bll):
 def test_workspace_get_workspace_file_status(bll):
     path = UrlPath("foo/bar.txt")
     workspace = factories.create_workspace("workspace")
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
 
     with pytest.raises(exceptions.FileNotFound):
         workspace.get_workspace_file_status(path)
@@ -233,7 +228,7 @@ def test_workspace_get_released_files(bll, mock_old_api):
             ),
         ],
     )
-    user = factories.create_user("test", workspaces=["workspace"])
+    user = factories.create_airlock_user("test", workspaces=["workspace"])
     workspace = bll.get_workspace("workspace", user)
     # supporting file is not considered a released file
     assert len(workspace.released_files) == 1
@@ -242,7 +237,7 @@ def test_workspace_get_released_files(bll, mock_old_api):
 
 
 def test_request_returned_get_workspace_file_status(bll):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     path = "file1.txt"
     workspace_file = factories.request_file(
         group="group",
@@ -264,7 +259,7 @@ def test_request_returned_get_workspace_file_status(bll):
 
 
 def test_request_pending_not_author_get_workspace_file_status(bll):
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     path = "file1.txt"
     workspace_file = factories.request_file(
         group="group",
@@ -287,7 +282,7 @@ def test_request_pending_not_author_get_workspace_file_status(bll):
 def test_request_pending_author_get_workspace_file_status(bll):
     status = RequestStatus.PENDING
 
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     workspace = factories.create_workspace("workspace")
     path = UrlPath("path/file.txt")
 
@@ -316,7 +311,7 @@ def test_request_pending_author_get_workspace_file_status(bll):
 def test_request_returned_author_get_workspace_file_status(bll):
     status = RequestStatus.RETURNED
 
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     workspace = factories.create_workspace("workspace")
     path = UrlPath("path/file.txt")
 
@@ -367,7 +362,7 @@ def test_request_container():
 def test_request_file_manifest_data(mock_notifications, bll):
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, "bar.txt")
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     release_request = factories.create_release_request(workspace, user=user)
 
     # modify the manifest data to known values for asserts
@@ -398,7 +393,7 @@ def test_request_file_manifest_data(mock_notifications, bll):
 def test_request_file_manifest_data_content_hash_mismatch(mock_notifications, bll):
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, "bar.txt")
-    user = factories.create_user(workspaces=["workspace"])
+    user = factories.create_airlock_user(workspaces=["workspace"])
     release_request = factories.create_release_request(workspace, user=user)
 
     # modify the manifest data to known values for asserts
@@ -534,7 +529,7 @@ def test_request_status_ownership(bll):
 
 
 def test_request_all_files_by_name(bll):
-    author = factories.create_user(username="author", workspaces=["workspace"])
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     path = UrlPath("path/file.txt")
     supporting_path = UrlPath("path/supporting_file.txt")
 
@@ -632,7 +627,7 @@ def test_request_release_request_filetype(bll):
 
 
 def setup_empty_release_request():
-    author = factories.create_user("author", ["workspace"], False)
+    author = factories.create_airlock_user("author", ["workspace"], False)
     path = UrlPath("path/file.txt")
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, path)
@@ -644,7 +639,7 @@ def setup_empty_release_request():
 
 
 def test_get_visible_comments_for_group_class(bll):
-    author = factories.create_user("author", workspaces=["workspace"])
+    author = factories.create_airlock_user("author", workspaces=["workspace"])
     checkers = factories.get_default_output_checkers()
 
     release_request = factories.create_request_at_status(

--- a/tests/unit/test_nav.py
+++ b/tests/unit/test_nav.py
@@ -32,7 +32,7 @@ def test_iter_nav(rf):
 
 
 def test_iter_nav_output_checker(rf):
-    factories.create_user("user", ["test"], output_checker=True)
+    factories.create_airlock_user("user", ["test"], output_checker=True)
     items = [
         nav.NavItem("Reviews", "requests_for_output_checker"),
     ]

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -15,7 +15,9 @@ from tests import factories
     ],
 )
 def test_user_can_view_workspace(output_checker, workspaces, can_view):
-    user = factories.create_user("test", workspaces, output_checker=output_checker)
+    user = factories.create_airlock_user(
+        "test", workspaces, output_checker=output_checker
+    )
     assert permissions.user_can_view_workspace(user, "test") == can_view
 
     if not can_view:
@@ -37,7 +39,9 @@ def test_user_can_view_workspace_no_user():
     ],
 )
 def test_user_has_role_on_workspace(output_checker, workspaces, has_role):
-    user = factories.create_user("test", workspaces, output_checker=output_checker)
+    user = factories.create_airlock_user(
+        "test", workspaces, output_checker=output_checker
+    )
     assert permissions.user_has_role_on_workspace(user, "test") == has_role
 
     if not has_role:
@@ -46,10 +50,9 @@ def test_user_has_role_on_workspace(output_checker, workspaces, has_role):
 
 
 def _details(archived=False, ongoing=True):
-    return {
-        "project_details": {"name": "Project", "ongoing": ongoing},
-        "archived": archived,
-    }
+    return factories.create_api_workspace(
+        project="Project", archived=archived, ongoing=ongoing
+    )
 
 
 @pytest.mark.parametrize(
@@ -97,7 +100,7 @@ def _details(archived=False, ongoing=True):
 def test_session_user_can_action_request(
     output_checker, workspaces, can_action_request, expected_reason
 ):
-    user = factories.create_user_from_dict(
+    user = factories.create_airlock_user(
         "test", workspaces, output_checker=output_checker
     )
     assert (
@@ -121,10 +124,12 @@ def test_session_user_can_action_request(
     ],
 )
 def test_user_can_review_request(output_checker, author, workspaces, can_review):
-    user = factories.create_user("user", workspaces, output_checker=output_checker)
+    user = factories.create_airlock_user(
+        "user", workspaces, output_checker=output_checker
+    )
     users = {
         "user": user,
-        "other": factories.create_user("other", ["test"], output_checker=False),
+        "other": factories.create_airlock_user("other", ["test"], output_checker=False),
     }
     release_request = factories.create_request_at_status(
         "test",

--- a/tests/unit/test_user.py
+++ b/tests/unit/test_user.py
@@ -1,38 +1,36 @@
 from typing import Any
 
 from airlock.users import User
+from tests import factories
 
 
 def test_session_user_from_session():
     mock_session = {
-        "user": {
-            "id": 1,
-            "username": "test",
-            "workspaces": {
-                "test-workspace-1": {
-                    "project_details": {"name": "Project 1", "ongoing": True},
-                    "archived": False,
-                },
-                "test_workspace2": {
-                    "project_details": {"name": "Project 2", "ongoing": True},
-                    "archived": True,
-                },
+        "user": factories.create_api_user(
+            username="test",
+            workspaces={
+                "workspace1": factories.create_api_workspace(
+                    project="Project 1", archived=False
+                ),
+                "workspace2": factories.create_api_workspace(
+                    project="Project 2", archived=True
+                ),
             },
-            "output_checker": True,
-        }
+            output_checker=True,
+        )
     }
     user = User.from_session(mock_session)
-    assert set(user.workspaces) == {"test-workspace-1", "test_workspace2"}
-    assert user.workspaces["test-workspace-1"]["project_details"] == {
+    assert set(user.workspaces) == {"workspace1", "workspace2"}
+    assert user.workspaces["workspace1"]["project_details"] == {
         "name": "Project 1",
         "ongoing": True,
     }
-    assert user.workspaces["test_workspace2"]["project_details"] == {
+    assert user.workspaces["workspace2"]["project_details"] == {
         "name": "Project 2",
         "ongoing": True,
     }
-    assert user.workspaces["test-workspace-1"]["archived"] is False
-    assert user.workspaces["test_workspace2"]["archived"] is True
+    assert user.workspaces["workspace1"]["archived"] is False
+    assert user.workspaces["workspace2"]["archived"] is True
     assert user.output_checker
 
 


### PR DESCRIPTION
Refactor test factories for creating users.

This PR has been extracted from work to use a db User class. It tries to draw a clearer distinction between test users in API json format, and test airlock users, which look almost the same atm, but are going to change shortly.

It also enables the linter to find typos, and will make it easier to change the API user format in future if needed.

