### PR TITLE
Group no longer looks like a hyperlink

### DIFF
--- a/assets/src/styles/main.css
+++ b/assets/src/styles/main.css
@@ -3,9 +3,7 @@
 @tailwind utilities;
 
 .tree__folder-name > .filegroup {
-  @apply
-    font-semibold text-oxford-600 underline underline-offset-2 decoration-oxford-200
-  ;
+  @apply font-semibold;
 }
 
 .tree__folder-name:has(.selected.filegroup) ~ .tree__child-list {


### PR DESCRIPTION
Group now looks like this:
![image](https://github.com/user-attachments/assets/db19d7ff-3e86-44ee-b7be-38c2374e66de)

instead of this:
![image](https://github.com/user-attachments/assets/cce30a8f-afe7-428d-8dbb-8b13f3acf41d)
