### PR TITLE
Improve template caching

### DIFF
--- a/airlock/renderers.py
+++ b/airlock/renderers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import hashlib
 import mimetypes
 import re
 from dataclasses import dataclass
@@ -28,11 +29,36 @@ class RendererTemplate:
 
     @classmethod
     def from_name(cls, name: str) -> Self:
-        template = cast(Template, loader.get_template(name))
-        return cls(name, template=template, path=Path(template.origin.name))
+        template = cls.get_template(name)
+        return cls(
+            name,
+            template=template,
+            path=Path(template.origin.name),
+        )
+
+    @staticmethod
+    def get_template(name) -> Template:
+        return cast(Template, loader.get_template(name))
+
+    @staticmethod
+    def content_key(template: Template) -> str:
+        # loader.get_template() returns a different Template depending on
+        # which template engine is used. Usually this will be a DjangoTemplates
+        # engine (django.template.backends.django.Template), but we cast it to the
+        # publicly exposed django.template.Template. Both versions of Template have
+        # a .render() method which works for the response, but django.template.Template
+        # doesn't have a template attribute, which we need for getting the source content
+        # So we just tell mypy to ignore here.
+        return hashlib.sha256(template.template.source.encode()).hexdigest()  # type: ignore
 
     def cache_id(self):
-        return filesystem_key(self.path.stat())
+        # cache the template using its content rather than filesystem data
+        # Django caches templates by default, so loading the template again
+        # is cheap
+        # We don't want to use the template mtime in the cache ID because it
+        # will change after a deploy, even if the content is the same
+        template = self.get_template(self.name)
+        return self.content_key(template)
 
 
 @dataclass

--- a/airlock/views/helpers.py
+++ b/airlock/views/helpers.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from email.utils import parsedate
 
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -88,13 +87,7 @@ def serve_file(request, renderer):
     Handles sending 304 Not Modified if possible.
     """
 
-    last_requested = request.headers.get("If-Modified-Since")
-
     if request.headers.get("If-None-Match") == renderer.etag:
-        response = HttpResponseNotModified(headers=renderer.headers())
-    elif last_requested and parsedate(last_requested) >= parsedate(
-        renderer.last_modified
-    ):
         response = HttpResponseNotModified(headers=renderer.headers())
     else:
         response = renderer.get_response()

--- a/tests/integration/views/test_helpers.py
+++ b/tests/integration/views/test_helpers.py
@@ -1,7 +1,14 @@
+import os
+from email.utils import formatdate
+
 from django.contrib.messages.api import get_messages
 from django.contrib.messages.storage.session import SessionStorage
 from django.contrib.sessions.backends.db import SessionStore
-from django.template import Context, Template
+from django.template import (  # type: ignore
+    Context,
+    Template,
+    autoreload,
+)
 from django.test import RequestFactory
 
 from airlock import forms, renderers
@@ -35,6 +42,76 @@ def test_serve_file(tmp_path, rf):
     )
     response = helpers.serve_file(request, renderer)
     assert response.status_code == 200
+
+
+def test_serve_file_template_changes(tmp_path, rf, settings):
+    settings.TEMPLATES = [
+        {
+            "BACKEND": "django.template.backends.django.DjangoTemplates",
+            "DIRS": [tmp_path],
+            "APP_DIRS": False,
+            "OPTIONS": {"debug": True},
+        },
+    ]
+
+    template_file = tmp_path / "test_template.html"
+    template_file.write_text("{{ text }}")
+
+    class TestRenderer(renderers.TextRenderer):
+        template = renderers.RendererTemplate.from_name("test_template.html")
+
+    test_file = tmp_path / "test.foo"
+    test_file.write_text("foo")
+
+    # set the time on both the test and template file to 03 Jan 2025
+    time = 1735900200
+    os.utime(test_file, (time, time))
+    os.utime(template_file, (time, time))
+
+    renderer = TestRenderer.from_file(test_file)
+    assert renderer.last_modified == formatdate(time, usegmt=True)
+
+    request = rf.get("/")
+    response = helpers.serve_file(request, renderer)
+    assert response.status_code == 200
+    assert response.rendered_content == "foo"
+
+    # update the template
+    template_file.write_text("{{ text }}123")
+
+    # Clear the template cache. In a development environment, django's template
+    # autoreloader would do this for us
+    # https://github.com/django/django/blob/5.1.7/django/template/autoreload.py#L55
+    # In production, it's irrelevant, because the template cache is in-memory, and
+    # templates won't change without a deploy and app restart
+    autoreload.reset_loaders()
+
+    # serve_file() is called from a workspace or request content view, where the
+    # renderer is instantiated again from the workspace or request file
+    # A new call to serve_file() will be called with a new renderer, so it will
+    # include any changes to the renderer's cache ID or last_modified date
+    new_renderer = TestRenderer.from_file(test_file)
+    # The etag is the combined cache ID based on both file and template; it has
+    # changed because the template has been updated
+    assert new_renderer.etag != renderer.etag
+    # last_modified is based on the file content only, so has not changed
+    assert new_renderer.last_modified == renderer.last_modified
+
+    request = rf.get(
+        "/",
+        # headers with etag and last_modified from the renderer used in the
+        # first request
+        headers={
+            "If-None-Match": renderer.etag,
+            "If-Modified-Since": renderer.last_modified,
+        },
+    )
+
+    # The template has changed, so we expect the file to be reloaded, and
+    # the content to reflect the updated template
+    response = helpers.serve_file(request, new_renderer)
+    assert response.status_code == 200
+    assert response.rendered_content == "foo123"
 
 
 def test_display_form_errors():

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -40,8 +40,10 @@ def test_renderers_get_renderer_workspace(
 
     if template_path:
         assert isinstance(renderer.template, renderers.RendererTemplate)
-        template_cache_id = renderers.filesystem_key(renderer.template.path.stat())
-        assert renderer.cache_id == f"{content_cache_id}-{template_cache_id}"
+        assert (
+            renderer.cache_id
+            == f"{content_cache_id}-{renderer.template.content_cache_id}"
+        )
     else:
         assert renderer.cache_id == content_cache_id
 
@@ -81,8 +83,10 @@ def test_renderers_get_renderer_request(
 
     if template_path:
         assert isinstance(renderer.template, renderers.RendererTemplate)
-        template_cache_id = renderers.filesystem_key(renderer.template.path.stat())
-        assert renderer.cache_id == f"{request_file.file_id}-{template_cache_id}"
+        assert (
+            renderer.cache_id
+            == f"{request_file.file_id}-{renderer.template.content_cache_id}"
+        )
     else:
         assert renderer.cache_id == request_file.file_id
 


### PR DESCRIPTION
Fixes a bug in the last modified time used*, and improves the template reloading in development

- Cache the template using its content only
File content is cached based on both the content source file and the template file. [Here](https://github.com/opensafely-core/airlock/blob/8fc9f5cf85ef5bd445812f23adb9094c58918ebe/airlock/views/helpers.py#L95) we first check if the ETag (based on both file content and template) has changed; if it has, we then check the last modified time. However, we only use the content file's update time as the last_modified time, which means that if the template was updated after the content file, its changes wouldn't be registered.
  We don't want to use the template's last modified date, because on a redeploy, these dates will change, even if the template content hasn't changed, and we'll reload the file content unecessarily.  So we now use a hash of the template's source as the template cache key. Although this means we now need to load the template in order to get the template cache_id, django caches templates by default, so it should be cheap to do. 

- Reload the template if it has been modified
Django by default caches templates, even in development. The RendererTemplate classes are defined on the Renderer classes, so the templates themselves are never reloaded even if a template file changes. Django's autoreload watches for template changes and clears the template cache, but in order to pick up those changes we need to ensure the RendererTemplate is reloaded.

  Note that the template cache is in-memory, so starting and stopping the development server would clear it. However, if you've changed a template and reloaded the page in the browser, the eTag and LastModified headers will be updated, so even when you start/stop the server, the changes don't get picked up.

  We could turn off caching in development by using different settings, but I think it's preferable to keep development settings as close to production as possible.
  
* I _think_ this is also a bug in production; a workspace/request file would have an older modified time than an updated template file, so even if the cache ID has changed due to the template file changing, you'd still get the not-modified response. 