### PR TITLE
Differentiate visibly between selected and disabled voting buttons

### DIFF
--- a/airlock/static/assets/file_browser/index.css
+++ b/airlock/static/assets/file_browser/index.css
@@ -185,3 +185,11 @@
   border-color: var(--color-gray-500);
   color: white;
 }
+
+.btn-group__btn--disabled,
+.btn-group__btn--disabled:hover,
+.btn-group__btn--disabled:focus {
+  background-color: var(--color-slate-300);
+  border-color: var(--color-slate-300);
+  color: var(--color-slate-800);
+}

--- a/airlock/templates/file_browser/request/file.html
+++ b/airlock/templates/file_browser/request/file.html
@@ -46,8 +46,8 @@
 
     {% if content_buttons.voting.approve.show %}
       <div class="btn-group">
-        {% if content_buttons.voting.approve.disabled %}
-          <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active whitespace-nowrap" id="file-approve-button" disabled="true">
+        {% if content_buttons.voting.approve.selected %}
+          <button aria-pressed="true" class="btn-group__btn btn-group__btn--left btn-group__btn--active cursor-not-allowed whitespace-nowrap" id="file-approve-button" disabled="true">
             Approve file
           </button>
         {% else %}
@@ -59,8 +59,8 @@
           </form>
         {% endif %}
 
-        {% if content_buttons.voting.request_changes.disabled %}
-          <button aria-pressed="true" class="btn-group__btn btn-group__btn--active whitespace-nowrap" id="file-request-changes-button" disabled="true">
+        {% if content_buttons.voting.request_changes.selected %}
+          <button aria-pressed="true" class="btn-group__btn btn-group__btn--active cursor-not-allowed whitespace-nowrap" id="file-request-changes-button" disabled="true">
             Request changes
           </button>
         {% else %}
@@ -72,8 +72,12 @@
           </form>
         {% endif %}
 
-        {% if content_buttons.voting.reset_review.disabled %}
-          <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active" id="file-reset-button" disabled="true">
+        {% if content_buttons.voting.reset_review.selected %}
+          <button aria-pressed="true" class="btn-group__btn btn-group__btn--right btn-group__btn--active cursor-not-allowed" id="file-reset-button" disabled="true">
+            Undecided
+          </button>
+        {% elif content_buttons.voting.reset_review.disabled %}
+          <button aria-pressed="false" class="btn-group__btn btn-group__btn--right btn-group__btn--disabled cursor-not-allowed" id="file-reset-button" disabled="true">
             Undecided
           </button>
         {% else %}

--- a/airlock/views/helpers.py
+++ b/airlock/views/helpers.py
@@ -23,6 +23,7 @@ class ButtonContext:
 
     show: bool = False
     disabled: bool = True
+    selected: bool = False
     url: str = ""
     tooltip: str = ""
 

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -234,15 +234,19 @@ def _get_file_button_context(user, release_request, workspace, path_item):
             button.show = True
     # Determine whether any of the voting buttons should be enabled
     if permissions.user_can_review_file(user, release_request, relpath):
-        # check what the current vote is, and enable the OTHER options
+        # check what the current vote is, make that button selected and
+        # enable the OTHER options
         match user_vote:
             case RequestFileVote.APPROVED:
+                voting_buttons["approve"].selected = True
                 voting_buttons["request_changes"].disabled = False
                 voting_buttons["reset_review"].disabled = False
             case RequestFileVote.CHANGES_REQUESTED:
+                voting_buttons["request_changes"].selected = True
                 voting_buttons["approve"].disabled = False
                 voting_buttons["reset_review"].disabled = False
             case RequestFileVote.UNDECIDED | None:
+                voting_buttons["reset_review"].selected = True
                 voting_buttons["approve"].disabled = False
                 voting_buttons["request_changes"].disabled = False
             case _:  # pragma: no cover
@@ -250,6 +254,7 @@ def _get_file_button_context(user, release_request, workspace, path_item):
         # reset review has an extra check for whether the user has
         # submitted their review
         if not permissions.user_can_reset_file_review(user, release_request, relpath):
+            voting_buttons["reset_review"].selected = False
             voting_buttons["reset_review"].disabled = True
 
     return {


### PR DESCRIPTION
Fixes #784 

Before submitting review (reset-review button is enabled):
![Screenshot from 2025-02-24 16-00-43](https://github.com/user-attachments/assets/c3827387-86a6-4a86-9057-b3a4c691afe8)

After submitting review  (reset-review button is disabled, using same styling as other disabled buttons):
![Screenshot from 2025-02-24 16-01-15](https://github.com/user-attachments/assets/2ce11177-955a-4e6a-a651-e6a753c2fdea)

Also adds the "cursor-not-allowed" class to selected and disabled voting buttons so it shows the :no_entry_sign: when you hover over it, instead of a cursor (similar to other disabled buttons)


