### PR TITLE
Fix bug where datatable was loading twice in some situations

### DIFF
--- a/assets/src/scripts/datatable.js
+++ b/assets/src/scripts/datatable.js
@@ -10,7 +10,12 @@ function hasOnlyDigits(value) {
 
 function buildTables() {
   /** @type {NodeListOf<HTMLTableElement> | null} */
-  const datatableEls = document.querySelectorAll("[data-datatable]");
+  // In some situations the buildTables is called twice. There may be better
+  // ways of doing this, but by restricting the selector to just html tables
+  // that have not already been DataTable-ified we solve the issue. This works
+  // because tables that need to be processed contain the attribute "data-datatable"
+  // and those that already have, contain the .datatable-table css class.
+  const datatableEls = document.querySelectorAll("[data-datatable]:not(.datatable-table)");
 
   datatableEls?.forEach((table) => {
     const columnFilter = table.hasAttribute("data-column-filter");


### PR DESCRIPTION
In some situations the `buildTables()` method that wires up the `DataTables` was being called twice. In most situations it just causes a console error. But with some combinations of page refresh and using the back button it caused the table to not display. This fixes it by excluding any tables that have already been wired up.