### PR TITLE
File browser pointer only in places you can click

### DIFF
--- a/airlock/static/assets/file_browser/tree.css
+++ b/airlock/static/assets/file_browser/tree.css
@@ -15,7 +15,6 @@
 
 .tree__item {
   display: inline-block;
-  cursor: pointer;
 }
 
 .tree__folder {
@@ -41,6 +40,7 @@
   display: flex;
   flex-direction: row;
   padding: 0;
+  cursor: pointer;
 }
 
 .tree__folder-name::marker,


### PR DESCRIPTION
The cursor is now only a pointer in places you can click. So on folders, groups, filenames, expanders you get a finger pointer:
![image](https://github.com/user-attachments/assets/6daece45-2f8f-4a71-b2f1-195c5426f8f5)

But on the dotted lines indicating folder structure you don't
![image](https://github.com/user-attachments/assets/20f89ec6-1463-4de5-bf81-6046653ca992)

The change works by restricting the `cursor:pointer` to anything that is a `folder-name` e.g. the request, groups and folders. The files retain their pointer as they are `a` hyperlinks which get the pointer from default browser styles.
