### PR TITLE
Better fullname fallback

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -48,6 +48,7 @@ def create_api_workspace(
 def create_api_user(
     *,
     username: str = "testuser",
+    fullname: str = "Test User",
     workspaces: dict[str, typing.Any] | list[str] | None = None,
     copiloted_workspaces: dict[str, typing.Any] | list[str] | None = None,
     output_checker: bool | None = None,
@@ -71,6 +72,7 @@ def create_api_user(
 
     return dict(
         username=username,
+        fullname=fullname,
         workspaces=_create_workspaces(workspaces),
         copiloted_workspaces=_create_workspaces(copiloted_workspaces),
         output_checker=output_checker or False,
@@ -93,6 +95,7 @@ def _create_workspaces(workspaces):
 def create_airlock_user(
     *,
     username: str = "testuser",
+    fullname: str = "Test User",
     workspaces: dict[str, typing.Any] | list[str] | None = None,
     copiloted_workspaces: dict[str, typing.Any] | list[str] | None = None,
     output_checker: bool | None = None,
@@ -105,6 +108,7 @@ def create_airlock_user(
     """
     api_user = create_api_user(
         username=username,
+        fullname=fullname,
         workspaces=workspaces,
         copiloted_workspaces=copiloted_workspaces,
         output_checker=output_checker,
@@ -114,6 +118,7 @@ def create_airlock_user(
 
 def get_or_create_airlock_user(
     username: str = "testuser",
+    fullname: str = "Test User",
     workspaces: dict[str, typing.Any] | list[str] | None = None,
     copiloted_workspaces: dict[str, typing.Any] | list[str] | None = None,
     output_checker: bool | None = None,
@@ -150,6 +155,7 @@ def get_or_create_airlock_user(
 
     api_user = create_api_user(
         username=username,
+        fullname=fullname,
         workspaces=workspaces,
         copiloted_workspaces=copiloted_workspaces,
         output_checker=output_checker,

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -82,6 +82,7 @@ def output_checker_user(live_server, context):
         context,
         factories.create_api_user(
             username="test_output_checker",
+            fullname="Test Output Checker",
             workspaces={
                 "test-dir2": factories.create_api_workspace(project="Project 2")
             },
@@ -97,6 +98,7 @@ def researcher_user(live_server, context):
         context,
         factories.create_api_user(
             username="test_researcher",
+            fullname="Test Researcher",
             workspaces={
                 "test-dir1": factories.create_api_workspace(project="Test Project")
             },
@@ -112,6 +114,7 @@ def copilot_user(live_server, context):
         context,
         factories.create_api_user(
             username="test_copilot",
+            fullname="Test Copilot",
             workspaces={},
             copiloted_workspaces={
                 "test-dir1": factories.create_api_workspace(project="Test Project")
@@ -131,6 +134,7 @@ def dev_users(tmp_path, settings):
                     "token": "output_checker",
                     "details": factories.create_api_user(
                         username="output_checker",
+                        fullname="Output Checker",
                         output_checker=True,
                         workspaces={},
                     ),
@@ -139,6 +143,7 @@ def dev_users(tmp_path, settings):
                     "token": "output_checker_1",
                     "details": factories.create_api_user(
                         username="output_checker_1",
+                        fullname="Output Checker 2",
                         output_checker=True,
                         workspaces={},
                     ),
@@ -147,6 +152,7 @@ def dev_users(tmp_path, settings):
                     "token": "researcher",
                     "details": factories.create_api_user(
                         username="researcher",
+                        fullname="Researcher",
                         output_checker=False,
                         workspaces={
                             "test-workspace": factories.create_api_workspace(

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -106,7 +106,7 @@ def test_e2e_release_files(
 
     # Click on to workspaces link
     find_and_click(page, page.get_by_test_id("nav-workspaces"))
-    expect(page.locator("body")).to_contain_text("Workspaces for researcher")
+    expect(page.locator("body")).to_contain_text("Workspaces for Researcher")
 
     # Click on the workspace
     find_and_click(page, page.get_by_role("link", name="test-workspace"))

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -17,14 +17,14 @@ def workspaces():
 def test_workspaces_index_as_ouput_checker(live_server, page, output_checker_user):
     # this should only list their workspaces, even though they can access all workspaces
     page.goto(live_server.url + "/workspaces/")
-    expect(page.locator("body")).to_contain_text("Workspaces for test_output_checker")
+    expect(page.locator("body")).to_contain_text("Workspaces for Test Output Checker")
     expect(page.locator("body")).not_to_contain_text("test-dir1")
     expect(page.locator("body")).to_contain_text("test-dir2")
 
 
 def test_workspaces_index_as_researcher(live_server, page, researcher_user):
     page.goto(live_server.url + "/workspaces/")
-    expect(page.locator("body")).to_contain_text("Workspaces for test_researcher")
+    expect(page.locator("body")).to_contain_text("Workspaces for Test Researcher")
     expect(page.locator("body")).to_contain_text("test-dir1")
     expect(page.locator("body")).not_to_contain_text("test-dir2")
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1,0 +1,11 @@
+from tests import factories
+from users.models import User
+
+
+def test_user_model_fullname_fallback():
+    api_data = factories.create_api_user(username="username", fullname="fullname")
+    assert User.from_api_data(api_data).fullname == "fullname"
+    api_data["fullname"] = ""
+    assert User.from_api_data(api_data).fullname == "username"
+    api_data.pop("fullname")
+    assert User.from_api_data(api_data).fullname == "username"

--- a/users/models.py
+++ b/users/models.py
@@ -34,7 +34,7 @@ class User(AbstractBaseUser):
 
     @property
     def fullname(self):
-        return self.api_data.get("fullname", self.username)
+        return self.api_data.get("fullname") or self.username
 
     @property
     def workspaces(self):


### PR DESCRIPTION
A user's `fullname` in job-server can be an empty string, which is not ideal. This changes the fallback to username to trigger on both the absence of a `fullname` key *or* its value being Falsey, i.e. `""`

Partially related to #863 