### PR TITLE
Use a filesystem db in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ assets/out
 
 # Hypothesis outputs
 .hypothesis
+

--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -194,6 +194,14 @@ DATABASES = {
             # https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
             "transaction_mode": "IMMEDIATE",
         },
+        # Specify a test db so that django uses a filesystem db instead on an in-memory
+        # one. This means it can use WAL mode in tests and prevents the "table is locked"
+        # error when two threads read and write at the same time (i.e. in the functional
+        # tests, where we have htmx polling in the running liveserver browser, and we
+        # also update a release request in the test code)
+        "TEST": {
+            "NAME": WORK_DIR / "test_db.sqlite3",
+        },
     }
 }
 

--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -1,24 +1,14 @@
 import pytest
 from django.db import connection, transaction
-from django.db.utils import ConnectionHandler
 from django.test.utils import CaptureQueriesContext
 
 
 @pytest.mark.django_db
 def test_database_init_command(settings, tmp_path):
-    # We want to test that we have correctly configured WAL mode, but we can't do this
-    # against the standard test database because that runs in memory. So we construct a
-    # temporary database using the same configuration as the default and check that.
-    connections = ConnectionHandler(
-        {
-            "default": settings.DATABASES["default"]
-            | {
-                "NAME": tmp_path / "test.db",
-            },
-        }
-    )
-    results = connections["default"].cursor().execute("PRAGMA journal_mode")
-    assert results.fetchone()[0] == "wal"
+    # Test that we have correctly configured WAL mode
+    with connection.cursor() as cursor:
+        results = cursor.execute("PRAGMA journal_mode")
+        assert results.fetchone()[0] == "wal"
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Django by default uses an in-memory database during tests. We can't set WAL mode on an in-memory database, so the functional tests that have htmx polling and also run the file uploader occasionally hit a "database table is locked" error when the polling tries to read at the same time as the file uploader writes. We can use a filesystem db instead by setting a test db name in the DATABASES settings.