### PR TITLE
Some more functional tests rework and a tracing workflow

### DIFF
--- a/.github/workflows/trace-functional-tests.yml
+++ b/.github/workflows/trace-functional-tests.yml
@@ -1,0 +1,48 @@
+---
+name: trace-functional-tests
+
+on:
+  workflow_dispatch:
+  push: 
+    branches: 
+      - rebkwok/flaky-functional-tests-take2
+
+jobs:
+
+  trace-functional-tests:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          python-version: "3.11"
+          install-just: true
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install node_modules
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build
+
+      - name: Set up development environment
+        run: just devenv
+
+      - name: Run functional tests
+        id: run_test
+        run: |
+          just test -k functional --tracing on
+        
+      - name: Upload trace artifact
+        if: failure() || success()
+        uses: actions/upload-artifact@v4
+        with:
+            name: test-results-trace
+            path: test-results/**/trace.zip

--- a/.github/workflows/trace-functional-tests.yml
+++ b/.github/workflows/trace-functional-tests.yml
@@ -3,9 +3,8 @@ name: trace-functional-tests
 
 on:
   workflow_dispatch:
-  push: 
-    branches: 
-      - rebkwok/flaky-functional-tests-take2
+  schedule:
+    - cron:  "0 * * * *"
 
 jobs:
 
@@ -38,10 +37,10 @@ jobs:
       - name: Run functional tests
         id: run_test
         run: |
-          just test -k functional --tracing on
+          just test -k functional --tracing retain-on-failure
         
       - name: Upload trace artifact
-        if: failure() || success()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
             name: test-results-trace

--- a/.github/workflows/trace-functional-tests.yml
+++ b/.github/workflows/trace-functional-tests.yml
@@ -45,3 +45,19 @@ jobs:
         with:
             name: test-results-trace
             path: test-results/**/trace.zip
+
+      - name: Notify slack of failures
+        if: failure()
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          errors: true
+          method: chat.postMessage
+          token: ${{ secrets.BENNETTBOT_SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "C069YDR4NCA"
+            text: "Airlock functional tests failed: Download the trace at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id}}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":warning: Airlock functional tests failed:warning:\nDownload the trace at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id}}"

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 
 # browser install location in docker
 .playwright-browsers/
+# playwright traces
+test-results/
 
 # docker temp config
 /job-server/.env.jobserver

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -171,6 +171,8 @@ or to run a single test, run e.g. `just test tests/unit/test_urls.py::test_urls`
 
 #### Debugging
 
+##### Headed mode
+
 Functional tests run headless by default. To see what's going on, they
 can be run in headed mode. The following command will run just the
 functional tests, in headed mode, slowed down by 500ms. See the
@@ -185,6 +187,34 @@ To leave the browser instance open after a test failure you can make
 pytest drop into the debugger using the `--pdb` argument:
 ```
 just test --headed --pdb ... <path/to/test.py>
+```
+
+##### The Playwright Inspector
+
+To use the [Playwright Inspector debugging tool](https://playwright.dev/python/docs/running-tests#debugging-tests), run with:
+```
+PWDEBUG=1 just test ...
+```
+
+This will run the tests and open up a browser window as well as the Playwright Inspector.
+In the inspector you can step throught the test and investigate element locators.
+
+##### Tracing tests
+
+[Record a trace](https://playwright.dev/python/docs/trace-viewer-intro#recording-a-trace)
+for each test with:
+
+```
+just test ... --tracing on
+```
+
+This will record the trace and place it into the file named trace.zip in the `test-results`
+directory.
+
+You can load the trace using Playwright's trace viewer, and see the state of the page
+at each action in each test:
+```
+playwright show-trace /path/to/trace.zip
 ```
 
 

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -109,20 +109,21 @@ def test_e2e_release_files(
     expect(page.locator("body")).to_contain_text("Workspaces for researcher")
 
     # Click on the workspace
-    find_and_click(page, page.locator("#workspaces").get_by_role("link"))
+    find_and_click(page, page.get_by_role("link", name="test-workspace"))
     expect(page.locator("body")).to_contain_text("subdir")
     # subdirectories start off collapsed; the file links are not present
-    assert page.get_by_role("link", name="file.txt").all() == []
-    assert page.get_by_role("link", name="file.foo").all() == []
+    expect(page.get_by_role("link", name="file.txt")).to_have_count(0)
+    expect(page.get_by_role("link", name="file.foo")).to_have_count(0)
 
     # Click on the subdir and then the file link to view in the workspace
-    # There will be more than one link to the folder/file in the page,
-    # one in the explorer, and one in the main folder view
-    # Click on the first link we find
-    find_and_click(page, page.get_by_role("link", name="subdir").first)
+    expect(page.get_by_role("link", name="subdir")).to_have_count(1)
+    find_and_click(page, page.get_by_role("link", name="subdir"))
 
-    # Get and click on the invalid file
-    find_and_click(page, page.get_by_role("link", name="file.foo").first)
+    # There will be more than one link to the file in the page,
+    # one in the tree, and one in the main folder view
+    # Click on the one in the tree
+    expect(page.get_by_role("link", name="file.foo")).to_have_count(2)
+    find_and_click(page, page.locator("#tree").get_by_role("link", name="file.foo"))
 
     # Check the expected iframe content is visible
     iframe_locator = page.locator("#content-iframe")
@@ -135,7 +136,7 @@ def test_e2e_release_files(
     expect(add_file_button).to_be_disabled()
 
     # Get and click on the valid file
-    find_and_click(page, page.get_by_role("link", name="file.txt").first)
+    find_and_click(page, page.locator("#tree").get_by_role("link", name="file.txt"))
 
     # Check the expected iframe content is visible
     valid_file_content = iframe_locator.content_frame.get_by_text(
@@ -151,10 +152,8 @@ def test_e2e_release_files(
     page.locator("#id_new_filegroup").fill("my-new-group")
 
     # By default, the selected filetype is OUTPUT
-    expect(page.locator("input[name=form-0-filetype][value=OUTPUT]")).to_be_checked()
-    expect(
-        page.locator("input[name=form-0-filetype][value=SUPPORTING]")
-    ).not_to_be_checked()
+    expect(page.get_by_role("radio", name="Output")).to_be_checked()
+    expect(page.get_by_role("radio", name="Supporting")).not_to_be_checked()
 
     form_element = page.get_by_role("form")
 
@@ -218,8 +217,10 @@ def test_e2e_release_files(
     expect(page).to_have_url(live_server.url + "/workspaces/view/test-workspace/")
 
     # Expand the tree and click on the supporting file
-    find_and_click(page, page.get_by_role("link", name="subdir").first)
-    find_and_click(page, page.get_by_role("link", name="supporting.txt").first)
+    find_and_click(page, page.get_by_role("link", name="subdir"))
+    find_and_click(
+        page, page.locator("#tree").get_by_role("link", name="supporting.txt")
+    )
 
     # Add supporting file to request, choosing the group we created previously
     # Find the add file button and click on it to open the modal

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -13,13 +13,9 @@ from .conftest import wait_for_htmx
 
 def find_and_click(page, locator):
     """
-    Helper function to find a locator element and click on it.
-    Asserts that the element is visible before trying to click.
-    This avoids playwright hanging on clicking an unavailable
-    element, which happens if we just chain the locator and click
-    methods.
+    Helper function to click on a locator element and wait for
+    any htmx operations that it might trigger.
     """
-    expect(locator).to_be_visible()
     locator.click()
     # Make sure any clicks that do htmx operations are complete
     wait_for_htmx(page)


### PR DESCRIPTION
This reworks some playwright locators, especially those around the flakiest bits (generally the tree clicks and iframe content), by using the locators that are identified in the [Playwright Inspector](https://playwright.dev/python/docs/running-tests#debugging-tests) when running the tests with `PWDEBUG=1`

Also adds a GHA workflow to run the functional tests with tracing and upload the trace as an artifact if the test fails.  The workflow will run every hour, so if it fails, we can download the trace for the failing test(s) and inspect the page state at the time of the failure. Hopefully this will give us some insights into how we might fix the flakiness.

The trace is found with the workflow run, [this is an example](https://github.com/opensafely-core/airlock/actions/runs/13544691316) from a test run where it uploaded the traces even if tests passed (i.e. at the second-to-last commit of this PR). 

Also some more developer docs around debugging and tracing.