### PR TITLE
Prevent output checkers from adding private comments for requests in author-owned states

### DIFF
--- a/airlock/models.py
+++ b/airlock/models.py
@@ -819,6 +819,10 @@ class ReleaseRequest:
         if not user.output_checker:
             return [Visibility.PUBLIC]
 
+        # in editing status, only public comments are allowed, even for output-checkers
+        if self.is_editing():
+            return [Visibility.PUBLIC]
+
         # all other cases - the output-checker can choose to write public or private comments
         return [Visibility.PRIVATE, Visibility.PUBLIC]
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -1938,7 +1938,7 @@ def test_group_edit_bad_group(airlock_client):
         (False, Visibility.PUBLIC, True),
         (False, Visibility.PRIVATE, False),
         (True, Visibility.PUBLIC, True),
-        (True, Visibility.PRIVATE, True),
+        (True, Visibility.PRIVATE, False),
     ],
 )
 def test_group_comment_create_success(
@@ -1949,6 +1949,7 @@ def test_group_comment_create_success(
     release_request = factories.create_release_request("workspace", user=author)
     factories.add_request_file(release_request, "group", "file.txt")
 
+    # collaborator user - has access to the workspace but is not the author
     user = factories.create_airlock_user(
         output_checker=output_checker, workspaces=["workspace"]
     )


### PR DESCRIPTION
Fixes #799 

Collaborators (i.e. users who are not the author but who have access to a workspace) can add comments to a request that is in pending or returned state. However, if they are also an output checker they can now only add comments that are public (i.e. they can only comment as a collaborator, not as an output-checker) 