### PR TITLE
Chromium for mac

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -51,15 +51,25 @@ just manage check
 ```
 
 Create a local database with:
-
 ```
 just manage migrate
+```
+
+Set up the frontend assets with:
+```
+just assets
+```
+
+Build the docs with
+```
+just docs-build
 ```
 
 You can run all the tests with:
 ```
 just test
 ```
+Note that you will need to run `just assets` and `just docs-build` on a clean checkout in order for the tests to run.
 
 To load some initial data for playing with the app locally use:
 ```

--- a/docker/justfile
+++ b/docker/justfile
@@ -29,7 +29,7 @@ build env="dev": _dotenv
 
 # Fetch and extract the chromium version we need for testing 
 get-chromium:
-    {{ just_executable() }} --justfile {{ justfile_directory() }}/../justfile get-chromium
+    PLATFORM="linux-gnu" {{ just_executable() }} --justfile {{ justfile_directory() }}/../justfile get-chromium
 
 
 # run tests in dev container

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -41,4 +41,8 @@ OTEL_EXPORTER_CONSOLE=False
 # Ensure playwright browser binaries are installed to a path in the
 # mounted volume that the non-root docker user has access to
 PLAYWRIGHT_BROWSERS_PATH=.playwright-browsers/
+# comment/uncomment as applicable
+# linux
 PLAYWRIGHT_BROWSER_EXECUTABLE_PATH=.playwright-browsers/chrome-linux/chrome
+# mac
+# PLAYWRIGHT_BROWSER_EXECUTABLE_PATH=.playwright-browsers/chrome-mac/Chromium.app/Contents/MacOS/Chromium


### PR DESCRIPTION
Add a mac version of `just get-chromium`.

Detects the OS and downloads the relevant version of chromium v108 for MacOS  or Linux, depending on the local OS.

A PLATFORM env var can be passed in to override this in `just docker/test` to use the linux version when running tests in docker on a Mac.

The executable path is different; I haven't tried to detect and set it for users, just added a warning if you're on MacOS and the `PLAYWRIGHT_BROWSER_EXECUTABLE_PATH` is set to the linux one.