### PR TITLE
Use user fullnames on UI

### DIFF
--- a/airlock/templates/_components/header/request/header.html
+++ b/airlock/templates/_components/header/request/header.html
@@ -23,7 +23,7 @@
           <span class="sr-only">User</span>
           <img class="icon" src="/static/icons/person.svg" alt="">
         </dt>
-        <dd>{{ release_request.author }}</dd>
+        <dd>{% airlock_user user=release_request.author %}</dd>
       </div>
       <div>
         <dt>

--- a/airlock/templates/_components/user.html
+++ b/airlock/templates/_components/user.html
@@ -1,0 +1,1 @@
+<span class="user" title="{{ user.username }}">{{ user.fullname }}</span>

--- a/airlock/templates/_includes/header.html
+++ b/airlock/templates/_includes/header.html
@@ -60,7 +60,7 @@
                         "
                   data-testid="switch-user"
                 >
-                  {{ request.user.username }}
+                  {% airlock_user user=request.user %}
                   <span class="opacity-75 ml-1">
                     <img height="16" width="16" class="icon inline-block group-open:hidden" src="/static/icons/keyboard_arrow_down.svg" alt="">
                     <img height="16" width="16" class="icon hidden group-open:inline-block" src="/static/icons/keyboard_arrow_up.svg" alt="">

--- a/airlock/templates/activity.html
+++ b/airlock/templates/activity.html
@@ -44,7 +44,7 @@
         {% for log in activity %}
           <tr>
             <td>{{ log.created_at|date:'Y-m-d H:i' }}</td>
-            <td>{{ log.user }}</td>
+            <td>{% airlock_user user=log.user %}</td>
             <td>{{ log.description }}</td>
             <td>
               <ul>

--- a/airlock/templates/file_browser/request/filegroup.html
+++ b/airlock/templates/file_browser/request/filegroup.html
@@ -55,7 +55,8 @@
               {% pill variant="info" text=comment.created_at|date:"Y-m-d H:i" %}
             </span>
           {% endfragment %}
-          {% #list_group_rich_item custom_status=comment_status class=comment_class title=comment.author %}
+          {% fragment as author %}{% airlock_user user=comment.author %}{% endfragment %}
+          {% #list_group_rich_item custom_status=comment_status class=comment_class title=author %}
             <div class="prose prose-code:before:hidden prose-code:after:hidden">{{ comment.comment|markdownify }}</div>
             {% if request.user == comment.author %}
               {% if comment.visibility.name == "PRIVATE" and comment.review_turn == release_request.review_turn %}

--- a/airlock/templates/requests_for_output_checker.html
+++ b/airlock/templates/requests_for_output_checker.html
@@ -11,7 +11,7 @@
     {% #card title="Outstanding requests awaiting review" %}
       {% #list_group id="outstanding-requests" %}
         {% for release_request, request_progress in outstanding_requests %}
-          {% fragment as title %}{{ release_request.get_short_id }} by {{ release_request.author }}{% endfragment %}
+          {% fragment as title %}{{ release_request.get_short_id }} by {% airlock_user user=release_request.author %}{% endfragment %}
           {% fragment as status %}{% pill variant="primary" text=release_request.status.description %}{% endfragment %}
           {% #list_group_rich_item type="Outstanding request" title=title url=release_request.get_url custom_status=status %}
             <div class="flex flex-col gap-1 text-xs text-slate-600 sm:flex-row">

--- a/airlock/templates/requests_for_researcher.html
+++ b/airlock/templates/requests_for_researcher.html
@@ -8,7 +8,7 @@
   <div class="flex flex-col gap-4 max-w-3xl">
     {% airlock_header title="Requests" %}
 
-    {% #card title="Requests by "|add:request.user.username %}
+    {% #card title="Requests by "|add:request.user.fullname %}
       {% #list_group id="authored-requests" %}
         {% for release_request in authored_requests|dictsortreversed:"created_at" %}
           {% fragment as title %}{{ release_request.get_short_id }}{% endfragment %}

--- a/airlock/templates/requests_for_workspace.html
+++ b/airlock/templates/requests_for_workspace.html
@@ -7,7 +7,7 @@
   {% #card title="All requests in workspace "|add:workspace %}
     {% #list_group id="requests-workspace" %}
       {% for request in requests_for_workspace %}
-        {% #list_group_item href=request.get_url %}{{ request.workspace }} ({{ request.author }}): {{ request.status.name }} {% /list_group_item %}
+        {% #list_group_item href=request.get_url %}{{ request.workspace }} ({% airlock_user user=request.author %}): {{ request.status.name }} {% /list_group_item %}
       {% empty %}
         {% list_group_empty title="No requests" description="There are no requests in this workspace" %}
       {% endfor %}

--- a/airlock/templates/workspaces.html
+++ b/airlock/templates/workspaces.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block metatitle %}{{ workspace_type|title }} for {{ request.user.username }} |  Airlock{% endblock metatitle %}
+{% block metatitle %}{{ workspace_type|title }} for {% airlock_user user=request.user %} |  Airlock{% endblock metatitle %}
 
 {% block content %}
   <div class="flex flex-col gap-4 max-w-3xl">
-    {% airlock_header title=workspace_type|title|add:" for "|add:request.user.username %}
+    {% airlock_header title=workspace_type|title|add:" for "|add:request.user.fullname %}
     {% for project, workspaces in projects.items %}
       {% #card %}
         <details class="group" open>

--- a/airlock/templatetags/airlock_components.py
+++ b/airlock/templatetags/airlock_components.py
@@ -12,6 +12,7 @@ register_components(
         "airlock_request_header": "_components/header/request/header.html",
         "airlock_repo_header": "_components/header/repo/header.html",
         "datatable": "_components/datatable.html",
+        "airlock_user": "_components/user.html",
     },
     register,
 )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -761,7 +761,7 @@ def create_audit_event(
     extra={"foo": "bar"},
 ):
     if user is None:
-        user = create_airlock_user("user")
+        user = create_airlock_user(username="user")
     event = AuditEvent(
         type=type_,
         user=user,

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -84,7 +84,8 @@ def test_request_view_root_summary(airlock_client):
     # supporting files
     assert ">\n      1\n    <" in response.rendered_content
     assert "Recent activity" in response.rendered_content
-    assert "audit_user" in response.rendered_content
+    assert audit_user.username in response.rendered_content
+    assert audit_user.fullname in response.rendered_content
 
 
 def test_request_view_root_group(airlock_client):
@@ -117,7 +118,8 @@ def test_request_view_root_group(airlock_client):
     response = airlock_client.get(f"/requests/view/{release_request.id}/group1/")
     assert response.status_code == 200
     assert "Recent activity" in response.rendered_content
-    assert "audit_user" in response.rendered_content
+    assert audit_user.username in response.rendered_content
+    assert audit_user.fullname in response.rendered_content
     assert "private comment" in response.rendered_content
 
 
@@ -1146,7 +1148,9 @@ def test_requests_for_workspace(airlock_client):
     assert "All requests in workspace test1" in response.rendered_content
     assert "PENDING" in response.rendered_content
     assert author1.username in response.rendered_content
+    assert author1.fullname in response.rendered_content
     assert author2.username in response.rendered_content
+    assert author2.fullname in response.rendered_content
 
 
 @pytest.mark.parametrize("review", [("approve"), ("request_changes"), ("reset_review")])

--- a/tests/local_db/test_data_access.py
+++ b/tests/local_db/test_data_access.py
@@ -34,7 +34,7 @@ def test_audits():
         ),
         "other_user": factories.create_audit_event(
             AuditEventType.REQUEST_CREATE,
-            user=factories.create_airlock_user("other"),
+            user=factories.create_airlock_user(username="other"),
             path=None,
         ),
     }

--- a/users/models.py
+++ b/users/models.py
@@ -33,6 +33,10 @@ class User(AbstractBaseUser):
         return self.api_data["username"]
 
     @property
+    def fullname(self):
+        return self.api_data.get("fullname", self.username)
+
+    @property
     def workspaces(self):
         return self.api_data.get("workspaces", {})
 


### PR DESCRIPTION
The username is available as title tooltip.

This is achevied by implementing new `airlock_user` component. It's very simple, but we may want to do more in future (e.g. link to an view for that user, or provided a better toolip).

Fixes #443 at last