### PR TITLE
Add row numbers and sticky headers to tables

### DIFF
--- a/airlock/renderers.py
+++ b/airlock/renderers.py
@@ -129,9 +129,9 @@ class CSVRenderer(Renderer):
         reader = csv.reader(self.stream)
         headers = next(reader, [])
         header_col_count = len(headers)
-        rows = list(reader)
+        rows = list(enumerate(reader, start=1))
         ctx = {"headers": headers, "rows": rows, "use_datatables": True}
-        if any(len(row) != header_col_count for row in rows):
+        if any(len(row) != header_col_count for _, row in rows):
             ctx["use_datatables"] = False
         return ctx
 

--- a/airlock/templates/file_browser/file_content/csv.html
+++ b/airlock/templates/file_browser/file_content/csv.html
@@ -12,6 +12,12 @@
     {% vite_hmr_client %}
     {% vite_asset "assets/src/scripts/main.js" %}
     {% vite_asset "assets/src/scripts/datatable.js" %}
+    <style>
+      #airlock-table td.datatable-row-number {
+        text-align: right;
+        color: rgb(186 189 197);
+      }
+    </style>
   </head>
 
   <body>
@@ -21,6 +27,11 @@
         {% #datatable column_filter searchable sortable %}
           <thead>
             <tr>
+              <th data-searchable="false">
+                <span class="sort-icon h-4 w-4 [&_img]:h-4 [&_img]:w-4">
+                  {% datatable_sort_icon %}
+                </span>
+              </th>
               {% for header in headers %}
                 <th>
                   <div class="flex flex-row gap-2 items-center">
@@ -34,8 +45,9 @@
             </tr>
           </thead>
           <tbody>
-            {% for row in rows %}
+            {% for index, row in rows %}
               <tr>
+                <td class="datatable-row-number" data-order="{{ index }}">{{ index }}</td>
                 {% for cell in row %}
                   <td data-order="{{ cell }}">{{ cell }}</td>
                 {% endfor %}
@@ -47,6 +59,7 @@
         <table>
           <thead>
             <tr>
+              <th></th>
               {% for header in headers %}
                 <th>
                   {{ header }}
@@ -55,8 +68,9 @@
             </tr>
           </thead>
           <tbody>
-            {% for row in rows %}
+            {% for index, row in rows %}
               <tr>
+                <td>{{ index }}</td>
                 {% for cell in row %}
                   <td>{{ cell }}</td>
                 {% endfor %}

--- a/airlock/templates/file_browser/file_content/csv.html
+++ b/airlock/templates/file_browser/file_content/csv.html
@@ -17,6 +17,15 @@
         text-align: right;
         color: rgb(186 189 197);
       }
+      #airlock-table thead tr {
+        position: sticky;
+      }
+      #airlock-table thead tr:first-child {
+        top: 0;
+      }
+      #airlock-table thead tr:nth-child(2) {
+        top: 2.374em; /* determined via binary search  */
+      }
     </style>
   </head>
 


### PR DESCRIPTION
I gave up trying to figure out how to do the CSS the proper way and so just added a style element to the head.

Preview:
![Screenshot from 2025-03-04 11-30-27](https://github.com/user-attachments/assets/4b72e82f-6426-4192-8ec0-9c99232d0830)


Closes #713