### PR TITLE
Use the TextRenderer for plaintext

### DIFF
--- a/airlock/renderers.py
+++ b/airlock/renderers.py
@@ -147,10 +147,6 @@ class TextRenderer(Renderer):
         }
 
 
-class PlainTextRenderer(TextRenderer):
-    template = RendererTemplate.from_name("file_browser/file_content/plaintext.html")
-
-
 class InvalidFileRenderer(Renderer):
     template = RendererTemplate.from_name("file_browser/file_content/text.html")
 
@@ -199,7 +195,7 @@ FILE_RENDERERS = {
 def get_renderer(relpath: UrlPath, plaintext=False) -> type[Renderer]:
     if is_valid_file_type(UrlPath(relpath)):
         if plaintext:
-            return PlainTextRenderer
+            return TextRenderer
         return FILE_RENDERERS.get(relpath.suffix, Renderer)
     return InvalidFileRenderer
 
@@ -207,7 +203,7 @@ def get_renderer(relpath: UrlPath, plaintext=False) -> type[Renderer]:
 def get_code_renderer(relpath: UrlPath, plaintext=False) -> type[Renderer]:
     """Guess correct renderer for code file."""
     if plaintext:
-        return PlainTextRenderer
+        return TextRenderer
 
     if relpath.suffix in FILE_RENDERERS:
         return FILE_RENDERERS[relpath.suffix]

--- a/airlock/templates/file_browser/file_content/plaintext.html
+++ b/airlock/templates/file_browser/file_content/plaintext.html
@@ -1,1 +1,0 @@
-<plaintext>{{ text }}

--- a/tests/unit/test_renderers.py
+++ b/tests/unit/test_renderers.py
@@ -13,11 +13,11 @@ RENDERER_TESTS = [
     (".csv", "text/html", False, "airlock/templates/file_browser/csv.html"),
     (".txt", "text/html", False, "airlock/templates/file_browser/text.html"),
     (".log", "text/html", False, "airlock/templates/file_browser/text.html"),
-    (".html", "text/html", True, "airlock/templates/file_browser/plaintext.html"),
-    (".png", "text/html", True, "airlock/templates/file_browser/plaintext.html"),
-    (".csv", "text/html", True, "airlock/templates/file_browser/plaintext.html"),
-    (".txt", "text/html", True, "airlock/templates/file_browser/plaintext.html"),
-    (".log", "text/html", True, "airlock/templates/file_browser/plaintext.html"),
+    (".html", "text/html", True, "airlock/templates/file_browser/text.html"),
+    (".png", "text/html", True, "airlock/templates/file_browser/text.html"),
+    (".csv", "text/html", True, "airlock/templates/file_browser/text.html"),
+    (".txt", "text/html", True, "airlock/templates/file_browser/text.html"),
+    (".log", "text/html", True, "airlock/templates/file_browser/text.html"),
 ]
 
 


### PR DESCRIPTION
Fixes #921

Replacing the deprecated `<plaintext>` tag with `<pre>` fixes the escaping behaviour (and we don't need to manually escape the file content, because django does that for us by default); this means we can get rid of the `PlaintextRenderer` altogether and just use the `TextRenderer` for plaintext content.

Literal csv content like:
```
Col1,Col2
15<1
```
Previously rendered as:
![image](https://github.com/user-attachments/assets/2964dfcb-65d1-487b-b593-aa9424b575c4)
Now renders as:
![Screenshot from 2025-03-26 15-53-52](https://github.com/user-attachments/assets/d0b3897b-851e-42f4-abef-1854dd411b71)
