### PR TITLE
Fix a mock assert call

### DIFF
--- a/tests/integration/management/commands/test_run_file_uploader.py
+++ b/tests/integration/management/commands/test_run_file_uploader.py
@@ -164,7 +164,7 @@ def test_run_file_uploader_command(upload_files_stubber, bll):
 def test_run_file_uploader_command_no_tasks(mock_sleep):
     run_fn = Mock(side_effect=[True, False])
     call_command("run_file_uploader", run_fn=run_fn)
-    assert mock_sleep.called_with(settings.UPLOAD_DELAY)
+    mock_sleep.assert_called_with(settings.UPLOAD_DELAY)
 
 
 def test_run_file_uploader_command_all_files_uploaded(


### PR DESCRIPTION
Use Mock.assert_called_with() instead of assert Mock.called_with() The latter is ok on python 3.11 but won't work in 3.12, and the former is the correct way to assert args a mock is called with.