### PR TITLE
Save session every request.

### DIFF
--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -260,6 +260,7 @@ SESSION_COOKIE_NAME = "airlock-sessionid"
 
 # login is painful, so reduce the frequency that users need to do it after inactivity.
 SESSION_COOKIE_AGE = 8 * 7 * 24 * 60 * 60  # 8 weeks
+SESSION_SAVE_EVERY_REQUEST = True  # 8 weeks of inactivity, not since login
 
 # time before we refresh users authorisation
 AIRLOCK_AUTHZ_TIMEOUT = 15 * 60  # 15 minutes


### PR DESCRIPTION
This will update the timestamp, causing the session to only expire after
8 weeks of *inactivity*, not just every 8 weeks, which is what we
originally intended and documented.

Fixes #1065
