### PR TITLE
No more grey clickable buttons

### DIFF
--- a/airlock/templates/file_browser/request/request.html
+++ b/airlock/templates/file_browser/request/request.html
@@ -81,7 +81,7 @@
       {% else %}
         <form action="{{ content_buttons.submit_review.url }}" method="POST">
           {% csrf_token %}
-          {% #button type="submit" small=True tooltip=content_buttons.submit_review.tooltip variant="secondary" id="submit-review-button" %}Submit review{% /button %}
+          {% #button type="submit" small=True tooltip=content_buttons.submit_review.tooltip variant="success" id="submit-review-button" %}Submit review{% /button %}
         </form>
       {% endif %}
     {% endif %}
@@ -111,15 +111,15 @@
       {% endif %}
     {% endif %}
     {% if content_buttons.return.show %}
-      {% #modal id="returnRequest" button_small=True button_text="Return request" button_variant="secondary" button_tooltip=content_buttons.return.tooltip %}
+      {% #modal id="returnRequest" button_small=True button_text="Return request" button_tooltip=content_buttons.return.tooltip %}
         {% #card container=True title="Return this request" %}
           <form action="{{ content_buttons.return.url }}" method="POST">
             {% csrf_token %}
             <div class="pb-8">
               {{content_buttons.return.modal_confirm_message}}
             </div>
-            {% #button type="submit" variant="warning" class="action-button" small=True id="return-request-button" %}Return request{% /button %}
-            {% #button variant="primary" type="cancel" small=True %}Cancel{% /button %}
+            {% #button type="submit" variant="primary" class="action-button" small=True id="return-request-button" %}Return request{% /button %}
+            {% #button variant="secondary-outline" type="cancel" small=True %}Cancel{% /button %}
           </form>
         {% /card %}
       {% /modal %}


### PR DESCRIPTION
The only two remaining buttons that were enabled and grey, were the "Submit review" and "Request changes". They are now green and blue respectively when enabled:
![image](https://github.com/user-attachments/assets/0b2f5f22-eec3-4d52-ad3d-3316b0730b2a)

I also changed the colour of the modal after you click "Request changes" so that:
1. The button in the modal has the same colour as the button that triggers it
2. The Cancel button is now white, which seems to be a common UI pattern
![image](https://github.com/user-attachments/assets/8ed0c585-e441-46b9-9b6c-98c8b4f18af6)
