### PR TITLE
Switch from username string to User object in BLL/DAL

### DIFF
--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -122,7 +122,7 @@ def user_can_review(user: User):
 
 def check_user_can_review_request(user: User, request: "ReleaseRequest"):
     """This user can be a reviewer for a specific request"""
-    if request.author == user.username or not user_can_review(user):
+    if request.author == user or not user_can_review(user):
         raise exceptions.RequestPermissionDenied(
             "You do not have permission to review this request"
         )
@@ -158,7 +158,7 @@ def check_user_can_edit_request(user: User, request: "ReleaseRequest"):
     This user has permission to edit the request, AND the request is in an
     editable state
     """
-    if user.username != request.author:
+    if user != request.author:
         raise exceptions.RequestPermissionDenied(
             f"only author {request.author} can edit this request"
         )
@@ -294,7 +294,7 @@ def check_user_can_reset_file_review(
     user: User, request: "ReleaseRequest", relpath: UrlPath
 ):
     check_user_can_review_file(user, request, relpath)
-    if user.username in request.submitted_reviews:
+    if user.user_id in request.submitted_reviews:
         raise exceptions.RequestReviewDenied("cannot reset file from submitted review")
 
 
@@ -313,7 +313,7 @@ def check_user_can_submit_review(user: User, request: "ReleaseRequest"):
             "You must review all files to submit your review"
         )
 
-    if user.username in request.submitted_reviews:
+    if user.user_id in request.submitted_reviews:
         raise exceptions.RequestReviewDenied(
             "You have already submitted your review of this request"
         )
@@ -368,7 +368,7 @@ def check_user_can_delete_comment(
     user: User, request: "ReleaseRequest", comment: "Comment"
 ):
     # Only the author of a comment can delete it
-    if not user.username == comment.author:
+    if not user == comment.author:
         raise exceptions.RequestPermissionDenied(
             f"User {user.username} is not the author of this comment, so cannot delete"
         )
@@ -402,7 +402,7 @@ def check_user_can_make_comment_publicly_visible(
     user: User, request: "ReleaseRequest", comment: "Comment"
 ):
     # Only the author of a comment can make it public
-    if not user.username == comment.author:
+    if not user == comment.author:
         raise exceptions.RequestPermissionDenied(
             f"User {user.username} is not the author of this comment, so cannot delete"
         )

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -122,7 +122,7 @@ def user_can_review(user: User):
 
 def check_user_can_review_request(user: User, request: "ReleaseRequest"):
     """This user can be a reviewer for a specific request"""
-    if not (user_can_review(user) and request.author != user.username):
+    if request.author == user.username or not user_can_review(user):
         raise exceptions.RequestPermissionDenied(
             "You do not have permission to review this request"
         )

--- a/airlock/templates/file_browser/request/filegroup.html
+++ b/airlock/templates/file_browser/request/filegroup.html
@@ -57,7 +57,7 @@
           {% endfragment %}
           {% #list_group_rich_item custom_status=comment_status class=comment_class title=comment.author %}
             <div class="prose prose-code:before:hidden prose-code:after:hidden">{{ comment.comment|markdownify }}</div>
-            {% if request.user.username == comment.author %}
+            {% if request.user == comment.author %}
               {% if comment.visibility.name == "PRIVATE" and comment.review_turn == release_request.review_turn %}
                 <div>
                   <form action="{{ group.comment_visibility_public_url }}" method="POST">

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -315,7 +315,7 @@ def request_view(request, request_id: str, path: str = ""):
         path_item, request.user, release_request, workspace
     )
 
-    is_author = release_request.author == request.user.username
+    is_author = release_request.author == request.user
 
     code_url = None
 
@@ -478,9 +478,7 @@ def request_contents(request, request_id: str, path: str):
     # Downloads are not allowed for request authors (including those that are also
     # output checkers)
     if download:
-        if not request.user.output_checker or (
-            release_request.author == request.user.username
-        ):
+        if not request.user.output_checker or (release_request.author == request.user):
             raise PermissionDenied()
 
         bll.audit_request_file_download(release_request, UrlPath(path), request.user)

--- a/airlock/visibility.py
+++ b/airlock/visibility.py
@@ -24,7 +24,7 @@ class RequestFileStatus:
 
 class VisibleItem(Protocol):
     @property
-    def author(self) -> str:
+    def author(self) -> User:
         raise NotImplementedError()
 
     @property
@@ -52,7 +52,7 @@ def filter_visible_items(
         # you can always see things you've authored. Doing this first
         # simplifies later logic, and avoids potential bugs with users adding
         # items but then they can not see the item they just added
-        if item.author == user.username:
+        if item.author == user:
             yield item
             continue
 

--- a/local_db/models.py
+++ b/local_db/models.py
@@ -88,11 +88,11 @@ class RequestMetadata(models.Model):
 
     workspace = models.TextField()
     status = EnumField(default=RequestStatus.PENDING, enum=RequestStatus)
-    author = models.TextField()  # just username, as we have no User model
+    author = models.TextField()  # just user id, as we have no User model
     created_at = models.DateTimeField(default=timezone.now)
     submitted_reviews = models.JSONField(default=dict)
     review_turn = models.IntegerField(default=0)
-    # comma-separated list of submitted reviewers' usernames
+    # comma-separated list of submitted reviewers' user ids
     # we need to store this at the end of a turn
     turn_reviewers = models.TextField(null=True)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -721,12 +721,14 @@ def refresh_release_request(release_request, user=None) -> ReleaseRequest:
 
 def create_audit_event(
     type_,
-    user="user",
+    user=None,
     workspace: str = "workspace",
     request="request",
     path=UrlPath("foo/bar"),
     extra={"foo": "bar"},
 ):
+    if user is None:
+        user = create_airlock_user("user")
     event = AuditEvent(
         type=type_,
         user=user,

--- a/tests/integration/management/commands/test_run_file_uploader.py
+++ b/tests/integration/management/commands/test_run_file_uploader.py
@@ -152,7 +152,8 @@ def test_run_file_uploader_command(upload_files_stubber, bll):
         "workspace": "workspace",
         "group": "group",
         "file": "test/file2.txt",
-        "user": checker.username,
+        "username": checker.username,
+        "user_id": checker.user_id,
     }
 
 
@@ -314,7 +315,8 @@ def test_run_file_uploader_command_unexpected_error(
         "workspace": "workspace",
         "group": "group",
         "file": "test/file2.txt",
-        "user": checker.username,
+        "username": checker.username,
+        "user_id": checker.user_id,
     }
     last_trace_event = last_trace.events[0]
     assert last_trace_event.name == "exception"

--- a/tests/integration/test_visibility.py
+++ b/tests/integration/test_visibility.py
@@ -39,14 +39,14 @@ class VisibleItemsHelper:
 
     def is_comment_visible(self, text: str, author: User) -> bool:
         for c, _ in self.comments:
-            if c.comment == text and c.author == author.username:
+            if c.comment == text and c.author == author:
                 return True
 
         return False
 
     def is_audit_visible(self, type_: AuditEventType, author: User) -> bool:
         for audit in self.audits:
-            if audit.type == type_ and audit.user == author.username:
+            if audit.type == type_ and audit.user == author:
                 return True
 
         return False

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -237,7 +237,9 @@ def test_request_view_submit_review_alert(airlock_client, files, has_message):
     assert ("You have reviewed all files" in response.rendered_content) == has_message
 
     # The all-files-reviewed reminder message is never shown to an author
-    airlock_client.login(username=release_request.author, workspaces=["workspace"])
+    airlock_client.login(
+        username=release_request.author.username, workspaces=["workspace"]
+    )
     response = airlock_client.get(f"/requests/view/{release_request.id}", follow=True)
     assert "You have reviewed all files" not in response.rendered_content
 
@@ -1219,7 +1221,7 @@ def test_file_approve(airlock_client):
         .reviews[airlock_client.user.username]
     )
     assert review.status == RequestFileVote.APPROVED
-    assert review.reviewer == "testuser"
+    assert review.reviewer.username == "testuser"
 
 
 def test_file_request_changes(airlock_client):
@@ -1246,7 +1248,7 @@ def test_file_request_changes(airlock_client):
         .reviews[airlock_client.user.username]
     )
     assert review.status == RequestFileVote.CHANGES_REQUESTED
-    assert review.reviewer == "testuser"
+    assert review.reviewer.username == "testuser"
 
 
 def test_file_reset_review(airlock_client):
@@ -1272,7 +1274,7 @@ def test_file_reset_review(airlock_client):
         airlock_client.user.username
     ]
     assert review.status == RequestFileVote.CHANGES_REQUESTED
-    assert review.reviewer == "testuser"
+    assert review.reviewer.username == "testuser"
 
     # then reset it to have no review
     response = airlock_client.post(
@@ -1968,7 +1970,7 @@ def test_group_comment_create_success(
         assert "Comment added" in messages[0].message
         release_request = bll.get_release_request(release_request.id, author)
         assert release_request.filegroups["group"].comments[0].comment == "opinion"
-        assert release_request.filegroups["group"].comments[0].author == user.username
+        assert release_request.filegroups["group"].comments[0].author == user
     else:
         assert "visibility: Select a valid choice" in messages[0].message
 

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -34,7 +34,7 @@ def test_audits():
         ),
         "other_user": factories.create_audit_event(
             AuditEventType.REQUEST_CREATE,
-            user="other",
+            user=factories.create_airlock_user("other"),
             path=None,
         ),
     }
@@ -248,7 +248,7 @@ def test_group_comment_modify_bad_params(comment_modify_function, audit_event):
         "author comment",
         Visibility.PUBLIC,
         release_request.review_turn,
-        author.username,
+        author,
         audit,
     )
 
@@ -260,9 +260,7 @@ def test_group_comment_modify_bad_params(comment_modify_function, audit_event):
         comment="author comment",
     )
     with pytest.raises(exceptions.APIException):
-        comment_modify_function(
-            release_request.id, "badgroup", "1", author.username, audit
-        )
+        comment_modify_function(release_request.id, "badgroup", "1", author, audit)
 
     audit = AuditEvent.from_request(
         request=release_request,
@@ -272,9 +270,7 @@ def test_group_comment_modify_bad_params(comment_modify_function, audit_event):
         comment="other comment",
     )
     with pytest.raises(models.FileGroupComment.DoesNotExist):
-        comment_modify_function(
-            release_request.id, "group", "50", author.username, audit
-        )
+        comment_modify_function(release_request.id, "group", "50", author, audit)
 
     audit = AuditEvent.from_request(
         request=release_request,
@@ -284,4 +280,4 @@ def test_group_comment_modify_bad_params(comment_modify_function, audit_event):
         comment="author comment",
     )
     with pytest.raises(exceptions.APIException):
-        comment_modify_function(release_request.id, "group", "1", other.username, audit)
+        comment_modify_function(release_request.id, "group", "1", other, audit)

--- a/users/models.py
+++ b/users/models.py
@@ -25,6 +25,9 @@ class User(AbstractBaseUser):
     # Time of last authentication refresh
     last_refresh = models.FloatField(default=time.time)
 
+    def __str__(self):
+        return self.username
+
     @property
     def username(self):
         return self.api_data["username"]


### PR DESCRIPTION
Basically, wherever we used a username string, we now have a db User object.
This is a consistent and more future-proof API, as it allows us natural access to full user data whenever we need it, moves us away from using username (which can change), and allows us to easily change the User model without altering the API again.

The local_db DAL implementation still just persists the user_id, however (which is currently just username, but we expect in future that it could be a different (e.g. Github) id, so we can support renames.

However, doing this when combined with our to_dict/from_dict serialisation barrier between the BLL and the DAL, creates a slightly strange interaction.  Everything in those dicts so far had been native python types, in part because it was kind of simulating a future JSON API with job-server.

But the BLL models need User objects.  So, if the DAL uses user_id to look upthe User, and passes it in the dict, it's not doing its intended purpose of simulating a JSON interface.  So, for this PR, I have made the BLL object's from_dict method responsible for converting a user_id passed from the DAL layer into a full User object. This is also a bit strange, as from_dict is now doing a DB query, which is not ideal. But I think its better than the DAL doing it.

I discussed this design change in detail with Dave, and we came to the conclusion that it is likely that the to_dict/from_dict interface is hoisted too high up, and in future, we will probably want the DAL to both receive and return full BLL objects directly, rather than dicts. This avoids unnecessarily exposing the details of a JSON dict to the BLL.  But that is a future piece of work.

