### PR TITLE
Improve default contents for request_file factory

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -702,7 +702,7 @@ class TestRequestFile:
 def request_file(
     group="group",
     path: UrlPath | str = "test/file.txt",
-    contents="",
+    contents: str = "",
     filetype=RequestFileType.OUTPUT,
     user: User | None = None,
     approved=False,
@@ -716,6 +716,11 @@ def request_file(
     At the right points, this metadata will be used to populate and act on
     a request.
     """
+    # Files with the same contents cannot be uploaded in the same workspace, so if no
+    # contents are provided we use the path to ensure that different files have
+    # different contents.
+    contents = contents or str(path)
+
     return TestRequestFile(
         group=group,
         path=UrlPath(path),


### PR DESCRIPTION
This test previously gave an unhelpful error message about being unable to add a released file to the second request:

    from airlock.enums import RequestStatus

    from . import factories

    def test_multiple_requests(mock_old_api):
        author = factories.create_airlock_user(
            username="author", workspaces=["test1"], output_checker=False
        )
        factories.create_request_at_status(
            "test1",
            author=author,
            status=RequestStatus.APPROVED,
            files=[factories.request_file(approved=True, path="file1.txt")],
        )
        factories.create_request_at_status(
            "test1",
            author=author,
            status=RequestStatus.APPROVED,
            files=[factories.request_file(approved=True, path="file2.txt")],
        )