### PR TITLE
Bump urllib3 to address security vulnerability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ django_settings_module = "airlock.settings"
 [tool.uv]
 required-version = ">=0.9"
 exclude-newer = "2025-12-31T00:00:00Z"
-exclude-newer-package = {}
+exclude-newer-package = {"urllib3"="2026-01-07T16:31:00Z"}
 
 [dependency-groups]
 dev = [

--- a/requirements.uvmirror.txt
+++ b/requirements.uvmirror.txt
@@ -292,7 +292,7 @@ tzdata==2025.3 ; sys_platform == 'win32'
     # via django
 ulid==1.1
     # via airlock
-urllib3==2.6.2
+urllib3==2.6.3
     # via
     #   requests
     #   responses

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,9 @@ resolution-markers = [
 [options]
 exclude-newer = "2025-12-31T00:00:00Z"
 
+[options.exclude-newer-package]
+urllib3 = "2026-01-07T16:31:00Z"
+
 [[package]]
 name = "airlock"
 version = "0.1.0"
@@ -1740,11 +1743,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/56/d4/6829692e4902d5368
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`urllib3 <v2.6.3` has a security vulnerability reported in https://github.com/advisories/GHSA-38jv-5279-wg99, so we are bumping the version to `2.6.3` without waiting for a 7-day cooldown period.

The `exclude-newer-package` timestamp should be removed once it is 7 days old, as per the guidelines in `DEVELOPERS.md`.