### PR TITLE
A few minor tidy ups to the "loading file" behaviour for large files

### DIFF
--- a/airlock/templates/_components/datatable.html
+++ b/airlock/templates/_components/datatable.html
@@ -1,6 +1,11 @@
+{% load static %}
+
 <div class="table-container">
-  <p class="spinner p-4" data-datatable-spinner>Loading table data...</p>
-  <div class="hidden" data-datatable-wrapper >
+  <p style="padding:24px;font-family:sans-serif;" data-datatable-spinner>
+    Loading table data...
+    <img height="16" width="16" class="icon animate-spin" src="{% static 'icons/progress_activity.svg' %}" alt="">
+  </p>
+  <div style="display:none" data-datatable-wrapper >
     <table
       class="{{ class }}"
       data-datatable

--- a/airlock/templates/file_browser/file_content/csv.html
+++ b/airlock/templates/file_browser/file_content/csv.html
@@ -11,7 +11,6 @@
 
     {% vite_hmr_client %}
     {% vite_asset "assets/src/scripts/main.js" %}
-    {% vite_asset "assets/src/scripts/datatable.js" %}
     <style>
       #airlock-table td.datatable-row-number {
         text-align: right;
@@ -90,6 +89,7 @@
       {% endif %}
 
     </div>
+    {% vite_asset "assets/src/scripts/datatable.js" %}
   </body>
 
 </html>

--- a/assets/src/scripts/datatable.js
+++ b/assets/src/scripts/datatable.js
@@ -107,8 +107,8 @@ function buildTables() {
       if (container) {
         const spinner = container.querySelector("[data-datatable-spinner]");
         const wrapper = container.querySelector("[data-datatable-wrapper]");
-        spinner?.classList.toggle("hidden");
-        wrapper.classList.toggle("hidden");
+        spinner.style.display = 'none'
+        wrapper.style.display = 'block'
       }
 
       // We want to display some visual indication when the table is sorting


### PR DESCRIPTION
In particular for csv files.
- sometimes the css for the class `hidden` is loaded too late and you get a flash of the unstyled table before it has a chance to set the style `display:none`. So we do that with inline styles rather than classes. Also do this for things like the padding and the font of the loading message to avoid them suddenly shifting.
- sometimes the loading message doesn't immediately display when the file is loaded. I think it was because the datatable.js file was immediately being called before the html was loaded and so the UI paint was delayed by the datatable script. By moving this to the end of the file it allows the html to render before the script is called.
- also added a spinner to make it look nicer - though in the occasional situations when the css fails to load in time you don't immediately see it. But this is pretty minor and would be harder to fix than the above.