### PR TITLE
Remove dummy methods from AirlockContainer

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -50,14 +50,6 @@ class AirlockContainer(Protocol):
     def get_file_metadata(self, relpath: UrlPath) -> FileMetadata | None:
         """Get the file metadata"""
 
-    def get_workspace_file_status(self, relpath: UrlPath) -> WorkspaceFileStatus | None:
-        """Get workspace state of file."""
-
-    def get_request_file_status(
-        self, relpath: UrlPath, user: User
-    ) -> RequestFileStatus | None:
-        """Get request status of file."""
-
 
 @dataclass
 class PathItem:
@@ -582,10 +574,11 @@ def get_path_tree(
                 # get_path_tree needs to work with both Workspace and
                 # ReleaseRequest containers, so we have these container specfic
                 # calls
-                node.workspace_status = container.get_workspace_file_status(path)
+                if isinstance(container, Workspace):
+                    node.workspace_status = container.get_workspace_file_status(path)
 
                 # user is required for request status, due to visibility
-                if user:
+                if isinstance(container, ReleaseRequest) and user:
                     node.request_status = container.get_request_file_status(path, user)
 
             tree.append(node)

--- a/airlock/models.py
+++ b/airlock/models.py
@@ -260,11 +260,6 @@ class Workspace:
 
         return WorkspaceFileStatus.UNRELEASED
 
-    def get_request_file_status(
-        self, relpath: UrlPath, user: User
-    ) -> RequestFileStatus | None:
-        return None  # pragma: nocover
-
     def get_requests_url(self):
         return reverse(
             "requests_for_workspace",
@@ -434,14 +429,6 @@ class CodeRepo:
 
     def request_filetype(self, relpath: UrlPath) -> RequestFileType | None:
         return RequestFileType.CODE
-
-    def get_workspace_file_status(self, relpath: UrlPath) -> WorkspaceFileStatus | None:
-        return None
-
-    def get_request_file_status(
-        self, relpath: UrlPath, user: User
-    ) -> RequestFileStatus | None:
-        return None  # pragma: nocover
 
 
 @dataclass(frozen=True)
@@ -725,9 +712,6 @@ class ReleaseRequest:
             rfile.timestamp,
             _content_hash=rfile.file_id,
         )
-
-    def get_workspace_file_status(self, relpath: UrlPath) -> WorkspaceFileStatus | None:
-        return None
 
     def get_request_file_status(
         self, relpath: UrlPath, user: User


### PR DESCRIPTION
* we assert that both Workspaces and ReleaseRequests conform to the AirlockContainer protocol
* but these methods are only applicable to the specific types
* they return None if not applicable, but PathItem already has None as the default value for these attributes