### PR TITLE
uv for security updates and uvmirror-check workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,10 @@ updates:
       interval: "monthly"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # Security updates only
+    open-pull-requests-limit: 0

--- a/.github/workflows/uvmirror-check.yml
+++ b/.github/workflows/uvmirror-check.yml
@@ -1,0 +1,24 @@
+---
+name: Check uvmirror
+
+permissions:
+  contents: read
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  check-uvmirror:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: opensafely-core/setup-action@v1
+        with:
+          install-just: true
+          install-uv: true
+          cache: uv
+
+      - name: Ensure requirements.uvmirror.txt is consistent with uv.lock
+        run: just uvmirror && git diff -s --exit-code


### PR DESCRIPTION
Add uv dependabot config for security updates only

Add a GHA workflow to ensure uvmirror file is consistent with uv.lock

Ensures that the uvmirror requirements file has not been updated independently of the pyproject.toml and uv.lock files. This will fail any dependabot security update PRs that modify only the mirror file, and will prompt us to fix the PRs with the correct uv updates.