### PR TITLE
Refactor login api and separate last_refresh from user data

### DIFF
--- a/airlock/middleware.py
+++ b/airlock/middleware.py
@@ -1,7 +1,6 @@
 import time
 from urllib.parse import urlencode
 
-import requests
 from django.conf import settings
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -25,7 +24,7 @@ class UserMiddleware:
             if time_since_authz > settings.AIRLOCK_AUTHZ_TIMEOUT:
                 try:
                     details = login_api.get_user_authz(user.username)
-                except requests.HTTPError:
+                except login_api.LoginError:
                     # TODO: log this, but we should have telemetry for the requests call anyway
                     pass
                 else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,27 @@ def mock_notifications(notifications_stubber):
 
 
 @pytest.fixture
+def auth_api_stubber(responses, settings):
+    settings.AIRLOCK_API_TOKEN = "token"
+
+    def stub_api_path(
+        action="authenticate",
+        status=200,
+        json=None,
+    ):
+        assert action in ["authenticate", "authorise"], (
+            "auth_api_stubber only supports authenticate and authorise actions"
+        )
+        responses.post(
+            f"{settings.AIRLOCK_API_ENDPOINT}/releases/{action}",
+            status=status,
+            json=json,
+        )
+
+    return stub_api_path
+
+
+@pytest.fixture
 def mock_old_api(monkeypatch):
     monkeypatch.setattr(
         old_api,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -87,14 +87,14 @@ def create_airlock_user(
     username: str = "testuser",
     workspaces: dict[str, typing.Any] | list[str] | None = None,
     output_checker: bool = False,
-    last_refresh: float = -1,
+    last_refresh: float | None = None,
 ) -> User:
     """Factory to create an Airlock User.
 
     The username, workspaces, and output_checker, are all just passed through to create_api_user.
     """
     api_user = create_api_user(username, workspaces, output_checker)
-    if last_refresh == -1:
+    if last_refresh is None:
         last_refresh = time.time()
 
     return User(

--- a/tests/functional/test_docs_screenshots.py
+++ b/tests/functional/test_docs_screenshots.py
@@ -25,11 +25,15 @@ def get_user_data():
     author_username = "researcher"
     author_workspaces = ["my-workspace"]
     user_dicts = {
-        "author": dict(
+        "author": factories.create_api_user(
             username=author_username, workspaces=author_workspaces, output_checker=False
         ),
-        "checker1": dict(username="checker1", workspaces=[], output_checker=True),
-        "checker2": dict(username="checker2", workspaces=[], output_checker=True),
+        "checker1": factories.create_api_user(
+            username="checker1", workspaces=[], output_checker=True
+        ),
+        "checker2": factories.create_api_user(
+            username="checker2", workspaces=[], output_checker=True
+        ),
     }
 
     author = factories.create_airlock_user(


### PR DESCRIPTION
This is in preparation for switching to a db user object.  Separating out last_refresh keeps things cleaner, making the user object purely a representation of the auth API data.

Includes fixture refactoring to make stubbing the auth api easier.