### PR TITLE
Update the uploaded files count on the request page

### DIFF
--- a/airlock/models.py
+++ b/airlock/models.py
@@ -846,6 +846,9 @@ class ReleaseRequest:
             return 0
         return sum(1 for rfile in self.output_files().values() if rfile.uploaded)
 
+    def uploaded_files_count_url(self):
+        return reverse("uploaded_files_count", args=(self.id,))
+
     def supporting_files_count(self):
         return sum(
             1

--- a/airlock/templates/file_browser/_includes/uploaded_files_count.html
+++ b/airlock/templates/file_browser/_includes/uploaded_files_count.html
@@ -1,0 +1,10 @@
+<div class="flex flex-row flex-wrap gap-6" id="uploaded-files-count">
+    {{ release_request.uploaded_files_count }}
+    {% if release_request.status.value == "RELEASED" %}
+      {% icon_check_circle_solid class="h-5 w-5 text-green-700" %}
+    {% elif upload_in_progress %}
+      {% icon_custom_spinner class="h-5 w-5 text-bn-egg-500 animate-spin stroke-current stroke-2" %}
+    {% elif release_request.can_be_rereleased %}
+      {% icon_exclamation_triangle_solid class="h-5 w-5 text-red-800" %}
+    {% endif %}
+</div>

--- a/airlock/templates/file_browser/_includes/uploaded_files_count.html
+++ b/airlock/templates/file_browser/_includes/uploaded_files_count.html
@@ -1,4 +1,11 @@
-<div class="flex flex-row flex-wrap gap-6" id="uploaded-files-count">
+<div
+  {% if upload_in_progress %}
+    hx-get={{ release_request.uploaded_files_count_url }}
+    hx-trigger="load delay:1s"
+    hx-swap="outerHTML"
+  {% endif %}
+>
+  <div class="flex flex-row flex-wrap gap-6" id="uploaded-files-count">
     {{ release_request.uploaded_files_count }}
     {% if release_request.status.value == "RELEASED" %}
       {% icon_check_circle_solid class="h-5 w-5 text-green-700" %}
@@ -7,4 +14,5 @@
     {% elif release_request.can_be_rereleased %}
       {% icon_exclamation_triangle_solid class="h-5 w-5 text-red-800" %}
     {% endif %}
+  </div>
 </div>

--- a/airlock/templates/file_browser/request/request.html
+++ b/airlock/templates/file_browser/request/request.html
@@ -156,16 +156,9 @@
       {{ release_request.supporting_files_count }}
     {% /description_item %}
     {% #description_item title="Files released and uploaded" %}
-      <div class="flex flex-row flex-wrap gap-6" id="uploaded-files-count">
-        {{ release_request.uploaded_files_count }}
-        {% if release_request.status.value == "RELEASED" %}
-          {% icon_check_circle_solid class="h-5 w-5 text-green-700" %}
-        {% elif release_request.upload_in_progress %}
-          {% icon_custom_spinner class="h-5 w-5 text-bn-egg-500 animate-spin stroke-current stroke-2" %}
-        {% elif release_request.can_be_rereleased %}
-          {% icon_exclamation_triangle_solid class="h-5 w-5 text-red-800" %}
-        {% endif %}
-      </div>
+
+      {% include "file_browser/_includes/uploaded_files_count.html" %}
+
     {% /description_item %}
   {% /description_list %}
 {% /card %}

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -179,6 +179,11 @@ urlpatterns = [
         name="group_comment_visibility_public",
     ),
     path(
+        "requests/<str:request_id>/uploaded-files-count",
+        airlock.views.uploaded_files_count,
+        name="uploaded_files_count",
+    ),
+    path(
         "code/view/<str:workspace_name>/<str:commit>/",
         airlock.views.code.view,
         name="code_view",

--- a/airlock/views/__init__.py
+++ b/airlock/views/__init__.py
@@ -21,6 +21,7 @@ from .request import (
     requests_for_output_checker,
     requests_for_researcher,
     requests_for_workspace,
+    uploaded_files_count,
 )
 from .workspace import (
     workspace_add_file_to_request,
@@ -56,6 +57,7 @@ __all__ = [
     "group_comment_create",
     "group_comment_delete",
     "group_comment_visibility_public",
+    "uploaded_files_count",
     "workspace_add_file_to_request",
     "workspace_multiselect",
     "workspace_contents",

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -386,6 +386,7 @@ def request_view(request, request_id: str, path: str = ""):
         "code_url": code_url,
         "include_code": code_url is not None,
         "include_download": not is_author,
+        "upload_in_progress": release_request.upload_in_progress(),
     }
 
     return TemplateResponse(request, template, context)

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -876,3 +876,25 @@ def group_comment_visibility_public(request, request_id, group):
                 messages.error(request, f"{field}: {error}")
 
     return redirect(release_request.get_url(group))
+
+
+def uploaded_files_count(request, request_id):
+    """
+    This view is called with htmx when a request is in the process of
+    uploading files, so we can update the file count displayed on the request
+    overview page.
+    """
+    release_request = get_release_request_or_raise(request.user, request_id)
+    if release_request.upload_in_progress():
+        return TemplateResponse(
+            request,
+            "file_browser/_includes/uploaded_files_count.html",
+            {"release_request": release_request, "upload_in_progress": True},
+        )
+    # If the request is no longer uploading, we just reload the whole page. It
+    # will either be released now, or the uploads have all been attempted and
+    # at least one has failed. In either case, we'll need need to update various
+    # other elements on the page (the request status, the release
+    # files button). We could do this with hx-swap-oob for the various different
+    # elements, but it's simpler just to reload.
+    return HttpResponse(headers={"HX-Redirect": release_request.get_url()})

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -698,3 +698,89 @@ def test_request_uploaded_files_status(
             expect(release_files_button).to_be_enabled()
         else:
             expect(release_files_button).not_to_be_enabled()
+
+
+def test_request_uploaded_files_counts(
+    live_server,
+    context,
+    page,
+    bll,
+    mock_old_api,
+    mock_notifications,
+):
+    # make a release request in APPROVED status
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.APPROVED,
+        files=[
+            factories.request_file(
+                group="group", contents="1", path="file1.txt", approved=True
+            ),
+            factories.request_file(
+                group="group", contents="2", path="file2.txt", approved=True
+            ),
+            factories.request_file(
+                group="group", contents="3", path="file3.txt", approved=True
+            ),
+        ],
+    )
+    output_checker = login_as_user(
+        live_server,
+        context,
+        user_dict={
+            "username": "output_checker",
+            "workspaces": {},
+            "output_checker": True,
+        },
+    )
+
+    page.goto(live_server.url + release_request.get_url())
+
+    release_files_button = page.locator("#release-files-button")
+    uploaded_files_count_el = page.locator("#uploaded-files-count")
+    uploaded_files_count_parent_el = uploaded_files_count_el.locator("..")
+
+    def assert_still_uploading(uploaded_count):
+        expect(uploaded_files_count_el).to_contain_text(str(uploaded_count))
+        expect(uploaded_files_count_parent_el).to_have_attribute(
+            "hx-get", release_request.uploaded_files_count_url()
+        )
+        expect(release_files_button).to_be_disabled()
+
+    assert_still_uploading(0)
+
+    # update the uploaded file count in the background, without reloading the page
+    bll.register_file_upload(release_request, UrlPath("file1.txt"), output_checker)
+    assert_still_uploading(1)
+
+    bll.register_file_upload(release_request, UrlPath("file2.txt"), output_checker)
+    assert_still_uploading(2)
+
+    # make the last file failed
+    for _ in range(settings.UPLOAD_MAX_ATTEMPTS):
+        bll.register_file_upload_attempt(release_request, UrlPath("file3.txt"))
+    # still shows 2 files; page has refreshed and no htmx attributes on the
+    # parent element anymore, so it doesn't continue to poll, and the release files
+    # button is enabled
+    expect(uploaded_files_count_el).to_contain_text("2")
+    expect(uploaded_files_count_parent_el).not_to_have_attribute(
+        "hx-get", release_request.uploaded_files_count_url()
+    )
+    expect(release_files_button).to_be_enabled()
+
+    # click the button to re-release
+    release_files_button.click()
+    assert_still_uploading(2)
+
+    # complete the upload and release
+    bll.register_file_upload(release_request, UrlPath("file3.txt"), output_checker)
+    bll.set_status(release_request, RequestStatus.RELEASED, output_checker)
+
+    # 3 files uploaded; request is no longer uploading so page has refreshed and no
+    # htmx attributes on the parent element anymore
+    # the release files button is not visible because the release is now complete
+    expect(uploaded_files_count_el).to_contain_text("3")
+    expect(uploaded_files_count_parent_el).not_to_have_attribute(
+        "hx-get", release_request.uploaded_files_count_url()
+    )
+    expect(release_files_button).not_to_be_visible()


### PR DESCRIPTION
When a request is approved and has files uploading in the background, we want to be able to keep the user updated as the files upload.  This adds a view that renders just the uploaded file count snippet, and uses htmx to poll it for updates.  If the request isn't in an upload-in-progress state, we don't include the htmx attributes, so we don't poll when nothing will change.

If the request moves out of uploading state (either because it complete, or because it fails and won't re-try anything automatically anymore), we reload the page so we update other relevant elements as well (request status, release button etc).

Note that the audit log on the overview page should technically be also updated along with the file count, but I think it's probably acceptable that it does update until the page is reloaded. If users are staying on the page to wait for the uploads to complete, they probably aren't looking at the audit log until the request either completes or fails, and then it'll be reloaded and updated anyway.