### PR TITLE
Reload page in screenshot test

### DIFF
--- a/tests/functional/test_docs_screenshots.py
+++ b/tests/functional/test_docs_screenshots.py
@@ -395,7 +395,7 @@ def test_screenshot_from_creation_to_release(
     for relpath in all_output_relpaths[1:]:
         bll.register_file_upload(release_request, relpath, checker_user)
     bll.set_status(release_request, RequestStatus.RELEASED, checker_user)
-    page.goto(live_server.url + release_request.get_url())
+    page.reload()
     take_screenshot(page, "request_released.png")
 
 


### PR DESCRIPTION
The test has failed a couple of times at [this point](https://github.com/opensafely-core/airlock/actions/runs/13559964118/job/37901163083#step:8:531) 

Looking at the trace replay, I suspect a conflict between the htmx polling for the uploaded files and the page.goto() call; tentatively suggesting that using page.reload() will help.