### PR TITLE
Add tracing for the summarize_csv function

### DIFF
--- a/airlock/utils.py
+++ b/airlock/utils.py
@@ -8,6 +8,7 @@ from opentelemetry import trace
 from pipeline.constants import LEVEL4_FILE_TYPES
 
 from airlock.types import UrlPath
+from services.tracing import instrument
 
 
 def is_valid_file_type(path: Path | UrlPath):
@@ -149,6 +150,7 @@ def summarize_column(column_name: str, column_data: tuple[str, ...]):
     return column_summary
 
 
+@instrument
 def summarize_csv(
     column_names: list[str], enumerated_rows: list[tuple[int, list[str]]]
 ):


### PR DESCRIPTION
To let us see how much it's being used and how long it takes. We don't have access to the filepath or workspace in the `summarize_csv` function itself, but we'll be able to see which file/workspace it applies to from the parent span