### PR TITLE
Update telemetry with new user details

### DIFF
--- a/airlock/middleware.py
+++ b/airlock/middleware.py
@@ -30,7 +30,8 @@ class UserMiddleware:
         span = trace.get_current_span()
 
         if request.user.is_authenticated:
-            span.set_attribute("user", request.user.username)
+            span.set_attribute("username", request.user.username)
+            span.set_attribute("user_id", request.user.user_id)
             time_since_authz = time.time() - request.user.last_refresh
             if time_since_authz > settings.AIRLOCK_AUTHZ_TIMEOUT:
                 span.set_attribute("auth_refresh", True)
@@ -38,7 +39,8 @@ class UserMiddleware:
                 if user:  # refresh may have failed for some reason
                     request.user = user
         else:
-            span.set_attribute("user", "")
+            span.set_attribute("username", "anonymous")
+            span.set_attribute("user_id", "anonymous")
 
         return self.get_response(request)
 

--- a/services/tracing.py
+++ b/services/tracing.py
@@ -115,7 +115,12 @@ def instrument(
             bound_args = func_signature.bind(*args, **kwargs).arguments
             if "request" in bound_args:
                 user = bound_args["request"].user
-                attributes_dict["user"] = user.username if user else ""
+                if user and user.is_authenticated:
+                    attributes_dict["user_id"] = user.user_id
+                    attributes_dict["username"] = user.username
+                else:  # pragma: nocover
+                    attributes_dict["user_id"] = "anonymous"
+                    attributes_dict["username"] = "anonymous"
 
             if func_attributes is not None:
                 bound_args = func_signature.bind(*args, **kwargs).arguments

--- a/tests/integration/test_middleware.py
+++ b/tests/integration/test_middleware.py
@@ -91,9 +91,14 @@ def test_middleware_user_trace(airlock_client):
     traces = {span.name: span.attributes for span in get_trace()}
     assert traces["mock_django_span"] == {
         "workspace": "workspace",
-        "user": user.username,
+        "username": user.username,
+        "user_id": user.user_id,
     }
-    assert traces["workspace_view"] == {"workspace": "workspace", "user": user.username}
+    assert traces["workspace_view"] == {
+        "workspace": "workspace",
+        "username": user.username,
+        "user_id": user.user_id,
+    }
 
 
 @pytest.mark.django_db
@@ -107,4 +112,7 @@ def test_middleware_user_trace_with_no_user(airlock_client):
 
     assert response.status_code == 200
     traces = {span.name: span.attributes for span in get_trace()}
-    assert traces["mock_django_span"] == {"user": ""}
+    assert traces["mock_django_span"] == {
+        "user_id": "anonymous",
+        "username": "anonymous",
+    }

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -1823,7 +1823,8 @@ def test_request_view_tracing_with_request_attribute(
     last_trace = traces[-1]
     assert last_trace.attributes == {
         "release_request": release_request.id,
-        "user": login_as,
+        "username": login_as,
+        "user_id": login_as,
     }
 
 

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -1153,5 +1153,6 @@ def test_workspace_view_tracing_with_workspace_attribute(
     last_trace = traces[-1]
     assert last_trace.attributes == {
         "workspace": "test-workspace",
-        "user": airlock_client.user.username,
+        "username": airlock_client.user.username,
+        "user_id": airlock_client.user.user_id,
     }


### PR DESCRIPTION
This fixes a missed check in the services instrument to be user.is_authenticated, rather then user existing, as with django.contrib.auth, the user always exists.

Also, track the user_id and username separately, to match the code, and to be ready for when user_id changes.

Additionally, rather than have an emtpy string when there is no user, use the string "anonymous" as it is unambiguous when veiwing the telemetry, and matches the way django.auth.contrib works