### PR TITLE
Enable dependabot for security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,10 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+
+  # Security updates only
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Setting max pull requests to 0 enables dependabot for security updates only
https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs#example-1-configuration-for-security-updates-only

Currently uv is not fully supported for uv; I think this means it will only scan direct dependencies, not transitive dependencies. However, at the moment it looks like we're not getting any python dependencies in the [dependency graph](https://github.com/opensafely-core/airlock/network/dependencies), and we know that at least one direct dependency (Django) currently has a security update from 5.2.7 -> 5.2.8

There are some potential solutions to this, mentioned in [this issue](https://github.com/dependabot/dependabot-core/issues/11913),  which I'll look at in a future PR.