### PR TITLE
Use PostgreSQL 16 for job-server

### DIFF
--- a/job-server/docker-compose.yml
+++ b/job-server/docker-compose.yml
@@ -2,7 +2,7 @@
 # configuring the production build
 services:
   db:
-    image: "postgres:13"
+    image: "postgres:16"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass


### PR DESCRIPTION
We intend to upgrade to PostgreSQL 16 for job-server.

This change keeps the Airlock development setup in line with that change.

See opensafely-core/job-server#4739