### PR TITLE
Make tree-view expand to display long file names and nested directories

### DIFF
--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -15,7 +15,7 @@
 
 {% block full_width_content %}
   <div id="file-browser-panel" class="grid grid-cols-4 gap-x-4 flex-1">
-    <div class="border-r border-t bg-white overflow-auto" id="tree-container">
+    <div class="border-r border-t bg-white overflow-auto min-w-full hover:z-10 hover:w-fit hover:shadow-2xl" id="tree-container">
       <ul
         class="tree root tree__root"
         hx-boost="true"

--- a/justfile
+++ b/justfile
@@ -254,6 +254,15 @@ load-example-data: devenv && manifests
       mkdir -p "$workspace_dir/sub_dir_empty"
     done
 
+    # Make a deep directory and long file names
+    workspace_dir="${workspace}_1/sub_dir_deep"
+    mkdir -p "${workspace_dir}"
+    echo "A large file name to test wrapping behaviour" > "${workspace_dir}/a_very_long_file_name_without_any_spaces_at_all.txt"
+    for i in {1..9}; do
+      workspace_dir="${workspace_dir}/another_sub_dir"
+      mkdir -p "${workspace_dir}"
+    done
+
     mkdir -p "$workspace/sub_dir_empty"
 
     tmp=$(mktemp)


### PR DESCRIPTION
Looks like this:

[Screencast from 07-03-25 12:04:35.webm](https://github.com/user-attachments/assets/8ce8bbb5-6ec8-4fac-889e-e8f044f4c024)
