### PR TITLE
Wait for iframe content to be present in functional tests

### DIFF
--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -132,6 +132,9 @@ def test_e2e_release_files(
 
     # Check the expected iframe content is visible
     iframe_locator = page.locator("#content-iframe")
+    # First make sure that the iframe container is visible
+    # hover() waits for the element to be visible, stable and receiving events
+    iframe_locator.hover()
     invalid_file_content = iframe_locator.content_frame.get_by_text(
         "file.foo is not a valid file type"
     )
@@ -143,6 +146,7 @@ def test_e2e_release_files(
     # Get and click on the valid file
     find_and_click(page.get_by_role("link", name="file.txt").first)
 
+    iframe_locator.hover()
     # Check the expected iframe content is visible
     valid_file_content = iframe_locator.content_frame.get_by_text(
         "I am the file content"
@@ -270,6 +274,7 @@ def test_e2e_release_files(
     assert_tree_element_is_selected(supporting_file_link)
     assert_tree_element_is_not_selected(page, file_link)
 
+    iframe_locator.hover()
     # Check the expected iframe content is visible
     supporting_file_content = iframe_locator.content_frame.get_by_text(
         "I am the supporting file content"


### PR DESCRIPTION
I don't have much confidence in this, but checking the iframe is the most frequently seen of the intermittent functional test timeouts.  `hover()` waits for the element to be [visible, stable and receiving events](https://playwright.dev/docs/actionability), so I wonder if calling `hover()` on the iframe container before getting its text content will help. If not, it might be informative to see whether it times out at the `hover()` or still on checking visibility of the text content.