### PR TITLE
Separate last refresh

### DIFF
--- a/airlock/login_api.py
+++ b/airlock/login_api.py
@@ -1,5 +1,4 @@
 import json
-import time
 from pathlib import Path
 
 import requests
@@ -20,21 +19,32 @@ def get_user_data(user: str, token: str):
         return get_user_data_prod(user, token)
 
 
+def get_user_authz(user):
+    if settings.AIRLOCK_DEV_USERS_FILE and not settings.AIRLOCK_API_TOKEN:
+        # automatically valid
+        # Note: passing user and returning user.to_dict() is a temporary hack
+        # until we can just return the db user.
+        return user.to_dict()
+    else:
+        return get_user_authz_prod(user.username)
+
+
 def get_user_data_prod(username: str, token: str):
-    api_user = auth_api_call(
-        "/releases/authenticate", {"user": username, "token": token}
+    return auth_api_call(
+        "/releases/authenticate",
+        {"user": username, "token": token},
     )
-    api_user["last_refresh"] = time.time()
-    return api_user
 
 
-def get_user_authz(username):
-    api_user = auth_api_call("/releases/authorise", {"user": username})
-    api_user["last_refresh"] = time.time()
-    return api_user
+def get_user_authz_prod(username: str):
+    return auth_api_call("/releases/authorise", json={"user": username})
 
 
 def get_user_data_dev(dev_users_file: Path, user: str, token: str):
+    """Look up a user from local dev config instead of API.
+
+    Optionally validate token if passed, otherwise return that users data.
+    """
     try:
         dev_users = json.loads(dev_users_file.read_text())
     except FileNotFoundError as e:  # pragma: no cover
@@ -45,10 +55,7 @@ def get_user_data_dev(dev_users_file: Path, user: str, token: str):
     if user not in dev_users or dev_users[user]["token"] != token:
         raise LoginError("Invalid user or token")
     else:
-        details = dev_users[user]["details"]
-        # ensure that we never try refresh this user with job-server
-        details["last_refresh"] = time.time() + (365 * 24 * 60 * 60)
-        return details
+        return dev_users[user]["details"]
 
 
 def auth_api_call(path, json):

--- a/airlock/middleware.py
+++ b/airlock/middleware.py
@@ -18,10 +18,12 @@ class UserMiddleware:
     def __call__(self, request):
         """Add the session user to the request"""
         user = User.from_session(request.session)
+        span = trace.get_current_span()
 
         if user:
             time_since_authz = time.time() - user.last_refresh
             if time_since_authz > settings.AIRLOCK_AUTHZ_TIMEOUT:
+                span.set_attribute("auth_refresh", True)
                 try:
                     details = login_api.get_user_authz(user)
                     details["last_refresh"] = time.time()
@@ -33,10 +35,8 @@ class UserMiddleware:
                     user = User.from_session(request.session)
 
         request.user = user
-        span = trace.get_current_span()
         span.set_attribute("user", user.username if user else "")
-        response = self.get_response(request)
-        return response
+        return self.get_response(request)
 
     def process_view(self, request, view_func, view_args, view_kwargs):
         if getattr(view_func, "login_exempt", False):

--- a/airlock/middleware.py
+++ b/airlock/middleware.py
@@ -23,7 +23,8 @@ class UserMiddleware:
             time_since_authz = time.time() - user.last_refresh
             if time_since_authz > settings.AIRLOCK_AUTHZ_TIMEOUT:
                 try:
-                    details = login_api.get_user_authz(user.username)
+                    details = login_api.get_user_authz(user)
+                    details["last_refresh"] = time.time()
                 except login_api.LoginError:
                     # TODO: log this, but we should have telemetry for the requests call anyway
                     pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def clear_all_traces():
     test_exporter.clear()
 
 
-# mark every test iwth django_db
+# mark every test with django_db
 def pytest_collection_modifyitems(config, items):
     for item in items:
         item.add_marker(pytest.mark.django_db)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -94,6 +94,7 @@ def create_airlock_user(
     The username, workspaces, and output_checker, are all just passed through to create_api_user.
     """
     api_user = create_api_user(username, workspaces, output_checker)
+
     if last_refresh is None:
         last_refresh = time.time()
 

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -9,8 +9,6 @@ from airlock.types import UrlPath
 from tests import factories
 
 
-
-
 def find_and_click(locator):
     """
     Helper function to find a locator element and click on it.

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -9,7 +9,6 @@ from airlock.types import UrlPath
 from tests import factories
 
 
-admin_user = factories.create_airlock_user("admin", output_checker=True)
 
 
 def find_and_click(locator):
@@ -107,6 +106,8 @@ def test_e2e_release_files(
         "subdir/supporting.txt",
         "I am the supporting file content",
     )
+
+    admin_user = factories.create_airlock_user("admin", output_checker=True)
 
     # Log in as a researcher
     login_as(live_server, page, "researcher")

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -306,22 +306,22 @@ def test_workspace_view_redirects_to_file(airlock_client):
     "user,can_see_form",
     [
         (
-            factories.create_airlock_user(
+            factories.create_api_user(
                 workspaces=["workspace"], output_checker=True
             ),
             True,
         ),
         (
-            factories.create_airlock_user(
+            factories.create_api_user(
                 workspaces=["workspace"], output_checker=False
             ),
             True,
         ),
-        (factories.create_airlock_user(workspaces=[], output_checker=True), False),
+        (factories.create_api_user(workspaces=[], output_checker=True), False),
     ],
 )
 def test_workspace_view_file_add_to_request(airlock_client, user, can_see_form):
-    airlock_client.login_with_user(user)
+    airlock_client.login(**user)
     factories.write_workspace_file("workspace", "file.txt")
     response = airlock_client.get("/workspaces/view/workspace/file.txt")
     button_enabled = not response.context["content_buttons"]["add_file_button"].disabled

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -306,15 +306,11 @@ def test_workspace_view_redirects_to_file(airlock_client):
     "user,can_see_form",
     [
         (
-            factories.create_api_user(
-                workspaces=["workspace"], output_checker=True
-            ),
+            factories.create_api_user(workspaces=["workspace"], output_checker=True),
             True,
         ),
         (
-            factories.create_api_user(
-                workspaces=["workspace"], output_checker=False
-            ),
+            factories.create_api_user(workspaces=["workspace"], output_checker=False),
             True,
         ),
         (factories.create_api_user(workspaces=[], output_checker=True), False),

--- a/tests/unit/test_login_api.py
+++ b/tests/unit/test_login_api.py
@@ -34,7 +34,6 @@ def test_get_user_data_with_dev_users(settings, tmp_path):
             "archived": False,
         },
     }
-    assert "last_refresh" in dev_data
 
 
 def test_get_user_data_with_dev_users_invalid(settings, tmp_path):


### PR DESCRIPTION
This is more preparatory work for landing django.contrib.auth based users.

It fixes a series of small issues that the db work uncovered. I've have pulled them out into a bit of grab bag PR in order to keep the db PR as small as possible.

The main change is making login_api.py not responsible for managing dev users last_refresh to avoid dealing with refreshing these in the middleware. We now do refresh dev users, but they automatically succeed.

The were some extra bits of telemetry, and also some global test factory usage that won't work when the users are backed by a db, so fix those now.