### PR TITLE
Making the csv display a lot more responsive

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,5 +22,13 @@
       "module": "pytest",
       "console": "integratedTerminal"
     },
+    {
+      "name": "Debug: Playwright test file",
+      "type": "debugpy",
+      "request": "launch",
+      "args": ["${file}", "--headed"],
+      "module": "pytest",
+      "console": "integratedTerminal"
+    },
   ]
 }

--- a/airlock/renderers.py
+++ b/airlock/renderers.py
@@ -130,9 +130,9 @@ class CSVRenderer(Renderer):
         headers = next(reader, [])
         header_col_count = len(headers)
         rows = list(enumerate(reader, start=1))
-        ctx = {"headers": headers, "rows": rows, "use_datatables": True}
+        ctx = {"headers": headers, "rows": rows, "use_clusterize_table": True}
         if any(len(row) != header_col_count for _, row in rows):
-            ctx["use_datatables"] = False
+            ctx["use_clusterize_table"] = False
         return ctx
 
 

--- a/airlock/templates/file_browser/_includes/file_content.html
+++ b/airlock/templates/file_browser/_includes/file_content.html
@@ -1,4 +1,9 @@
+{% load static %}
 {% #card id="fileCard" title=path_item.name container=False custom_button=buttons %}
+  <div class="file-loading-message fixed w-full h-full bg-white border-t border-slate-200 pl-4">
+    Loading...
+    <img height="16" width="16" class="icon animate-spin" src="{% static 'icons/progress_activity.svg' %}" alt="">
+  </div>
   <iframe
     class="w-full h-full bg-white border-t border-slate-200 pl-4"
     style="height: 400px;"
@@ -6,6 +11,7 @@
     height="100"
     id="content-iframe"
     sandbox="{{ path_item.iframe_sandbox }} allow-same-origin"
+    onload="document.querySelector('.file-loading-message').style.display = 'none';"
     src="{{ path_item.contents_url }}"
     title="{{ path_item.relpath }}"
   ></iframe>

--- a/airlock/templates/file_browser/file_content/csv.html
+++ b/airlock/templates/file_browser/file_content/csv.html
@@ -29,23 +29,23 @@
       }
 
       /* Ensure the correct sort icon displays */
-      .csv-table-wrapper .clusterize-table-sorter .datatable-icon--ascending,
-      .csv-table-wrapper .clusterize-table-sorter .datatable-icon--descending,
-      .csv-table-wrapper .clusterize-table-sorter .datatable-icon--sorting{
+      .clusterize-table-wrapper .clusterize-table-sorter .datatable-icon--ascending,
+      .clusterize-table-wrapper .clusterize-table-sorter .datatable-icon--descending,
+      .clusterize-table-wrapper .clusterize-table-sorter .datatable-icon--sorting{
         display: none;
       }
-      .csv-table-wrapper .sort-ascending .datatable-icon--ascending {
+      .clusterize-table-wrapper .sort-ascending .datatable-icon--ascending {
         display: block;
       }
-      .csv-table-wrapper .sort-descending .datatable-icon--descending {
+      .clusterize-table-wrapper .sort-descending .datatable-icon--descending {
         display: block;
       }
-      .csv-table-wrapper .table-sorting .datatable-icon--sorting {
+      .clusterize-table-wrapper .table-sorting .datatable-icon--sorting {
         display: block;
       }
-      .csv-table-wrapper .sort-ascending .datatable-icon--no-sort,
-      .csv-table-wrapper .sort-descending .datatable-icon--no-sort,
-      .csv-table-wrapper .table-sorting .datatable-icon--no-sort  {
+      .clusterize-table-wrapper .sort-ascending .datatable-icon--no-sort,
+      .clusterize-table-wrapper .sort-descending .datatable-icon--no-sort,
+      .clusterize-table-wrapper .table-sorting .datatable-icon--no-sort  {
         display: none;
       }
 
@@ -146,7 +146,7 @@
 
     <div id="airlock-table">
       {% if use_clusterize_table %}
-        <div class="csv-table-wrapper min-w-full table-loading">
+        <div class="clusterize-table-wrapper min-w-full table-loading">
           <div class="table-loading-spinner">
             <div class="table-loading-message">
               Loading...
@@ -193,7 +193,7 @@
               </tbody>
             </table>
             {% comment %}
-            The csv renderer relies on the data being passed in a table with
+            The csv clusterize renderer relies on the data being passed in a table with
             id="table-content". display:none ensures the browser doesn't try
             to render it (which is the costly thing we avoid with a virtualized table)
             {% endcomment %}
@@ -207,7 +207,7 @@
             </table>
           </div>
         </div>
-        {% vite_asset "assets/src/scripts/csv-datatable.js" %}
+        {% vite_asset "assets/src/scripts/clusterize-datatable.js" %}
       {% else %}
         <table>
           <thead>

--- a/airlock/templates/file_browser/file_content/csv.html
+++ b/airlock/templates/file_browser/file_content/csv.html
@@ -16,6 +16,8 @@
         text-align: right;
         color: rgb(186 189 197);
       }
+
+      /* Make the header stick to the top */
       #airlock-table thead tr {
         position: sticky;
       }
@@ -25,6 +27,118 @@
       #airlock-table thead tr:nth-child(2) {
         top: 2.374em; /* determined via binary search  */
       }
+
+      /* Ensure the correct sort icon displays */
+      .csv-table-wrapper .clusterize-table-sorter .datatable-icon--ascending,
+      .csv-table-wrapper .clusterize-table-sorter .datatable-icon--descending,
+      .csv-table-wrapper .clusterize-table-sorter .datatable-icon--sorting{
+        display: none;
+      }
+      .csv-table-wrapper .sort-ascending .datatable-icon--ascending {
+        display: block;
+      }
+      .csv-table-wrapper .sort-descending .datatable-icon--descending {
+        display: block;
+      }
+      .csv-table-wrapper .table-sorting .datatable-icon--sorting {
+        display: block;
+      }
+      .csv-table-wrapper .sort-ascending .datatable-icon--no-sort,
+      .csv-table-wrapper .sort-descending .datatable-icon--no-sort,
+      .csv-table-wrapper .table-sorting .datatable-icon--no-sort  {
+        display: none;
+      }
+
+      /* Enable scrolling on the scroll area (unless loading to avoid page jank) */
+      #scrollArea {
+        max-height: calc(100vh - 50px); /* 50px to account for the height of the search input*/
+        overflow: auto;
+      }
+      .table-loading #scrollArea {
+        overflow: hidden;
+      }
+      .table-loading table {
+        min-width: 100%;
+      }
+
+      /* Effects when loading the tables */
+      .table-loading-spinner {
+        opacity: 0;
+        position: absolute;
+        width: 100%;
+        background: white;
+        height: 100%;
+        z-index: 1;
+        pointer-events: none;
+        transition: opacity 0.3s ease-in-out;
+      }
+      .table-loading .table-loading-spinner {
+        opacity: 1;
+      }
+      .table-loading .table-loading-message{
+        opacity: 0;
+        animation: fadeIn 0.2s ease-in-out 100ms forwards;
+      }
+      @keyframes fadeIn {
+        to {
+          opacity: 1;
+        }
+      }
+
+      /* Centering message that appears when loading or no data provided */
+      .clusterize-no-data td{
+        text-align: center;
+      }
+
+      /* Searching... icon */
+      .search-wrapper {
+        position: relative;
+      }
+      .search-wrapper .icon {
+        position: absolute;
+        top: calc(50% - 12px);
+        right: 5px;
+        display: none;
+      }
+      .search-wrapper.searching .icon {
+        display: block;
+      }
+      .search-wrapper.searching input::-webkit-search-cancel-button {
+        display:none;
+      }
+
+      /* Search results message */
+      .search-results {
+        color: #4d4d4d;
+        font-size: 0.9rem;
+        padding-left: 10px;
+      }
+
+      /* The remaining style are the minimal things required by the clusterize.js plugin */
+      /**
+      * Avoid vertical margins for extra tags
+      * Necessary for correct calculations when rows have nonzero vertical margins
+      */
+      .clusterize-extra-row{
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+      }
+
+      /* By default extra tag .clusterize-keep-parity added to keep parity of rows.
+      * Useful when used :nth-child(even/odd)
+      */
+      .clusterize-extra-row.clusterize-keep-parity{
+        display: none;
+      }
+
+      /* During initialization clusterize adds tabindex to force the browser to keep focus
+      * on the scrolling list, see issue #11
+      * Outline removes default browser's borders for focused elements.
+      */
+      .clusterize-content{
+        outline: 0;
+        counter-reset: clusterize-counter;
+      }
     </style>
   </head>
 
@@ -32,37 +146,68 @@
 
     <div id="airlock-table">
       {% if use_datatables %}
-        {% #datatable column_filter searchable sortable %}
-          <thead>
-            <tr>
-              <th data-searchable="false">
-                <span class="sort-icon h-4 w-4 [&_img]:h-4 [&_img]:w-4">
-                  {% datatable_sort_icon %}
-                </span>
-              </th>
-              {% for header in headers %}
-                <th>
-                  <div class="flex flex-row gap-2 items-center">
-                    {{ header }}
-                    <span class="sort-icon h-4 w-4 [&_img]:h-4 [&_img]:w-4">
-                      {% datatable_sort_icon %}
-                    </span>
-                  </div>
-                </th>
-              {% endfor %}
-            </tr>
-          </thead>
-          <tbody>
-            {% for index, row in rows %}
-              <tr>
-                <td class="datatable-row-number" data-order="{{ index }}">{{ index }}</td>
-                {% for cell in row %}
-                  <td data-order="{{ cell }}">{{ cell }}</td>
+        <div class="csv-table-wrapper min-w-full table-loading">
+          <div class="table-loading-spinner">
+            <div class="table-loading-message">
+              Loading...
+              <img height="16" width="16" class="icon animate-spin" src="{% static 'icons/progress_activity.svg' %}" alt="">
+            </div>
+          </div>
+          <span class="search-wrapper">
+            <input type="search" id="search-table" placeholder="Type to search table..."/>
+            <img class="icon animate-spin" src="/static/icons/progress_activity.svg" alt="">
+          </span>
+          <span class="search-results">
+          </span>
+          <div id="scrollArea">
+            <table class="divide-y divide-slate-300
+                          [&_td]:text-slate-700 [&_td]:text-sm [&_td]:p-2
+                          [&_tr]:border-t [&_tr]:border-slate-200 first:[&_tr]:border-t-0 [&_tr]:bg-white even:[&_tr]:bg-slate-50
+                          [&_th]:bg-slate-200 [&_th]:text-slate-900 [&_th]:text-sm [&_th]:font-semibold [&_th]:leading-5 [&_th]:text-left [&_th]:whitespace-nowrap [&_th]:w-auto">
+              <thead id="headersArea">
+                <tr>
+                  <th class="sort-ascending">
+                    <button class="clusterize-table-sorter p-2 relative text-left w-full">
+                      <div class="flex flex-row gap-2 items-center">
+                        <span class="sort-icon h-4 w-4 [&_img]:h-4 [&_img]:w-4">
+                          {% datatable_sort_icon %}
+                        </span>
+                      </div>
+                    </button>
+                  </th>
+                  {% for header in headers %}
+                    <th>
+                      <button class="clusterize-table-sorter p-2 relative text-left w-full">
+                        <div class="flex flex-row gap-2 items-center">
+                          {{ header }}
+                          <span class="sort-icon h-4 w-4 [&_img]:h-4 [&_img]:w-4">
+                            {% datatable_sort_icon %}
+                          </span>
+                        </div>
+                      </button>
+                    </th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody id="contentArea" class="clusterize-content">
+              </tbody>
+            </table>
+            {% comment %}
+            The csv renderer relies on the data being passed in a table with
+            id="table-content". display:none ensures the browser doesn't try
+            to render it (which is the costly thing we avoid with a virtualized table)
+            {% endcomment %}
+            <table id="table-content" style="display:none">
+              <tbody>
+                {% for index, row in rows %}
+                  <tr><td class="datatable-row-number">{{ index }}</td>
+                    {% for cell in row %}<td>{{ cell }}</td>{% endfor %}</tr>
                 {% endfor %}
-              </tr>
-            {% endfor %}
-          </tbody>
-        {% /datatable %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        {% vite_asset "assets/src/scripts/csv-datatable.js" %}
       {% else %}
         <table>
           <thead>
@@ -89,7 +234,6 @@
       {% endif %}
 
     </div>
-    {% vite_asset "assets/src/scripts/datatable.js" %}
   </body>
 
 </html>

--- a/airlock/templates/file_browser/file_content/csv.html
+++ b/airlock/templates/file_browser/file_content/csv.html
@@ -145,7 +145,7 @@
   <body>
 
     <div id="airlock-table">
-      {% if use_datatables %}
+      {% if use_clusterize_table %}
         <div class="csv-table-wrapper min-w-full table-loading">
           <div class="table-loading-spinner">
             <div class="table-loading-message">

--- a/assets/src/scripts/clusterize-datatable.js
+++ b/assets/src/scripts/clusterize-datatable.js
@@ -18,7 +18,7 @@ Clusterize.prototype.insertToDOM = function(rows, cache) {
 }
 
 // Get handles for key elements
-const containerEl = document.querySelector('.csv-table-wrapper');
+const containerEl = document.querySelector('.clusterize-table-wrapper');
 const scrollEl = document.getElementById("scrollArea");
 const contentEl = document.getElementById("contentArea");
 const headerEl = document.getElementById("headersArea");
@@ -33,7 +33,7 @@ const CLASS_SORT_ASC = 'sort-ascending';
 const CLASS_SORT_DESC = 'sort-descending';
 
 // Global markers
-let csvRows = [];
+let tableRows = [];
 let isMarkupGenerated = false;
 let largestColumnItems = [];
 let initialColumnWidths;
@@ -293,12 +293,12 @@ function processRows(sortIndex, isSortAscending) {
     const tableContentRows = tableContent.querySelectorAll('tbody tr');
     tableContentRows.forEach((row, i) => {
       const cells = Array.from(row.children);
-      csvRows.push({
+      tableRows.push({
         markup: row.outerHTML,
         active: true,
         data: cells.map((cell) => cell.textContent.trim()),
       })
-      csvRows[i].data.forEach((item, idx) => {
+      tableRows[i].data.forEach((item, idx) => {
         if(largestColumnItems.length < idx + 1) {
           largestColumnItems.push(item);
         } else if(item.length > largestColumnItems[idx].length){
@@ -313,25 +313,25 @@ function processRows(sortIndex, isSortAscending) {
     // "longest" value will always end up being 10..0 and the 1 tends to be
     // narrower in most fonts. So let's pretend the highest number is made
     // up of 3s to get a reasonable max width that doesn't shift perceptibly
-    largestColumnItems[0] = `${csvRows.length}`.replace(/./g,"3");
+    largestColumnItems[0] = `${tableRows.length}`.replace(/./g,"3");
     isMarkupGenerated = true;
   }
   if (sortIndex || sortIndex === 0) {
-    csvRows.sort((a, b) => {
+    tableRows.sort((a, b) => {
       const valA = a.data[sortIndex];
       const valB = b.data[sortIndex];
       return isSortAscending ? mixedSort(valA, valB) : mixedSort(valB, valA);
     });
   }
-  const markupArray = csvRows.filter(x => x.active).map(x => x.markup);
+  const markupArray = tableRows.filter(x => x.active).map(x => x.markup);
   isEmpty = markupArray.length === 0;
 
-  if (markupArray.length === csvRows.length) {
-    searchResultsMessage = `Showing all ${csvRows.length} rows`;
+  if (markupArray.length === tableRows.length) {
+    searchResultsMessage = `Showing all ${tableRows.length} rows`;
   } else {
     searchResultsMessage = `Showing ${markupArray.length} row${
       markupArray.length === 1 ? '' : 's'
-    } (out of ${csvRows.length})`;
+    } (out of ${tableRows.length})`;
   }
 
   return markupArray;
@@ -380,10 +380,10 @@ function wireUpSearchBox() {
 
   function search() {
     const searchTerms = searchEl.value.toLowerCase().trim().split(/ +/);
-    for (let i = 0; i < csvRows.length; i++) {
-      csvRows[i].active = true;
+    for (let i = 0; i < tableRows.length; i++) {
+      tableRows[i].active = true;
       for (let j = 0; j < searchTerms.length; j++) {
-        csvRows[i].active = csvRows[i].active && csvRows[i].markup.toLowerCase().indexOf(searchTerms[j]) > -1;
+        tableRows[i].active = tableRows[i].active && tableRows[i].markup.toLowerCase().indexOf(searchTerms[j]) > -1;
       }
     }
 

--- a/assets/src/scripts/csv-datatable.js
+++ b/assets/src/scripts/csv-datatable.js
@@ -1,0 +1,448 @@
+import Clusterize from "clusterize.js"
+
+// Clusterize.js (https://clusterize.js.org/) is a library for displaying
+// large tables by only creating a relatively small number of <tr> elements
+// and updating their contents as you scroll.
+// It's good, but missing a key callback so we know when the DOM has been
+// updated. E.g. if a sort only changes things not in the DOM, then the
+// clusterChanged callback is not called. There are things (like knowing
+// when the sort is complete to hide the "sorting" ison) where we need this
+// so patching it here:
+const insertToDOMOriginal = Clusterize.prototype.insertToDOM;
+Clusterize.prototype.insertToDOM = function(rows, cache) {
+  // Call original function
+  insertToDOMOriginal.call(this, rows, cache);
+
+  // Fire domUpdated callback
+  this.options.callbacks.domUpdated && this.options.callbacks.domUpdated();
+}
+
+// Get handles for key elements
+const containerEl = document.querySelector('.csv-table-wrapper');
+const scrollEl = document.getElementById("scrollArea");
+const contentEl = document.getElementById("contentArea");
+const headerEl = document.getElementById("headersArea");
+const searchEl = document.getElementById("search-table");
+const searchResultsEl = document.querySelector(".search-results");
+const searchWrapper = document.querySelector(".search-wrapper");
+const headerCells = [...headerEl.querySelector('tr').children];
+
+// CONST strings
+const CLASS_SORTING = 'table-sorting';
+const CLASS_SORT_ASC = 'sort-ascending';
+const CLASS_SORT_DESC = 'sort-descending';
+
+// Global markers
+let csvRows = [];
+let isMarkupGenerated = false;
+let largestColumnItems = [];
+let initialColumnWidths;
+let isSorting = false;
+let isEmpty = false;
+let searchResultsMessage = '';
+let clusterize;
+let sortColumnPositionX;
+let sortColumn;
+let isSortAscending;
+
+// Wire up the table using Clusterize.js
+clusterize = new Clusterize({
+  rows: processRows(),
+  scrollId: 'scrollArea',
+  contentId: 'contentArea',
+  callbacks: {
+    domUpdated: function() {
+      updateCellWidths();
+    }
+  },
+  no_data_text: "No results match",
+  tag: 'tr' // needed for empty csv files to correctly display "no data" message
+});
+
+wireUpColumnHeaderSortButtons();
+wireUpSearchBox();
+
+// We need to update all the cell widths whenever the window resizes. But
+// we use a debounce function so that the update is not called continuously
+window.addEventListener('resize', debounce(updateCellWidths, 150));
+
+/**
+ * This keeps all the column widths updated when:
+ *  - the table is sorted
+ *  - the table is filtered
+ *  - the table is scrolled
+ */
+function updateCellWidths() {
+  containerEl.classList.remove('table-loading');
+  searchWrapper.classList.remove('searching');
+
+  const firstRowEl = contentEl.querySelector('tr:not(.clusterize-extra-row)');
+  const firstRowCells = [...firstRowEl.children];
+
+  if(!initialColumnWidths) {
+    // Get the font of the first non-row-number table cell element
+    const el = firstRowCells[1] || firstRowCells[0]; // in case empty csv file
+    const font = getFont(el);
+
+    // Get the cell padding
+    const padding = getHorizontalPadding(el);
+    initialColumnWidths = largestColumnItems.map(item => padding + getTextWidth(item, font));
+  }  
+
+  // Update search message
+  searchResultsEl.innerText = searchResultsMessage;
+
+  if (isEmpty) {
+    // First reset the header widths
+    setCellMinWidths(headerCells, 0);
+
+    // Then if sorting (why would you sort an empty table? but you can so...)
+    // update the headers, and stop the sort
+    if(isSorting){
+      endSort()
+    }
+
+    // There is no data so we just want the header to fill available space
+    const extraSpace = containerEl.getBoundingClientRect().width - headerEl.getBoundingClientRect().width;
+    expandCellsToFixedWidth(headerCells.slice(1), extraSpace);
+    return;
+  }
+
+  setCellMinWidths(headerCells, initialColumnWidths);
+  const containerWidth = containerEl.getBoundingClientRect().width;
+  const firstRowWidth = firstRowEl.getBoundingClientRect().width;
+  if (isSorting) {
+    // When you click on a column header to sort a column you would expect the header
+    // to stay in the same place, and not shift left or right. However because the
+    // table column widths might change we need to artificially increase the size of
+    // some and/or change the scroll position of the table to achieve this effect.
+
+    // First we establish how much space is required by:
+    //  - the columns to the left of the sort column
+    //  - the sort column itselft
+    //  - the columns to the right of the sort column
+    let widthToLeft = 0;
+    let widthOfSortColumn = 0;
+    let widthToRight = 0;
+    firstRowCells.forEach((cell, idx) => {
+      const cellWidth = cell.getBoundingClientRect().width;
+      if (idx < sortColumn) { widthToLeft += cellWidth; }
+      else if (idx === sortColumn) { widthOfSortColumn = cellWidth; }
+      else { widthToRight += cellWidth; }
+    });
+    let scrollX = 0;
+    if (widthToLeft < sortColumnPositionX) {
+      // The space required to the left is not enough. If left as it is then the
+      // sort column would shift to the left. So instead we work out how much we
+      // need to expand the columns to the left, and make each of them a bit wider
+      // to accommodate this. We don't make the row number column wider as this
+      // looks a bit odd if it gets really wide.
+      const extraSpace = sortColumnPositionX - widthToLeft;
+      expandCellsToFixedWidth(firstRowCells.slice(1, sortColumn), extraSpace);
+    } else {
+      // The space to the left is enough, but maybe too much. We therefore need
+      // to scroll the table to the left so that the sort column remains in its
+      // original place
+      scrollX = widthToLeft - sortColumnPositionX;
+    }
+    const sortColumnRightHandSideX = sortColumnPositionX + widthOfSortColumn;
+    const availableGapToRightOfSortColumn = containerWidth - sortColumnRightHandSideX;
+    if (widthToRight < availableGapToRightOfSortColumn) {
+      // The columns to the right don't fill the available space. We always want
+      // the table to be full width, so we make each cell to the right bigger to
+      // fill the gap.
+      const extraSpace = availableGapToRightOfSortColumn - widthToRight - 20;
+      expandCellsToFixedWidth(firstRowCells.slice(sortColumn + 1), extraSpace);
+    }
+
+    // We scroll the table to ensure the sort column is in place
+    scrollEl.scrollLeft = scrollX;
+
+    // Also we have now finished the sort
+    endSort()
+  } else {
+    // If we're not sorting then we just want to ensure the table fills the available
+    // space.
+    if (firstRowWidth < containerWidth) {
+      const extraSpace = containerWidth - firstRowWidth - 20;
+      expandCellsToFixedWidth(firstRowCells.slice(1), extraSpace);
+    } else {
+      setCellMinWidths(firstRowCells, firstRowCells.map(x => 0));
+    }
+  }
+}
+
+/*
+ * Resets the sort ensuring all the loading indicators are hidden
+ */
+function endSort() {
+  headerCells[sortColumn].classList.remove(CLASS_SORTING);
+  headerCells[sortColumn].classList.add(isSortAscending ? CLASS_SORT_ASC : CLASS_SORT_DESC);
+  isSorting = false;
+}
+
+/**
+ * Takes an array of table cells and expands them uniformly to fill the
+ * extra available space
+ * @param {HTMLElement[]} cells 
+ * @param {number} width 
+ */
+function expandCellsToFixedWidth(cells, width) {
+  const extraSpacePerCell = Math.max(0, width / cells.length);
+  const cellWidths = cells.map((el, i) => {
+    return el.getBoundingClientRect().width + extraSpacePerCell;
+  });
+  setCellMinWidths(cells, cellWidths);
+}
+
+/**
+ * Sets the min-width style property of an array of table cells. Sets the
+ * value to 'unset' if a 0 min-width is passed.
+ * @param {HTMLElement[]} cells 
+ * @param {number[]} widths 
+ */
+function setCellMinWidths(cells, widths) {
+  cells.forEach((cell, i) => {
+    cell.style.minWidth = widths[i] > 0 ? `${widths[i]}px` : 'unset';
+  });
+}
+
+// 
+/**
+ * Creates a debounced version of a function that delays its execution until after
+ * a specified wait time has elapsed since the last time it was invoked.
+ * @param {Function} func - The function to debounce
+ * @param {number} wait - The number of milliseconds to delay execution
+ * @returns {Function} A debounced version of the input function that:
+ *  - Won't execute `func` until the wait time has passed
+ *  - Resets the wait time if called again during the delay
+ */
+function debounce(func, wait) {
+  let timeout;
+  return (...args) => {
+    const later = () => {
+      timeout = null;
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
+
+/**
+ * We want to ensure that numeric values are sorted numerically and
+ * text values are sorted lexicographically. This sort function
+ * handles both situations - and also the case where a column contains
+ * a mix of both.
+ */
+function mixedSort(a, b) {
+  // Handle null/undefined
+  if (a == null) return -1;
+  if (b == null) return 1;
+  
+  // Convert to numbers if both are numeric strings
+  const numA = Number(a);
+  const numB = Number(b);
+  const isNumA = !isNaN(numA);
+  const isNumB = !isNaN(numB);
+
+  // If both are numbers, compare numerically
+  if (isNumA && isNumB) {
+    return numA - numB;
+  }
+  
+  // If mixed types, numbers come before strings
+  if (isNumA) return -1;
+  if (isNumB) return 1;
+  
+  // Both are strings, compare lexicographically
+  return String(a).localeCompare(String(b));
+}
+
+/**
+ * Escapes special characters in text to so they display correctly in HTML.
+ * Converts &, <, >, ", and ' to their HTML entity equivalents.
+ * See https://stackoverflow.com/a/6234804/596639
+ * @param {string} text The original text to display
+ * @returns {string} HTML-escaped version of the input text
+ */
+function escapeHtml(text) {
+  return text
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+/**
+ * Provides the markup array expected by Clusterize.js, filtered and sorted as appropriate.
+ * @param {int} sortIndex The index of the column to be sorted. Null if no sort.
+ * @param {boolean} isSortAscending Whether the sort is ascending or descending.
+ */
+function processRows(sortIndex, isSortAscending) {
+  if (!isMarkupGenerated) {
+    // First time this is called, so we need to:
+    // - find the table rows from the hidden "#table-content" tables
+    // - extract the text content from each cell for sorting/searching
+    // - mark each row as "active" for the search functionality
+    // - find the longest (string length) in each field to make a guess as to column width
+    //   (this is to reduce the amount the column widths adjust as you sort and filter)
+
+    const tableContent = document.getElementById('table-content');
+    const tableContentRows = tableContent.querySelectorAll('tbody tr');
+    tableContentRows.forEach((row, i) => {
+      const cells = Array.from(row.children);
+      csvRows.push({
+        markup: row.outerHTML,
+        active: true,
+        data: cells.map((cell) => cell.textContent.trim()),
+      })
+      csvRows[i].data.forEach((item, idx) => {
+        if(largestColumnItems.length < idx + 1) {
+          largestColumnItems.push(item);
+        } else if(item.length > largestColumnItems[idx].length){
+          largestColumnItems[idx] = item;
+        }        
+      });
+    })
+
+    //We can remove the, now redundant, html rows
+    tableContent.remove();
+    // The row number column can shift around a bit because currently the
+    // "longest" value will always end up being 10..0 and the 1 tends to be
+    // narrower in most fonts. So let's pretend the highest number is made
+    // up of 3s to get a reasonable max width that doesn't shift perceptibly
+    largestColumnItems[0] = `${csvRows.length}`.replace(/./g,"3");
+    isMarkupGenerated = true;
+  }
+  if (sortIndex || sortIndex === 0) {
+    csvRows.sort((a, b) => {
+      const valA = a.data[sortIndex];
+      const valB = b.data[sortIndex];
+      return isSortAscending ? mixedSort(valA, valB) : mixedSort(valB, valA);
+    });
+  }
+  const markupArray = csvRows.filter(x => x.active).map(x => x.markup);
+  isEmpty = markupArray.length === 0;
+
+  if (markupArray.length === csvRows.length) {
+    searchResultsMessage = `Showing all ${csvRows.length} rows`;
+  } else {
+    searchResultsMessage = `Showing ${markupArray.length} row${
+      markupArray.length === 1 ? '' : 's'
+    } (out of ${csvRows.length})`;
+  }
+
+  return markupArray;
+}
+
+/**
+ * Enables the header sorting.
+ */
+function wireUpColumnHeaderSortButtons() {
+  headerCells.forEach((el, idx) => {
+    const button = el.querySelector('button');
+    button.addEventListener('click', () => {
+      isSortAscending = !el.classList.contains(CLASS_SORT_ASC);
+      headerCells.forEach(header => {
+        header.classList.remove(CLASS_SORTING);
+        header.classList.remove(CLASS_SORT_ASC);
+        header.classList.remove(CLASS_SORT_DESC);
+      });
+      headerCells[idx].classList.add(CLASS_SORTING);
+      isSorting = true;
+      sortColumnPositionX = Math.max(0, headerCells[idx].getBoundingClientRect().x);
+      sortColumn = idx;
+
+      // So that the "sorting" icon can appear we need to push the table
+      // update into the next "tick"
+      setTimeout(() => {
+        clusterize.update(processRows(idx, isSortAscending));
+      },0);
+    });
+  });
+}
+
+/**
+ * Enables the search box.
+ */
+function wireUpSearchBox() {
+  // The search strategy is to split the text input into words and filter
+  // to rows that contain ALL the words, case insensitive.
+
+  // For fast typers we only want the table to attempt to update
+  // during pauses in their typing
+  function updateAfterSearch() {
+    clusterize.update(processRows());
+  }
+  const debouncedUpdate = debounce(updateAfterSearch, 120);
+
+  function search() {
+    const searchTerms = searchEl.value.toLowerCase().trim().split(/ +/);
+    for (let i = 0; i < csvRows.length; i++) {
+      csvRows[i].active = true;
+      for (let j = 0; j < searchTerms.length; j++) {
+        csvRows[i].active = csvRows[i].active && csvRows[i].markup.toLowerCase().indexOf(searchTerms[j]) > -1;
+      }
+    }
+
+    searchWrapper.classList.add('searching');
+
+    // In large files this can be slow, so we push the table update into
+    // the next tick so that the key just pressed appears visible in the
+    // search box before the update. Otherwise it feels laggy.
+    setTimeout(() => {
+      debouncedUpdate();
+    }, 0)
+  }
+  searchEl.addEventListener('input', search);
+}
+
+/**
+ * Measures the width of text in pixels using a canvas context
+ * @param {string} text - The text string to measure
+ * @param {string} font - CSS font specification (e.g. "bold 16px Arial")
+ * @returns {number} The width of the text in pixels
+ */
+function getTextWidth(text, font) {
+  const canvas = getTextWidth.canvas || (getTextWidth.canvas = document.createElement("canvas"));
+  const context = canvas.getContext("2d");
+  context.font = font;
+  const metrics = context.measureText(text);
+  return metrics.width;
+}
+
+/**
+ * Gets the font string of a DOM element
+ * @param {HTMLElement} domElement The element to assess
+ * @returns {string} CSS font specification (e.g. "bold 16px Arial")
+ */
+function getFont(domElement) {
+  const fontWeight = getStyleValue(domElement, 'font-weight', 'normal');
+  const fontSize = getStyleValue(domElement, 'font-size', '16px');
+  const fontFamily = getStyleValue(domElement, 'font-family', 'Times New Roman');
+  return `${fontWeight} ${fontSize} ${fontFamily}`;
+}
+
+/**
+ * Get the horizontal padding (left + right) of a DOM element
+ * @param {HTMLElement} domElement The element to assess
+ * @returns {number} The horizontal padding in pixels
+ */
+function getHorizontalPadding(domElement) {
+  const paddingLeft = Number.parseFloat(getStyleValue(domElement, 'padding-left', 0));
+  const paddingRight = Number.parseFloat(getStyleValue(domElement, 'padding-right', 0));
+  return paddingLeft + paddingRight;
+}
+
+/**
+ * Retrieves the computed style value for a given CSS property of a DOM element
+ * @param {HTMLElement} domElement - The DOM element to get the style from
+ * @param {string} property - The CSS property name to look up
+ * @param {*} valueIfNull - Default value to return if the property is not found
+ * @returns {string} The computed style value or the default value if not found
+ */
+function getStyleValue(domElement, property, valueIfNull) {
+  return window.getComputedStyle(domElement).getPropertyValue(property) || valueIfNull;
+}

--- a/justfile
+++ b/justfile
@@ -272,6 +272,10 @@ load-example-data: devenv && manifests
 
     cp example-data/bennett.svg $workspace/output/sample.svg
 
+    # Make a large csv file
+    cp $workspace/output/rows.csv $workspace/output/rows_LARGE.csv
+    for i in {1..4}; do cat $workspace/output/rows.csv >> $workspace/output/rows_LARGE.csv; done
+
     request_dir="${AIRLOCK_WORK_DIR%/}/${AIRLOCK_REQUEST_DIR%/}/example-workspace/test-request"
     mkdir -p $request_dir
     cp -a $workspace/output $request_dir

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@fontsource-variable/public-sans": "^5.1.1",
+        "clusterize.js": "^1.0.0",
         "htmx.org": "^2.0.3",
         "simple-datatables": "^9.1.0"
       },
@@ -1047,6 +1048,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/clusterize.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clusterize.js/-/clusterize.js-1.0.0.tgz",
+      "integrity": "sha512-EEYhO8rOvw9JVaHLgEFdvvg9H6ug/GVl8KgakOoc9hg4FK6xmyYsC4B0Aw/QI6ClPxaGPKBetO+ISvCY8N/uUQ==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@fontsource-variable/public-sans": "^5.1.1",
+    "clusterize.js": "^1.0.0",
     "htmx.org": "^2.0.3",
     "simple-datatables": "^9.1.0"
   }

--- a/tests/functional/csv_generator.py
+++ b/tests/functional/csv_generator.py
@@ -53,6 +53,9 @@ def csv_row(draw, columns):
     return tuple(_escape_csv_field(draw(column)) for column in columns)
 
 
+ascii_lowers = functools.partial(
+    text, min_size=1, max_size=20, alphabet=string.ascii_lowercase
+)
 valid_column_types = [
     integers,
     floats,
@@ -61,7 +64,13 @@ valid_column_types = [
 
 
 @composite
-def csv_rows(draw, num_columns: int = 5, min_lines: int = 2, max_lines: int = 10):
+def csv_rows(
+    draw,
+    num_columns: int = 5,
+    min_lines: int = 2,
+    max_lines: int = 10,
+    just_text: bool = False,
+):
     """
     Strategy to produce a list of csv rows
 
@@ -73,8 +82,8 @@ def csv_rows(draw, num_columns: int = 5, min_lines: int = 2, max_lines: int = 10
     Returns:
       list[tuple]: a list of csv rows as tuples
     """
-
-    columns = [draw(sampled_from(valid_column_types))() for _ in range(num_columns)]
+    column_types = [ascii_lowers] if just_text else valid_column_types
+    columns = [draw(sampled_from(column_types))() for _ in range(num_columns)]
     rows = draw(
         lists(
             csv_row(columns=columns),
@@ -86,7 +95,13 @@ def csv_rows(draw, num_columns: int = 5, min_lines: int = 2, max_lines: int = 10
 
 
 @composite
-def csv_file(draw, num_columns: int = 5, min_lines: int = 2, max_lines: int = 10):
+def csv_file(
+    draw,
+    num_columns: int = 5,
+    min_lines: int = 2,
+    max_lines: int = 10,
+    just_text: bool = False,
+):
     """
     Strategy to produce a CSV file as a string. Uses `csv_rows` strategy to
     generate the data.
@@ -102,7 +117,12 @@ def csv_file(draw, num_columns: int = 5, min_lines: int = 2, max_lines: int = 10
 
     rows = list(
         draw(
-            csv_rows(min_lines=min_lines, max_lines=max_lines, num_columns=num_columns)
+            csv_rows(
+                min_lines=min_lines,
+                max_lines=max_lines,
+                num_columns=num_columns,
+                just_text=just_text,
+            )
         )
     )
 

--- a/tests/functional/test_csv_viewer.py
+++ b/tests/functional/test_csv_viewer.py
@@ -261,7 +261,7 @@ def test_csv_scroll(live_server, page, context):
     page.locator("tbody").hover()
     for i in range(num_rows):
         row_locator = page.get_by_text(f"value{i}", exact=True)
-        if not row_locator.is_visible():  # pragma: no cover (if we ever revert to non-virtualized tables then this is never True)
+        if not row_locator.is_visible():  # pragma: no branch (if we ever revert to non-virtualized tables then this is never True)
             # We need to scroll the table sufficiently so the next row appears.
             # This scrolls 6000 pixels which seems to be about right. NB "visible"
             # in the playwright context means it is potentially visible, even if

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -378,22 +378,22 @@ def test_csv_filtering(live_server, page, context, bll):
     for age_band in age_bands:
         expect(page.locator("body")).to_contain_text(age_band)
 
-    # Filter the mean column to value 20 (in age band 21-40)
-    column_filter = page.get_by_placeholder("Filter mean")
-    column_filter.fill("20")
-    expect(page.locator("body")).to_contain_text("21-40")
+    # Filter to rows with a "30"
+    table_filter = page.get_by_role("searchbox")
+    table_filter.fill("30")
+    expect(page.locator("body")).to_contain_text("41-60")
 
-    for age_band in age_bands - {"21-40"}:
+    for age_band in age_bands - {"41-60"}:
         expect(page.locator("body")).not_to_contain_text(age_band)
 
     # Filter the mean column to a value that doesn't match anything
-    column_filter.fill("foo")
+    table_filter.fill("foo")
     for age_band in age_bands:
         expect(page.locator("body")).not_to_contain_text(age_band)
     expect(page.locator("body")).to_contain_text("No results match")
 
     # Reset the filter by removing text
-    column_filter.fill("")
+    table_filter.fill("")
     for age_band in age_bands:
         expect(page.locator("body")).to_contain_text(age_band)
 

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -126,7 +126,7 @@ def test_csv_renderer_handles_empty_file(tmp_path):
 def test_csv_renderer_handles_uneven_columns(tmp_path):
     # CSVs without the equal numbers of columns per row
     # can be rendered in a plain html table, but not with datatables
-    bad_csv = tmp_path / "empty.csv"
+    bad_csv = tmp_path / "bad.csv"
     bad_csv.write_text("Foo Bar\nfoo,bar")
     relpath = bad_csv.relative_to(tmp_path)
     Renderer = renderers.get_renderer(relpath)
@@ -134,7 +134,19 @@ def test_csv_renderer_handles_uneven_columns(tmp_path):
     response = renderer.get_response()
     response.render()
     assert response.status_code == 200
-    assert response.context_data["use_datatables"] is False
+    assert response.context_data["use_clusterize_table"] is False
+
+
+def test_csv_renderer_uses_faster_csv_renderer(tmp_path):
+    good_csv = tmp_path / "good.csv"
+    good_csv.write_text("Foo,Bar\nfoo,bar")
+    relpath = good_csv.relative_to(tmp_path)
+    Renderer = renderers.get_renderer(relpath)
+    renderer = Renderer.from_file(good_csv, relpath)
+    response = renderer.get_response()
+    response.render()
+    assert response.status_code == 200
+    assert response.context_data["use_clusterize_table"] is True
 
 
 def test_plaintext_renderer_handles_invalid_utf8(tmp_path):

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         datatable: "assets/src/scripts/datatable.js",
-        "csv-datatable": "assets/src/scripts/csv-datatable.js",
+        "clusterize-datatable": "assets/src/scripts/clusterize-datatable.js",
         htmx: "assets/src/scripts/htmx.js",
         main: "assets/src/scripts/main.js",
         resizer: "assets/src/scripts/resizer.js",

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
     rollupOptions: {
       input: {
         datatable: "assets/src/scripts/datatable.js",
+        "csv-datatable": "assets/src/scripts/csv-datatable.js",
         htmx: "assets/src/scripts/htmx.js",
         main: "assets/src/scripts/main.js",
         resizer: "assets/src/scripts/resizer.js",


### PR DESCRIPTION
Currently we use the simple-datatables library to display csv files. Because this requires rendering the entire table it can become a bit laggy, particularly when sorting and searching (searching isn't too bad except as it's incremental as you type, but is not great when you clear the selection). The sort of files we display in output checking are likely to be pretty small. But even so, users have noticed the slowness, and so we recently added better visual indications that something was happening when the table was loading and sorting.

This draft PR is an attempt to display the csv files in a much more responsive way. It uses a library called clusterize.js which solves the rendering problem of large tables by only actually creating DOM nodes for a few hundred rows at a time and updating them on scrolling and sorting. This PR currently displays csv files with the old method, unless they contain the string `faster` in which case they use the new way so you can compare the behaviour side by side.  `just load-example-data` will set up `example-workspace` with `rows.csv` and `rows-faster.csv` - identical files except the latter will display with the new method. There are also `rows-LARGE.csv` and `rows-LARGE-faster.csv` which are again identical and are simply csvs 5x larger than the `rows.csv` to really demonstrate the difference.

Pros:
- This will work for csv files of millions of rows - we don't need that but it's nice that this will never hit problems
- The loading, sorting, and searching are all a lot more responsive than before

Cons:
- Relies on the clusterize.js library which hasn't been updated for a while, and in fact I needed to monkey patch a callback. However partly the reason for not being updated is that it works well and is stable (I've used in previous projects with no issues) so maybe not a problem.
- clusterize.js only deals with the "display large numbers of rows" problem and so you need to implement things like "search" and "sort" yourself. That is done in this PR but if we needed to add something like pagination it is no longer a one line change - though we could always revert to simple-datatables for paginated tables.
- The column widths change depending on the rows currently in the DOM. This PR code keeps these widths updated, and does sensible things like ensuring when you sort a column, the column you click on doesn't move. However it's possible that some people might not like it.