### PR TITLE
Fix workspace name/repo name mixup

### DIFF
--- a/airlock/models.py
+++ b/airlock/models.py
@@ -375,7 +375,7 @@ class CodeRepo:
 
     def get_url(self, relpath: UrlPath = ROOT_PATH) -> str:
         kwargs = {
-            "workspace_name": self.name,
+            "workspace_name": self.workspace,
             "commit": self.commit,
         }
         if relpath != ROOT_PATH:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -285,7 +285,7 @@ def write_workspace_file(workspace: Workspace | str, path, contents="", manifest
 
 def create_repo(workspace: Workspace | str, files=None, temporary=True) -> CodeRepo:
     workspace = ensure_workspace(workspace)
-    repo_dir = settings.GIT_REPO_DIR / workspace.name
+    repo_dir = settings.GIT_REPO_DIR / f"{workspace.name}-repo"
 
     if files is None:
         files = [

--- a/tests/integration/views/test_code.py
+++ b/tests/integration/views/test_code.py
@@ -12,7 +12,9 @@ def test_code_view_index(airlock_client):
     repo = factories.create_repo("workspace")
 
     response = airlock_client.get(f"/code/view/workspace/{repo.commit}/")
-    assert "project.yaml" in response.rendered_content
+    assert (
+        f"/code/view/workspace/{repo.commit}/project.yaml" in response.rendered_content
+    )
 
 
 def test_code_view_index_return_url(airlock_client):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -499,7 +499,7 @@ def test_code_repo_container():
     factories.write_workspace_file(workspace, "foo.txt")
     repo = factories.create_repo(workspace)
 
-    assert repo.get_id() == f"workspace@{repo.commit[:7]}"
+    assert repo.get_id() == f"{repo.name}@{repo.commit[:7]}"
     assert (
         repo.get_url(UrlPath("project.yaml"))
         == f"/code/view/workspace/{repo.commit}/project.yaml"


### PR DESCRIPTION
This resulted in the code browser generating the wrong URLs in its file menu which meant that the initial load of the `project.yaml` file worked, but clicking any of the other filenames would silently fail (the HTMX call would 403 but no error would be displayed to the user).

In cases where the repo name happened to match the workspace name things would work fine, which is why we didn't spot this locally.

Closes #845