### PR TITLE
Better alerts for action required and group name in request header

### DIFF
--- a/airlock/templates/_components/header/request/header.html
+++ b/airlock/templates/_components/header/request/header.html
@@ -31,6 +31,14 @@
           <img class="icon" src="/static/icons/token.svg" alt=""></dt>
         <dd>{{ release_request.id }}</dd>
       </div>
+      {% if group %}
+        <div>
+          <dt>
+            <span class="sr-only">ID</span>
+            <img class="icon" src="/static/icons/layers.svg" alt=""></dt>
+          <dd>{{ group.name }}</dd>
+        </div>
+      {% endif %}
     </dl>
 
   </div>

--- a/airlock/templates/file_browser/request/header.html
+++ b/airlock/templates/file_browser/request/header.html
@@ -1,5 +1,5 @@
 <div hx-swap-oob="innerHTML:#content">
-  {% #airlock_request_header release_request=release_request title=title workspace=workspace %}
+  {% #airlock_request_header release_request=release_request title=title workspace=workspace group=group %}
     {% if is_request_root %}
       <h2 class="font-semibold tracking-tight text-slate-900">Request overview</h2>
     {% else %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -362,7 +362,10 @@ def request_view(request, request_id: str, path: str = ""):
                 "Two independent reviews have been submitted. You can now "
             )
         else:
-            request_action_required = f"Two independent reviews have been submitted. go to the <a class='text-oxford-600' href='{release_request.get_url()}'>request overview</a> to "
+            request_action_required = (
+                "Two independent reviews have been submitted. Go to the "
+                f"<a class='text-oxford-600' href='{release_request.get_url()}'>request overview</a> to "
+            )
 
         if release_request.can_be_released():
             request_action_required += "return, reject or release this request."

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -343,17 +343,33 @@ def request_view(request, request_id: str, path: str = ""):
         group_context = group_presenter(release_request, relpath, request)
 
     if permissions.user_can_submit_review(request.user, release_request):
-        request_action_required = (
-            "You have reviewed all files. You can now submit your review."
-        )
+        if relpath == ROOT_PATH:
+            request_action_required = (
+                "You have reviewed all files. Go to individual file groups to add "
+                "comments, or submit your review now."
+            )
+        else:
+            request_action_required = mark_safe(
+                "You have reviewed all files. Go to individual file groups to add "
+                f"comments, or go to the <a class='text-oxford-600' href='{release_request.get_url()}'>request overview</a> to submit your review."
+            )
     elif (
         release_request.status.name == "REVIEWED"
         and permissions.user_can_review_request(request.user, release_request)
     ):
-        if release_request.can_be_released():
-            request_action_required = "Two independent reviews have been submitted. You can now return, reject or release this request."
+        if relpath == ROOT_PATH:
+            request_action_required = (
+                "Two independent reviews have been submitted. You can now "
+            )
         else:
-            request_action_required = "Two independent reviews have been submitted. You can now return or reject this request."
+            request_action_required = f"Two independent reviews have been submitted. go to the <a class='text-oxford-600' href='{release_request.get_url()}'>request overview</a> to "
+
+        if release_request.can_be_released():
+            request_action_required += "return, reject or release this request."
+        else:
+            request_action_required += "return or reject this request."
+        request_action_required = mark_safe(request_action_required)
+
     else:
         request_action_required = None
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -234,14 +234,12 @@ def test_request_view_submit_review_alert(airlock_client, files, has_message):
 
     # The all-files-reviewed reminder message is only shown if the request has
     # output files and all have been reviewed
-    assert (
-        "You can now submit your review" in response.rendered_content
-    ) == has_message
+    assert ("You have reviewed all files" in response.rendered_content) == has_message
 
     # The all-files-reviewed reminder message is never shown to an author
     airlock_client.login(username=release_request.author, workspaces=["workspace"])
     response = airlock_client.get(f"/requests/view/{release_request.id}", follow=True)
-    assert "You can now submit your review" not in response.rendered_content
+    assert "You have reviewed all files" not in response.rendered_content
 
 
 @pytest.mark.parametrize(
@@ -1045,7 +1043,7 @@ def test_request_review_output_checker(airlock_client):
 
     response = airlock_client.get(release_request.get_url())
     # Files have been reviewed but review has not been submitted yet
-    assert "You can now submit your review" in response.rendered_content
+    assert "You have reviewed all files" in response.rendered_content
 
     response = airlock_client.post(
         f"/requests/review/{release_request.id}", follow=True
@@ -1061,7 +1059,7 @@ def test_request_review_output_checker(airlock_client):
 
     response = airlock_client.get(release_request.get_url())
     # Reminder message no longer shown now that review is submitted
-    assert "You can now submit your review" not in response.rendered_content
+    assert "You have reviewed all files" not in response.rendered_content
 
 
 def test_request_review_non_output_checker(airlock_client):


### PR DESCRIPTION
Fixes #718 
Fixes #797 

Include links back to the request overview page in the action required alerts (visible when a user completes their file reviews but hasn't submitted the review yet, or when a request is ready to return/reject/release). For the submit-review, i considered putting a link to actually submit the review in the alert, rather than directing the user back to the overview page, but it requires a form and a post, and would move more logic out to the templates.

Also adds the group into the header, because both of these elements are different if you're on the overview page, and use the same htmx oob to update when the user navigates around via tree links. 

Example overview page: No group in header, no links in alert
![Screenshot from 2025-02-21 16-51-41](https://github.com/user-attachments/assets/3a679ebc-6c23-40b3-b80f-92b4f11f6a42)

Example content page (a file, same header for group and folder views): Group in header, alter has link to the overview page.
![Screenshot from 2025-02-21 16-51-31](https://github.com/user-attachments/assets/20539e8d-1212-4e88-878d-89bdf8c278d8)