### PR TITLE
Pin playwright to v1.52.0

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -8,6 +8,7 @@ djhtml
 hypothesis
 ruff
 pip-tools
+playwright==1.52.0
 pytest
 pytest-cov
 pytest-django

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,7 +8,7 @@ asgiref==3.8.1 \
     --hash=sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47 \
     --hash=sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   django
 attrs==25.3.0 \
     --hash=sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3 \
@@ -22,7 +22,7 @@ certifi==2025.6.15 \
     --hash=sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057 \
     --hash=sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   requests
 charset-normalizer==3.4.2 \
     --hash=sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4 \
@@ -118,13 +118,13 @@ charset-normalizer==3.4.2 \
     --hash=sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a \
     --hash=sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   requests
 click==8.2.1 \
     --hash=sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202 \
     --hash=sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   pip-tools
 coverage==7.9.1 \
     --hash=sha256:02532fd3290bb8fa6bec876520842428e2a6ed6c27014eca81b031c2d30e3f71 \
@@ -201,7 +201,7 @@ django==5.2.3 \
     --hash=sha256:335213277666ab2c5cac44a792a6d2f3d58eb79a80c14b6b160cd4afc3b75684 \
     --hash=sha256:c517a6334e0fd940066aa9467b29401b93c37cec2e61365d663b80922542069d
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   django-debug-toolbar
     #   django-stubs
     #   django-stubs-ext
@@ -297,7 +297,7 @@ idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   requests
 iniconfig==2.1.0 \
     --hash=sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7 \
@@ -347,29 +347,31 @@ packaging==25.0 \
     --hash=sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484 \
     --hash=sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   build
     #   pytest
 pathspec==0.12.1 \
     --hash=sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08 \
     --hash=sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   mypy
 pip-tools==7.4.1 \
     --hash=sha256:4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9 \
     --hash=sha256:864826f5073864450e24dbeeb85ce3920cdfb09848a3d69ebf537b521f14bcc9
     # via -r requirements.dev.in
-playwright==1.53.0 \
-    --hash=sha256:36eedec101724ff5a000cddab87dd9a72a39f9b3e65a687169c465484e667c06 \
-    --hash=sha256:48a1a15ce810f0ffe512b6050de9871ea193b41dd3cc1bbed87b8431012419ba \
-    --hash=sha256:9276c9c935fc062f51f4f5107e56420afd6d9a524348dc437793dc2e34c742e3 \
-    --hash=sha256:a701f9498a5b87e3f929ec01cea3109fbde75821b19c7ba4bba54f6127b94f76 \
-    --hash=sha256:d68975807a0fd997433537f1dcf2893cda95884a39dc23c6f591b8d5f691e9e8 \
-    --hash=sha256:db19cb5b58f3b15cad3e2419f4910c053e889202fc202461ee183f1530d1db60 \
-    --hash=sha256:f765498341c4037b4c01e742ae32dd335622f249488ccd77ca32d301d7c82c61 \
-    --hash=sha256:fcfd481f76568d7b011571160e801b47034edd9e2383c43d83a5fb3f35c67885
-    # via pytest-playwright
+playwright==1.52.0 \
+    --hash=sha256:0797c0479cbdc99607412a3c486a3a2ec9ddc77ac461259fd2878c975bcbb94a \
+    --hash=sha256:19b2cb9d4794062008a635a99bd135b03ebb782d460f96534a91cb583f549512 \
+    --hash=sha256:4173e453c43180acc60fd77ffe1ebee8d0efbfd9986c03267007b9c3845415af \
+    --hash=sha256:7223960b7dd7ddeec1ba378c302d1d09733b8dac438f492e9854c85d3ca7144f \
+    --hash=sha256:9d0085b8de513de5fb50669f8e6677f0252ef95a9a1d2d23ccee9638e71e65cb \
+    --hash=sha256:cd0bdf92df99db6237a99f828e80a6a50db6180ef8d5352fc9495df2c92f9971 \
+    --hash=sha256:d010124d24a321e0489a8c0d38a3971a7ca7656becea7656c9376bfea7f916d4 \
+    --hash=sha256:dcbf75101eba3066b7521c6519de58721ea44379eb17a0dafa94f9f1b17f59e4
+    # via
+    #   -r requirements.dev.in
+    #   pytest-playwright
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
@@ -384,7 +386,7 @@ pygments==2.19.2 \
     --hash=sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887 \
     --hash=sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   pytest
 pyproject-hooks==1.2.0 \
     --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \
@@ -426,7 +428,7 @@ python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   freezegun
 python-slugify==8.0.4 \
     --hash=sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8 \
@@ -487,13 +489,13 @@ pyyaml==6.0.2 \
     --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   responses
 requests==2.32.4 \
     --hash=sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c \
     --hash=sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   pytest-base-url
     #   responses
 responses==0.25.7 \
@@ -524,7 +526,7 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   python-dateutil
 sortedcontainers==2.4.0 \
     --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88 \
@@ -534,7 +536,7 @@ sqlparse==0.5.3 \
     --hash=sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272 \
     --hash=sha256:cf2196ed3418f3ba5de6af7e82c694a9fbdbfecccdfc72e281548517081f16ca
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   django
     #   django-debug-toolbar
 text-unidecode==1.3 \
@@ -553,7 +555,7 @@ typing-extensions==4.14.0 \
     --hash=sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4 \
     --hash=sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   django-stubs
     #   django-stubs-ext
     #   mypy
@@ -562,7 +564,7 @@ urllib3==2.5.0 \
     --hash=sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760 \
     --hash=sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   requests
     #   responses
     #   types-requests
@@ -651,7 +653,7 @@ wrapt==1.17.2 \
     --hash=sha256:fc78a84e2dfbc27afe4b2bd7c80c8db9bca75cc5b85df52bfe634596a1da846b \
     --hash=sha256:ff04ef6eec3eee8a5efef2401495967a916feaa353643defcc03fc74fe213b58
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   django-debug-toolbar-template-profiler
 
 # The following packages are considered to be unsafe in a requirements file:
@@ -665,5 +667,5 @@ setuptools==80.9.0 \
     --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
     --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via
-    #   -c /home/runner/work/airlock/airlock/requirements.prod.txt
+    #   -c /home/becky/datalab/airlock/requirements.prod.txt
     #   pip-tools


### PR DESCRIPTION
Playwright tests have been intermittently failing and/or getting a django UserWarning that a template variable can't be resolved (usually path_item.contents_url, sometimes path_item.contents_plaintext_url) since [this PR](https://github.com/opensafely-core/airlock/pull/965/) was merged, which upgraded playwright from 1.52.0 to 1.53.0. Although there's nothing in the [release notes](https://playwright.dev/python/docs/release-notes#version-153) that would suggest it would have this effect, let's pin it to see if the errors/warnings stop happening.