### PR TITLE
Update to PostgreSQL v17

### DIFF
--- a/job-server/docker-compose.yml
+++ b/job-server/docker-compose.yml
@@ -2,7 +2,7 @@
 # configuring the production build
 services:
   db:
-    image: "postgres:16"
+    image: "postgres:17"
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass


### PR DESCRIPTION
The Digital Ocean production database upgraded to v17.

We're not sure why yet (opensafely-core/job-server#5339).

The proposed fix is to upgrade local setups to match production (opensafely-core/job-server#5338).