### PR TITLE
Replace wait_for_timeout with wait for htmx classes

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -14,6 +14,13 @@ from tests import factories
 expect.set_options(timeout=15_000)
 
 
+def wait_for_htmx(page):
+    # see https://htmx.org/docs/#request-operations
+    # Wait for the htmx-added class to be removed so we know
+    # htmx operations are done
+    expect(page.locator(".htmx-added")).to_have_count(0)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def set_env():
     # This is required for playwright tests with Django

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -8,8 +8,10 @@ from airlock.enums import RequestStatus
 from airlock.types import UrlPath
 from tests import factories
 
+from .conftest import wait_for_htmx
 
-def find_and_click(locator):
+
+def find_and_click(page, locator):
     """
     Helper function to find a locator element and click on it.
     Asserts that the element is visible before trying to click.
@@ -19,29 +21,25 @@ def find_and_click(locator):
     """
     expect(locator).to_be_visible()
     locator.click()
+    # Make sure any clicks that do htmx operations are complete
+    wait_for_htmx(page)
 
 
 def login_as(live_server, page, username):
     page.goto(live_server.url + "/login/?next=/")
     page.locator("#id_user").fill(username)
     page.locator("#id_token").fill(username)
-    find_and_click(page.locator("button[type=submit]"))
+    find_and_click(page, page.locator("button[type=submit]"))
 
     expect(page).to_have_url(live_server.url + "/workspaces/")
     expect(page.locator("body")).to_contain_text(f"Logged in as: {username}")
 
 
 def assert_tree_element_is_not_selected(page, locator):
-    # We need to wait for a tiny amount to ensure the js that swaps the
-    # selected classes around has had time to run before we assert that the
-    # class isn't present. An arbitrary 20ms seems to be enough.
-    page.wait_for_timeout(20)
     expect(locator).not_to_have_class(re.compile("selected"))
 
 
 def assert_tree_element_is_selected(locator):
-    # expect waits for the default timeout period, so we don't need
-    # to rely on an explicit timeout
     expect(locator).to_have_class(re.compile("selected"))
 
 
@@ -111,11 +109,11 @@ def test_e2e_release_files(
     login_as(live_server, page, "researcher")
 
     # Click on to workspaces link
-    find_and_click(page.get_by_test_id("nav-workspaces"))
+    find_and_click(page, page.get_by_test_id("nav-workspaces"))
     expect(page.locator("body")).to_contain_text("Workspaces for researcher")
 
     # Click on the workspace
-    find_and_click(page.locator("#workspaces").get_by_role("link"))
+    find_and_click(page, page.locator("#workspaces").get_by_role("link"))
     expect(page.locator("body")).to_contain_text("subdir")
     # subdirectories start off collapsed; the file links are not present
     assert page.get_by_role("link", name="file.txt").all() == []
@@ -125,10 +123,10 @@ def test_e2e_release_files(
     # There will be more than one link to the folder/file in the page,
     # one in the explorer, and one in the main folder view
     # Click on the first link we find
-    find_and_click(page.get_by_role("link", name="subdir").first)
+    find_and_click(page, page.get_by_role("link", name="subdir").first)
 
     # Get and click on the invalid file
-    find_and_click(page.get_by_role("link", name="file.foo").first)
+    find_and_click(page, page.get_by_role("link", name="file.foo").first)
 
     # Check the expected iframe content is visible
     iframe_locator = page.locator("#content-iframe")
@@ -141,7 +139,7 @@ def test_e2e_release_files(
     expect(add_file_button).to_be_disabled()
 
     # Get and click on the valid file
-    find_and_click(page.get_by_role("link", name="file.txt").first)
+    find_and_click(page, page.get_by_role("link", name="file.txt").first)
 
     # Check the expected iframe content is visible
     valid_file_content = iframe_locator.content_frame.get_by_text(
@@ -152,7 +150,7 @@ def test_e2e_release_files(
     # Add file to request, with custom named group
     # Find the add file button and click on it to open the modal
     add_file_button = page.locator("button[value=add_files]")
-    find_and_click(add_file_button)
+    find_and_click(page, add_file_button)
     # Fill in the form with a new group name
     page.locator("#id_new_filegroup").fill("my-new-group")
 
@@ -165,7 +163,7 @@ def test_e2e_release_files(
     form_element = page.get_by_role("form")
 
     # Click the button to add the file to a release request
-    find_and_click(form_element.locator("#add-file-button"))
+    find_and_click(page, form_element.locator("#add-file-button"))
 
     expect(page).to_have_url(
         f"{live_server.url}/workspaces/view/test-workspace/subdir/file.txt"
@@ -178,7 +176,7 @@ def test_e2e_release_files(
     expect(add_file_button).to_be_disabled()
 
     # We now have a "Current release request" button
-    find_and_click(page.locator("#current-request-button"))
+    find_and_click(page, page.locator("#current-request-button"))
     # Clicking it takes us to the release
     url_regex = re.compile(rf"{live_server.url}\/requests\/view\/([A-Z0-9].+)/")
     expect(page).to_have_url(url_regex)
@@ -210,39 +208,39 @@ def test_e2e_release_files(
 
     # Click on the output directory to ensure that renders correctly.
     subdir_link = page.get_by_role("link").locator(".directory:scope")
-    find_and_click(subdir_link)
+    find_and_click(page, subdir_link)
     expect(page.locator("#selected-contents")).to_contain_text("file.txt")
 
     # Tree opens fully expanded, so now the file (in its subdir) is visible
-    find_and_click(file_link)
+    find_and_click(page, file_link)
 
     # Check the expected iframe content is visible
     expect(valid_file_content).to_be_visible()
 
     # Go back to the Workspace view so we can add a supporting file
-    find_and_click(page.locator("#workspace-home-button"))
+    find_and_click(page, page.locator("#workspace-home-button"))
     expect(page).to_have_url(live_server.url + "/workspaces/view/test-workspace/")
 
     # Expand the tree and click on the supporting file
-    find_and_click(page.get_by_role("link", name="subdir").first)
-    find_and_click(page.get_by_role("link", name="supporting.txt").first)
+    find_and_click(page, page.get_by_role("link", name="subdir").first)
+    find_and_click(page, page.get_by_role("link", name="supporting.txt").first)
 
     # Add supporting file to request, choosing the group we created previously
     # Find the add file button and click on it to open the modal
-    find_and_click(page.locator("button[value=add_files]"))
+    find_and_click(page, page.locator("button[value=add_files]"))
 
     page.locator("select[name=filegroup]").select_option("my-new-group")
     # Select supporting file
     page.locator("input[name=form-0-filetype][value=SUPPORTING]").check()
 
     # Click the button to add the file to a release request
-    find_and_click(page.get_by_role("form").locator("#add-file-button"))
+    find_and_click(page, page.get_by_role("form").locator("#add-file-button"))
 
     # refresh release_request
     release_request = bll.get_release_request(request_id, admin_user)
 
     # Go back to the request
-    find_and_click(page.locator("#current-request-button"))
+    find_and_click(page, page.locator("#current-request-button"))
 
     # Expand the tree
     filegroup_link.click()
@@ -251,13 +249,13 @@ def test_e2e_release_files(
     subdir_link = page.get_by_role("link").locator(".directory:scope")
 
     assert_tree_element_is_not_selected(page, subdir_link)
-    find_and_click(subdir_link)
+    find_and_click(page, subdir_link)
     # subdir link is shown as selected
     assert_tree_element_is_selected(subdir_link)
     expect(page.locator("#selected-contents")).to_contain_text("file.txt")
 
     # Tree opens fully expanded, so now the file (in its subdir) is visible
-    find_and_click(file_link)
+    find_and_click(page, file_link)
     # File is selected, subdir is now unselected
     assert_tree_element_is_selected(file_link)
     assert_tree_element_is_not_selected(page, subdir_link)
@@ -266,7 +264,7 @@ def test_e2e_release_files(
 
     # Click on the supporting file link.
     supporting_file_link = page.get_by_role("link").locator(".supporting.file:scope")
-    find_and_click(supporting_file_link)
+    find_and_click(page, supporting_file_link)
     assert_tree_element_is_selected(supporting_file_link)
     assert_tree_element_is_not_selected(page, file_link)
 
@@ -277,7 +275,7 @@ def test_e2e_release_files(
     expect(supporting_file_content).to_be_visible()
 
     # Click back to the output file link and ensure the selected classes are correctly applied
-    find_and_click(file_link)
+    find_and_click(page, file_link)
     assert_tree_element_is_selected(file_link)
     assert_tree_element_is_not_selected(page, supporting_file_link)
     # Check the expected iframe content is visible
@@ -285,35 +283,35 @@ def test_e2e_release_files(
 
     # Add context & controls to the filegroup
     filegroup_link = page.get_by_role("link").locator(".filegroup:scope")
-    find_and_click(filegroup_link)
+    find_and_click(page, filegroup_link)
 
     # context and controls instruction help text is shown
     expect(page.get_by_test_id("c3")).to_contain_text("Please describe")
 
     context_input = page.locator("#id_context")
-    find_and_click(context_input)
+    find_and_click(page, context_input)
     context_input.fill("some context")
 
     controls_input = page.locator("#id_controls")
-    find_and_click(controls_input)
+    find_and_click(page, controls_input)
     controls_input.fill("some controls")
 
     save_button = page.locator("#edit-group-button")
-    find_and_click(save_button)
+    find_and_click(page, save_button)
 
     # Submit request
-    find_and_click(page.locator("#request-home-button"))
+    find_and_click(page, page.locator("#request-home-button"))
     submit_button = page.locator("button[data-modal=submitRequest]")
-    find_and_click(submit_button)
+    find_and_click(page, submit_button)
     confirm_button = page.locator("#submit-for-review-button")
-    find_and_click(confirm_button)
+    find_and_click(page, confirm_button)
     expect(page.locator("body")).to_contain_text("SUBMITTED")
     # After the request is submitted, the submit button is no longer visible
     expect(submit_button).not_to_be_visible()
 
     # Before we log the researcher out and continue, let's just check
     # their requests
-    find_and_click(page.get_by_test_id("nav-requests"))
+    find_and_click(page, page.get_by_test_id("nav-requests"))
     expect(page).to_have_url(live_server.url + "/requests/researcher")
 
     authored_request_locator = page.locator("#authored-requests")
@@ -324,8 +322,8 @@ def test_e2e_release_files(
     expect(request_link).to_have_attribute("href", f"/requests/view/{request_id}/")
 
     # Log out with buttons
-    find_and_click(page.get_by_test_id("nav-account"))
-    find_and_click(page.get_by_test_id("nav-logout"))
+    find_and_click(page, page.get_by_test_id("nav-account"))
+    find_and_click(page, page.get_by_test_id("nav-logout"))
 
     # Login button is visible now
     login_button = page.get_by_test_id("nav-login")
@@ -335,10 +333,10 @@ def test_e2e_release_files(
     login_as(live_server, page, "output_checker")
 
     # View requests
-    find_and_click(page.get_by_test_id("nav-reviews"))
+    find_and_click(page, page.get_by_test_id("nav-reviews"))
 
     # View submitted request (in the output-checker's outstanding requests for review)
-    find_and_click(page.locator("#outstanding-requests").get_by_role("link"))
+    find_and_click(page, page.locator("#outstanding-requests").get_by_role("link"))
     expect(page.locator("body")).to_contain_text(request_id)
 
     submit_review_button = page.locator("#submit-review-button")
@@ -348,66 +346,66 @@ def test_e2e_release_files(
 
     # Reuse the locators from the workspace view to click on filegroup and then file
     # Click to open the filegroup tree
-    find_and_click(filegroup_link)
-    find_and_click(file_link)
+    find_and_click(page, filegroup_link)
+    find_and_click(page, file_link)
     # Check the expected iframe content is visible
     expect(valid_file_content).to_be_visible()
 
     # File is not yet approved, so the release button is disabled
-    find_and_click(page.locator("#request-home-button"))
+    find_and_click(page, page.locator("#request-home-button"))
     release_button = page.locator("#release-files-button")
     expect(release_button).to_be_disabled()
 
     # Request changes to the file
-    find_and_click(file_link)
+    find_and_click(page, file_link)
     expect(page.locator("#file-request-changes-button")).to_have_attribute(
         "aria-pressed", "false"
     )
     expect(page.locator("#file-reset-button")).to_be_disabled()
-    find_and_click(page.locator("#file-request-changes-button"))
+    find_and_click(page, page.locator("#file-request-changes-button"))
     expect(page.locator("#file-request-changes-button")).to_have_attribute(
         "aria-pressed", "true"
     )
     expect(page.locator("#file-reset-button")).not_to_be_disabled()
 
     # output checker has now reviewed all output files
-    find_and_click(page.locator("#request-home-button"))
+    find_and_click(page, page.locator("#request-home-button"))
     expect(submit_review_button).to_be_visible()
     expect(submit_review_button).to_be_enabled()
 
     # Change our minds & remove the review
-    find_and_click(file_link)
+    find_and_click(page, file_link)
     expect(page.locator("#file-reset-button")).to_have_attribute(
         "aria-pressed", "false"
     )
-    find_and_click(page.locator("#file-reset-button"))
+    find_and_click(page, page.locator("#file-reset-button"))
     expect(page.locator("#file-reset-button")).to_have_attribute("aria-pressed", "true")
 
     # submit review button disabled again
-    find_and_click(page.locator("#request-home-button"))
+    find_and_click(page, page.locator("#request-home-button"))
     expect(submit_review_button).to_be_visible()
     expect(submit_review_button).to_be_disabled()
 
     # Think some more & finally approve the file
-    find_and_click(file_link)
+    find_and_click(page, file_link)
     expect(page.locator("#file-approve-button")).to_have_attribute(
         "aria-pressed", "false"
     )
-    find_and_click(page.locator("#file-approve-button"))
+    find_and_click(page, page.locator("#file-approve-button"))
     expect(page.locator("#file-approve-button")).to_have_attribute(
         "aria-pressed", "true"
     )
 
     # File is only approved once, so the release files button is still disabled
-    find_and_click(page.locator("#request-home-button"))
+    find_and_click(page, page.locator("#request-home-button"))
     expect(release_button).to_be_disabled()
 
-    find_and_click(file_link)
-    find_and_click(page.locator("#file-button-more"))
+    find_and_click(page, file_link)
+    find_and_click(page, page.locator("#file-button-more"))
 
     # Download the file
     with page.expect_download() as download_info:
-        find_and_click(page.locator("#download-button"))
+        find_and_click(page, page.locator("#download-button"))
     download = download_info.value
     assert download.suggested_filename == "file.txt"
 
@@ -415,7 +413,7 @@ def test_e2e_release_files(
     supporting_file_link = page.get_by_role("link", name="supporting.txt").locator(
         ".file:scope"
     )
-    find_and_click(supporting_file_link)
+    find_and_click(page, supporting_file_link)
     # Check the expected iframe content is visible
     expect(supporting_file_content).to_be_visible()
 
@@ -424,11 +422,11 @@ def test_e2e_release_files(
     expect(page.locator("#file-reset-button")).not_to_be_visible()
 
     # submit review for this output-checker
-    find_and_click(page.locator("#request-home-button"))
-    find_and_click(page.locator("#submit-review-button"))
+    find_and_click(page, page.locator("#request-home-button"))
+    find_and_click(page, page.locator("#submit-review-button"))
 
     # After submitting the review, the output-checker can change their vote, but can't reset it
-    find_and_click(file_link)
+    find_and_click(page, file_link)
     # file is already approved, so the approve button is disable
     expect(page.locator("#file-approve-button")).to_be_disabled()
     # they can change their minds and request changes, but can't reset now
@@ -441,15 +439,15 @@ def test_e2e_release_files(
     login_as(live_server, page, "output_checker_1")
     # Approve the file
     page.goto(live_server.url + release_request.get_url("my-new-group/subdir/file.txt"))
-    find_and_click(page.locator("#file-approve-button"))
+    find_and_click(page, page.locator("#file-approve-button"))
 
     # The file has 2 approvals, but the release files button is not yet enabled until this
     # reviewer submits their review
-    find_and_click(page.locator("#request-home-button"))
+    find_and_click(page, page.locator("#request-home-button"))
     expect(release_button).to_be_disabled()
 
     # submit review
-    find_and_click(page.locator("#submit-review-button"))
+    find_and_click(page, page.locator("#submit-review-button"))
     expect(release_button).to_be_enabled()
 
     # Mock the responses from job-server
@@ -457,7 +455,7 @@ def test_e2e_release_files(
     release_files_stubber(release_request)
 
     # Release the files
-    find_and_click(release_button)
+    find_and_click(page, release_button)
     expect(page.locator("body")).to_contain_text(
         "Files have been released and will be uploaded to jobs.opensafely.org"
     )
@@ -465,7 +463,7 @@ def test_e2e_release_files(
     expect(page.locator("body")).to_contain_text("APPROVED - FILES UPLOADING")
 
     # Reviews page still shows approved request
-    find_and_click(page.get_by_test_id("nav-reviews"))
+    find_and_click(page, page.get_by_test_id("nav-reviews"))
     expect(page.locator("body")).to_contain_text("test-workspace")
     expect(page.locator("body")).to_contain_text("APPROVED - FILES UPLOADING")
 
@@ -512,15 +510,15 @@ def test_e2e_update_file(page, live_server, dev_users, multiselect):
         page.goto(live_server.url + workspace.get_url(UrlPath("subdir/")))
 
         # click on the multi-select checkbox
-        find_and_click(page.locator('input[name="selected"]'))
+        find_and_click(page, page.locator('input[name="selected"]'))
     else:
         page.goto(live_server.url + workspace.get_url(UrlPath("subdir/file.txt")))
 
     # Find the add file button and click on it to open the modal
-    find_and_click(page.locator("button[value=update_files]"))
+    find_and_click(page, page.locator("button[value=update_files]"))
 
     # Click the button to update the file in the release request
-    find_and_click(page.get_by_role("form").locator("#update-file-button"))
+    find_and_click(page, page.get_by_role("form").locator("#update-file-button"))
 
     expect(page.locator("body")).to_contain_text("file has been updated in request")
 
@@ -549,22 +547,22 @@ def test_e2e_withdraw_and_readd_file(page, live_server, dev_users):
 
     # Withdraw file1 from the file page
     page.goto(live_server.url + release_request.get_url("default/subdir/file1.txt"))
-    find_and_click(page.locator("#withdraw-file-button"))
+    find_and_click(page, page.locator("#withdraw-file-button"))
     expect(page.locator("body")).to_contain_text("has been withdrawn from the request")
 
     # Withdraw file2 from the directory page
     page.goto(live_server.url + release_request.get_url("default/subdir"))
     expect(page.locator(".datatable-table")).to_be_visible()
     find_and_click(
-        page.locator('input[name="selected"][value="default/subdir/file2.txt"]')
+        page, page.locator('input[name="selected"][value="default/subdir/file2.txt"]')
     )
-    find_and_click(page.locator("button[value=withdraw_files]"))
+    find_and_click(page, page.locator("button[value=withdraw_files]"))
     expect(page.locator("body")).to_contain_text("has been withdrawn from the request")
 
     # Change our mind on file 2: go to file page and re-add it
     page.goto(live_server.url + workspace.get_url(UrlPath(path2)))
-    find_and_click(page.locator("button[value=add_files]"))
-    find_and_click(page.get_by_role("form").locator("#add-file-button"))
+    find_and_click(page, page.locator("button[value=add_files]"))
+    find_and_click(page, page.get_by_role("form").locator("#add-file-button"))
 
     # Confirm it's been re-added
     expect(page.locator("body")).to_contain_text(
@@ -576,10 +574,10 @@ def test_e2e_withdraw_and_readd_file(page, live_server, dev_users):
     # We have to wait for the datatable to finish rendering before we interact with the
     # checkboxes otherwise the wrong thing gets selected
     expect(page.locator(".datatable-table")).to_be_visible()
-    find_and_click(page.locator(f'input[name="selected"][value="{path1}"]'))
+    find_and_click(page, page.locator(f'input[name="selected"][value="{path1}"]'))
 
-    find_and_click(page.locator("button[value=add_files]"))
-    find_and_click(page.get_by_role("form").locator("#add-file-button"))
+    find_and_click(page, page.locator("button[value=add_files]"))
+    find_and_click(page, page.get_by_role("form").locator("#add-file-button"))
 
     # Confirm it's been re-added
     expect(page.locator("body")).to_contain_text(
@@ -606,12 +604,12 @@ def test_e2e_reject_request(page, live_server, dev_users):
     page.goto(live_server.url + release_request.get_url())
 
     # Reject request
-    find_and_click(page.locator("button[data-modal=rejectRequest]"))
-    find_and_click(page.locator("#reject-request-button"))
+    find_and_click(page, page.locator("button[data-modal=rejectRequest]"))
+    find_and_click(page, page.locator("#reject-request-button"))
     # Page contains rejected message text
     expect(page.locator("body")).to_contain_text("Request has been rejected")
     # Requests view does not show rejected request
-    find_and_click(page.get_by_test_id("nav-requests"))
+    find_and_click(page, page.get_by_test_id("nav-requests"))
     expect(page.locator("body")).not_to_contain_text("test-workspace by author")
 
 
@@ -634,8 +632,8 @@ def test_e2e_withdraw_request(page, live_server, dev_users):
     # View submitted request
     page.goto(live_server.url + release_request.get_url())
 
-    find_and_click(page.locator("[data-modal=withdrawRequest]"))
+    find_and_click(page, page.locator("[data-modal=withdrawRequest]"))
 
-    find_and_click(page.locator("#withdraw-request-confirm"))
+    find_and_click(page, page.locator("#withdraw-request-confirm"))
 
     expect(page.locator("body")).to_contain_text("Request has been withdrawn")

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -5,7 +5,7 @@ from airlock.enums import RequestFileType, RequestStatus
 from airlock.types import UrlPath
 from tests import factories
 
-from .conftest import login_as_user
+from .conftest import login_as_user, wait_for_htmx
 
 
 @pytest.fixture(autouse=True)
@@ -414,7 +414,7 @@ def test_bug_rendering_datatable_in_combination_with_back_button(
 
     # The above click triggers an htmx request. This waits for that to
     # complete
-    page.wait_for_load_state()
+    wait_for_htmx(page)
     # should load the table but previously didn't
     expect(page.locator(".datatable-table")).to_be_visible()
 


### PR DESCRIPTION
Playwright docs warn that `wait_for_timeout` is flaky https://playwright.dev/python/docs/api/class-frame#frame-wait-for-timeout

Replace it with a wait for the htmx class that's added and then removed during an htmx operation.
https://htmx.org/docs/#request-operations

Also wait for htmx to be done in the `find_and_click` helper function. Not all of these clicks will involve htmx, but lots of them do. Note that we could wait for `htmx-added` counts of 1 and then 0, which would verify that an htmx swap happened - but it doesn't always pick up the 1 count, even when it's definitely an htmx operation, so I think sometimes it's too fast for playwright; in any case, this means that we can add it in the `find_and_click` function without being too bothered about whether it's htmx or not, we just make sure there's no htmx-swapping still going on.