### PR TITLE
Reduce functional test workflow to nightly

### DIFF
--- a/.github/workflows/trace-functional-tests.yml
+++ b/.github/workflows/trace-functional-tests.yml
@@ -4,7 +4,7 @@ name: trace-functional-tests
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "0 * * * *"
+    - cron:  "0 3 * * *"
 
 jobs:
 


### PR DESCRIPTION
Functional tests have been running hourly and haven't failed in a few weeks. Reduce them to running just once overnight.