### PR TITLE
Fix upload bug when file content has changed

### DIFF
--- a/airlock/management/commands/run_file_uploader.py
+++ b/airlock/management/commands/run_file_uploader.py
@@ -81,6 +81,7 @@ class Command(BaseCommand):
                         attributes={
                             "release_request": approved_request.id,
                             "workspace": approved_request.workspace,
+                            "group": file_for_upload.group,
                             "file": str(file_for_upload.relpath),
                         },
                     ) as span:

--- a/airlock/management/commands/run_file_uploader.py
+++ b/airlock/management/commands/run_file_uploader.py
@@ -10,6 +10,7 @@ from opentelemetry import trace
 import old_api
 from airlock.business_logic import bll
 from airlock.enums import RequestStatus
+from airlock.types import UrlPath
 from airlock.users import User
 from services.tracing import instrument
 
@@ -61,7 +62,6 @@ class Command(BaseCommand):
                     # nothing to do
                     continue
 
-                workspace = bll.get_workspace(approved_request.workspace, system_user)
                 for file_for_upload in files_for_upload:
                     if file_for_upload.upload_attempts >= settings.UPLOAD_MAX_ATTEMPTS:
                         logger.debug(
@@ -85,15 +85,16 @@ class Command(BaseCommand):
                         },
                     ) as span:
                         try:
-                            do_upload_task(file_for_upload, approved_request, workspace)
+                            do_upload_task(file_for_upload, approved_request)
                         except Exception as error:
                             # The most likely error here is old_api.FileUploadError, however
                             # we catch any unexpected exception here so we don't stop the task runner
                             # from running
                             span.record_exception(error)
                             logger.error(
-                                "Upload for %s - %s failed (attempt %d of %d): %s",
+                                "Upload for %s - %s/%s failed (attempt %d of %d): %s",
                                 approved_request.id,
+                                file_for_upload.group,
                                 file_for_upload.relpath,
                                 file_for_upload.upload_attempts,
                                 settings.UPLOAD_MAX_ATTEMPTS,
@@ -107,7 +108,7 @@ class Command(BaseCommand):
 
 
 @instrument
-def do_upload_task(file_for_upload, release_request, workspace):
+def do_upload_task(file_for_upload, release_request):
     """
     Perform an upload task.
     """
@@ -115,7 +116,9 @@ def do_upload_task(file_for_upload, release_request, workspace):
         release_request.id,
         release_request.workspace,
         file_for_upload.relpath,
-        workspace.abspath(file_for_upload.relpath),
+        release_request.abspath(
+            UrlPath(file_for_upload.group) / file_for_upload.relpath
+        ),
         file_for_upload.released_by,
     )
     # mark the request file as uploaded and set the task completed time

--- a/tests/integration/management/commands/test_run_file_uploader.py
+++ b/tests/integration/management/commands/test_run_file_uploader.py
@@ -153,6 +153,7 @@ def test_run_file_uploader_command(upload_files_stubber, bll):
     assert last_trace.attributes == {
         "release_request": release_request.id,
         "workspace": "workspace",
+        "group": "group",
         "file": "test/file2.txt",
     }
 
@@ -268,6 +269,7 @@ def test_run_file_uploader_command_unexpected_error(upload_files_stubber, bll):
     assert last_trace.attributes == {
         "release_request": release_request.id,
         "workspace": "workspace",
+        "group": "group",
         "file": "test/file2.txt",
     }
     last_trace_event = last_trace.events[0]

--- a/tests/integration/management/commands/test_run_file_uploader.py
+++ b/tests/integration/management/commands/test_run_file_uploader.py
@@ -69,7 +69,7 @@ def test_do_upload_task(upload_files_stubber, bll, freezer):
     assert request_file.uploaded_at is None
 
     freezer.move_to("2022-01-03T12:34:56")
-    do_upload_task(request_file, release_request, workspace)
+    do_upload_task(request_file, release_request)
 
     request_file = refresh_request_file(release_request, relpath)
     assert request_file.uploaded
@@ -91,7 +91,7 @@ def test_do_upload_task_updated_file_content(upload_files_stubber, bll):
 
     request_file = release_request.get_request_file_from_output_path(relpath)
 
-    do_upload_task(request_file, release_request, workspace)
+    do_upload_task(request_file, release_request)
     # 2 calls, to create the release and then to upload one file
     assert len(upload_files_responses.calls) == 2
     upload_call = upload_files_responses.calls[-1]
@@ -111,7 +111,7 @@ def test_do_upload_task_api_error(upload_files_stubber, bll, freezer):
     request_file = release_request.get_request_file_from_output_path(relpath)
 
     with pytest.raises(FileUploadError):
-        do_upload_task(request_file, release_request, workspace)
+        do_upload_task(request_file, release_request)
 
     request_file = refresh_request_file(release_request, relpath)
     assert not request_file.uploaded

--- a/tests/integration/management/commands/test_run_file_uploader.py
+++ b/tests/integration/management/commands/test_run_file_uploader.py
@@ -45,10 +45,10 @@ def setup_release_request(upload_files_stubber, bll, response_statuses=None):
             ),
         ],
     )
-    upload_files_stubber(release_request, response_statuses)
+    upload_files_responses = upload_files_stubber(release_request, response_statuses)
     bll.release_files(release_request, factories.get_default_output_checkers()[0])
     release_request = factories.refresh_release_request(release_request)
-    return release_request, workspace
+    return release_request, workspace, upload_files_responses
 
 
 def refresh_request_file(release_request, relpath):
@@ -74,6 +74,32 @@ def test_do_upload_task(upload_files_stubber, bll, freezer):
     request_file = refresh_request_file(release_request, relpath)
     assert request_file.uploaded
     assert request_file.uploaded_at == parse_datetime("2022-01-03T12:34:56Z")
+
+
+def test_do_upload_task_updated_file_content(upload_files_stubber, bll):
+    release_request, workspace, upload_files_responses = setup_release_request(
+        upload_files_stubber, bll, response_statuses=[201]
+    )
+
+    relpath = UrlPath("test/file.txt")
+    # modify workspace file content
+    factories.write_workspace_file(release_request.workspace, relpath, contents="changed")
+    # refresh workspace
+    workspace = bll.get_workspace(
+        release_request.workspace, factories.get_default_output_checkers()[0]
+    )
+
+    request_file = release_request.get_request_file_from_output_path(relpath)
+
+    do_upload_task(request_file, release_request, workspace)
+    # 2 calls, to create the release and then to upload one file
+    assert len(upload_files_responses.calls) == 2
+    upload_call = upload_files_responses.calls[-1]
+    assert upload_call.request.url.endswith(f"/releases/release/{release_request.id}")
+
+    # The upload endpoint is called with the (old) request file content, not the
+    # updated workspace file content
+    assert upload_call.request.body == b"test"
 
 
 def test_do_upload_task_api_error(upload_files_stubber, bll, freezer):

--- a/tests/integration/management/commands/test_run_file_uploader.py
+++ b/tests/integration/management/commands/test_run_file_uploader.py
@@ -48,7 +48,7 @@ def setup_release_request(upload_files_stubber, bll, response_statuses=None):
     upload_files_responses = upload_files_stubber(release_request, response_statuses)
     bll.release_files(release_request, factories.get_default_output_checkers()[0])
     release_request = factories.refresh_release_request(release_request)
-    return release_request, workspace, upload_files_responses
+    return release_request, upload_files_responses
 
 
 def refresh_request_file(release_request, relpath):
@@ -59,7 +59,7 @@ def refresh_request_file(release_request, relpath):
 
 def test_do_upload_task(upload_files_stubber, bll, freezer):
     freezer.move_to("2022-01-01T12:34:56")
-    release_request, workspace = setup_release_request(
+    release_request, _ = setup_release_request(
         upload_files_stubber, bll, response_statuses=[201]
     )
 
@@ -77,15 +77,17 @@ def test_do_upload_task(upload_files_stubber, bll, freezer):
 
 
 def test_do_upload_task_updated_file_content(upload_files_stubber, bll):
-    release_request, workspace, upload_files_responses = setup_release_request(
+    release_request, upload_files_responses = setup_release_request(
         upload_files_stubber, bll, response_statuses=[201]
     )
 
     relpath = UrlPath("test/file.txt")
     # modify workspace file content
-    factories.write_workspace_file(release_request.workspace, relpath, contents="changed")
+    factories.write_workspace_file(
+        release_request.workspace, relpath, contents="changed"
+    )
     # refresh workspace
-    workspace = bll.get_workspace(
+    bll.get_workspace(
         release_request.workspace, factories.get_default_output_checkers()[0]
     )
 


### PR DESCRIPTION
The uploader was incorrectly uploading the workspace file content instead of the request file content. This fixes the bug and adds a test for it.