### PR TITLE
Add hypothesis tests to check that randomly generated csv files display correctly in airlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ test-results/
 # Node.js
 node_modules/
 assets/out
+
+# Hypothesis outputs
+.hypothesis

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -5,6 +5,7 @@
 django-debug-toolbar
 django-debug-toolbar-template-profiler
 djhtml
+hypothesis
 ruff
 pip-tools
 pytest

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,6 +11,10 @@ asgiref==3.8.1 \
     #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
     #   django
     #   django-stubs
+attrs==25.3.0 \
+    --hash=sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3 \
+    --hash=sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b
+    # via hypothesis
 build==1.2.2.post1 \
     --hash=sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5 \
     --hash=sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7
@@ -301,6 +305,10 @@ greenlet==3.1.1 \
     --hash=sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79 \
     --hash=sha256:f6ff3b14f2df4c41660a7dec01045a045653998784bf8cfcb5a525bdffffbc8f
     # via playwright
+hypothesis==6.130.0 \
+    --hash=sha256:274050b4518611500a55f7a5d0247a5359dce0107cb20f10323d6b587cc522d2 \
+    --hash=sha256:b75e6fc4738d2e2a1b75d151432cb06e1303de3142905cd7060ba293c18376ce
+    # via -r requirements.dev.in
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
@@ -519,6 +527,10 @@ six==1.17.0 \
     # via
     #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
     #   python-dateutil
+sortedcontainers==2.4.0 \
+    --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \
+    --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+    # via hypothesis
 sqlparse==0.5.3 \
     --hash=sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272 \
     --hash=sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca

--- a/tests/functional/csv_generator.py
+++ b/tests/functional/csv_generator.py
@@ -1,0 +1,123 @@
+"""
+A Hypothesis strategy for generating valid CSV files
+"""
+
+import functools
+import string
+from csv import writer
+from io import StringIO
+
+from hypothesis.strategies import (
+    composite,
+    floats,
+    integers,
+    lists,
+    sampled_from,
+    text,
+)
+
+
+def _records_to_csv(rows, lineterminator):
+    """
+    Convert the results into a csv string
+    """
+    f = StringIO()
+    w = writer(f, lineterminator=lineterminator)
+    for row in rows:
+        w.writerow(row)
+
+    return f.getvalue()
+
+
+def _escape_csv_field(field) -> str:
+    field = str(field)
+
+    # Carriage return characters (\r) become newline (\n) characters in the html
+    # This is fine, but annoying for the tests which then fail. So easier to just
+    # exclude them as a possible csv character
+    while "\r" in field:
+        field = field.replace("\r", "_")
+    return str(field)
+
+
+@composite
+def csv_row(draw, columns):
+    """
+    Strategy to produce a single csv row
+
+    Args:
+      columns: a list of hypothesis strategies, one per column
+
+    Returns:
+      tuple: the csv row
+    """
+    return tuple(_escape_csv_field(draw(column)) for column in columns)
+
+
+valid_column_types = [
+    integers,
+    floats,
+    functools.partial(text, min_size=1, max_size=20, alphabet=string.printable),
+]
+
+
+@composite
+def csv_rows(draw, num_columns: int = 5, min_lines: int = 2, max_lines: int = 10):
+    """
+    Strategy to produce a list of csv rows
+
+    Args:
+      num_columns: The number of columns to generate
+      min_lines: The minimum number of rows in the CSV
+      max_lines: The maximum number of rows in the CSV
+
+    Returns:
+      list[tuple]: a list of csv rows as tuples
+    """
+
+    columns = [draw(sampled_from(valid_column_types))() for _ in range(num_columns)]
+    rows = draw(
+        lists(
+            csv_row(columns=columns),
+            min_size=min_lines,
+            max_size=max_lines,
+        )
+    )
+    return rows
+
+
+@composite
+def csv_file(draw, num_columns: int = 5, min_lines: int = 2, max_lines: int = 10):
+    """
+    Strategy to produce a CSV file as a string. Uses `csv_rows` strategy to
+    generate the data.
+
+    Args:
+      num_columns: The number of columns to generate
+      min_lines: The minimum number of rows in the CSV
+      max_lines: The maximum number of rows in the CSV
+
+    Returns:
+      str: a string in CSV format
+    """
+
+    rows = list(
+        draw(
+            csv_rows(min_lines=min_lines, max_lines=max_lines, num_columns=num_columns)
+        )
+    )
+
+    # The headers in our html table contain lots of whitespace because of the styling
+    # and the presence of the sorting icons. If a header in the csv has any leading or
+    # trailing whitespace then it's impossible to tell how much from the rendered table.
+    # So to make life easier let's just generate csv files that don't have leading or
+    # trailing spaces in the first row
+    rows[0] = ["_" if field.strip() == "" else field.strip() for field in rows[0]]
+
+    # Whether the line terminator is \r\n (excel, windows) or \n (linux/unix)
+    lineterminator = draw(sampled_from(["\r\n", "\n"]))
+
+    return _records_to_csv(
+        rows=rows,
+        lineterminator=lineterminator,
+    )

--- a/tests/functional/csv_generator.py
+++ b/tests/functional/csv_generator.py
@@ -35,8 +35,7 @@ def _escape_csv_field(field) -> str:
     # Carriage return characters (\r) become newline (\n) characters in the html
     # This is fine, but annoying for the tests which then fail. So easier to just
     # exclude them as a possible csv character
-    while "\r" in field:
-        field = field.replace("\r", "_")
+    field = field.replace("\r", "_")
     return str(field)
 
 

--- a/tests/functional/test_csv_viewer.py
+++ b/tests/functional/test_csv_viewer.py
@@ -1,0 +1,108 @@
+import csv
+import sys
+from io import StringIO
+
+from hypothesis import given, settings
+
+from airlock.types import UrlPath
+from tests import factories
+
+from .conftest import login_as_user
+from .csv_generator import csv_file
+
+
+# An attempt to check that when a csv file is displayed in airlock, it contains
+# the same content as the underlying file.
+#
+# I initially tried to use playwright.evaluate() to pull out the table contents
+# and then compare it to the csv file in the python test. However string
+# escaping was problematic e.g. a csv containing a carriage return (\r) would
+# end up as a newline (\n) by the time it had come back to the test. Similarly
+# escaped strings like hex (\x00) and unicode (\u0000) would turn from raw
+# strings into their corresponding hex/unicode characters.
+#
+# So this is why we instead pass the csv file into pyright.evaluate() and let
+# the evaluated javascript do the comparison, before returning an array of any
+# failures
+
+
+@given(csv_file=csv_file(min_lines=2, max_lines=10, num_columns=5))
+@settings(deadline=None)
+def test_csv_renders_all_text(live_server, browser, csv_file):
+    # Normally we pass "context" and "page" as per function fixtures.
+    # However hypothesis would then use the same context/page for each
+    # test run and occasionally caching causes tests to fail. So instead
+    # we create a new context and page for each test run
+    context = browser.new_context()
+    page = context.new_page()
+    workspace = factories.create_workspace("my-workspace")
+
+    factories.write_workspace_file(
+        workspace,
+        "outputs/file1.csv",
+        csv_file,
+    )
+    login_as_user(
+        live_server,
+        context,
+        user_dict=factories.create_api_user(
+            username="author",
+            workspaces={
+                "my-workspace": factories.create_api_workspace(project="Project 2"),
+            },
+        ),
+    )
+
+    page.goto(
+        live_server.url + workspace.get_contents_url(UrlPath("outputs/file1.csv"))
+    )
+
+    reader = csv.reader(StringIO(csv_file), delimiter=",")
+    csv_list = []
+    for row in reader:  # each row is a list
+        csv_list.append(row)
+
+    failures = page.evaluate(
+        """(csv_list) => {
+            let failures = [];
+
+            // First we get the contents of the header row
+            const headerRow = document.querySelector('thead tr');
+            const headerRowCells = Array.from(headerRow.querySelectorAll('th'));
+            // This assumes the first column are the row numbers so we ignore them
+            const headerValues = headerRowCells.map(cell => cell.textContent.trim()).slice(1);
+
+            // Next we get the table rows
+            const bodyRows = Array.from(document.querySelector('tbody').querySelectorAll('tr'));
+            const rowValues = bodyRows.map((row) => {
+                return Array.from(row.querySelectorAll('td')).map(cell => cell.textContent).slice(1)
+            });
+
+            // We add the headers back to the rowValues array as the first row
+            rowValues.unshift(headerValues);
+
+            // For each row in the actual csv file, we check that it is the same
+            // as what is displayed in the table.
+            csv_list.forEach((row, i) => {
+              if(JSON.stringify(row) !== JSON.stringify(rowValues[i])) {
+                failures.push(`The csv row ${JSON.stringify(row)} does not match the table row ${JSON.stringify(rowValues[i])}. In case it's useful the table row is ${rowValues[i]} before passed to JSON.strinfigy.`)
+              }
+            })
+
+            // Finally we check that the number of rows in the csv file matches the html table
+            if(csv_list.length !== rowValues.length) {
+              failures.push(`CSV has ${csv.length} rows, but HTML table has ${rowValues.length}`);
+            }
+            return failures;
+          }
+        """,
+        csv_list,
+    )
+
+    assert len(failures) == 0, print(repr(failures))
+
+    # In theory we should tidy up by closing the context. But there is a bug which
+    # causes this test to hang when run with coverage turned on. So we check to see
+    # if coverage is on, and if not we tidy up.
+    if "coverage" not in sys.modules.keys():  # pragma: no cover
+        context.close()

--- a/tests/functional/test_csv_viewer.py
+++ b/tests/functional/test_csv_viewer.py
@@ -58,9 +58,7 @@ def test_csv_renders_all_text(live_server, browser, csv_file):
     )
 
     reader = csv.reader(StringIO(csv_file), delimiter=",")
-    csv_list = []
-    for row in reader:  # each row is a list
-        csv_list.append(row)
+    csv_list = list(reader)
 
     failures = page.evaluate(
         """(csv_list) => {
@@ -104,5 +102,9 @@ def test_csv_renders_all_text(live_server, browser, csv_file):
     # In theory we should tidy up by closing the context. But there is a bug which
     # causes this test to hang when run with coverage turned on. So we check to see
     # if coverage is on, and if not we tidy up.
+    # This (https://github.com/HypothesisWorks/hypothesis/issues/4052) is possibly the
+    # same bug. But it's not clear whether it's hypothesis, pytest or coverage at fault
+    # and it seeems to get fixed in higher versions of python. Maybe can test if it's
+    # still a problem if we move higher than python 3.11
     if "coverage" not in sys.modules.keys():  # pragma: no cover
         context.close()


### PR DESCRIPTION
Currently to display a csv file in airlock we:
- read the file from disk
- parse it with `csv.reader()`
- render it to a HTML table via a Django template
- enhance the table with a client side javascript library
If there was a bug somewhere in this flow, then in theory you could have a csv file that displayed differently in airlock. This is an attempt to write tests to confirm that this will never happen.