### PR TITLE
Extend create_release_request action to allow supporting files

### DIFF
--- a/airlock/management/commands/create_release_request.py
+++ b/airlock/management/commands/create_release_request.py
@@ -29,6 +29,11 @@ class Command(BaseCommand):
             help="list of directory paths containing output files to add",
         )
         parser.add_argument(
+            "--supporting-files",
+            nargs="*",
+            help="list of paths to files to be added as supporting files; must exist in one of the specified dirs",
+        )
+        parser.add_argument(
             "--context",
             default="",
             help="Group context; if multiple groups are created, the same context will be added for each group",


### PR DESCRIPTION
This means we can create an automated release request that includes supporting files.

Supporting files must be specified by a full path, and must be contained within one of the specified output file dirs. As groups are generated based on the specified dirs, this ensures that supporting files get put in the same group. We assume that there are relatively few supporting files, so specifying them individually should not be too onerous.