### PR TITLE
Exclude non-l4 files from the workspace tree

### DIFF
--- a/airlock/models.py
+++ b/airlock/models.py
@@ -197,7 +197,7 @@ class Workspace:
         # build a map of all valid workspace UrlPaths and their children from the
         # manifest file, plus a set of all paths for just the files
         workspace_child_map, workspace_files = cls.get_workspace_child_map(
-            cls.get_valid_filepaths_from_manifest_outputs(manifest["outputs"])
+            set(cls.get_valid_filepaths_from_manifest_outputs(manifest["outputs"]))
             | cls.scan_metadata_dir(name)
         )
 
@@ -248,11 +248,12 @@ class Workspace:
 
     @staticmethod
     def get_valid_filepaths_from_manifest_outputs(outputs):
-        return {
-            filename
-            for filename, output in outputs.items()
-            if output["level"] == "moderately_sensitive" and not output["excluded"]
-        }
+        for filename, output in outputs.items():
+            if output["level"] == "moderately_sensitive":
+                if not output["excluded"]:
+                    yield filename
+                else:
+                    yield f"{filename}.txt"
 
     @staticmethod
     def get_workspace_child_map(

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 
 import pytest
@@ -63,16 +64,39 @@ def test_get_workspace_tree_general(release_request):
     factories.write_workspace_file(
         workspace, "metadata/metadata_subdir/file.log", manifest=False
     )
-    # refresh workspace
-    workspace = factories.create_workspace("workspace")
+
+    # Write a workspace file for an excluded L4 file
+    # These are replaced by the RAP agent with a message file that contains the reason for the exclusion
+    # The replacement file should appear in the tree, with the original filename plus an extra
+    # .txt extension
+    # https://github.com/opensafely-core/job-runner/blob/da2cd57c56ffdce1469f0e959cc87caab4218903/agent/executors/local.py#L675
+    factories.write_workspace_file(
+        workspace, "some_dir/excluded.csv.txt", "Not allowed on L4", manifest=False
+    )
+    # The manifest entry still refers to the file by its real filename
+    manifest = workspace.manifest
+    output_metadata = factories.get_output_metadata(
+        workspace.root() / "some_dir/excluded.csv.txt",
+        level="moderately_sensitive",
+        excluded=True,
+        job_id="job",
+        job_request="job-request",
+        action="action",
+        repo="http://example.com/org/repo",
+        commit="abcdefgh",
+        user="user",
+    )
+    manifest["outputs"]["some_dir/excluded.csv"] = output_metadata
+    (workspace.root() / workspace.manifest_path()).write_text(json.dumps(manifest))
+
+    # refresh workspace without rewriting the manifest from files on disk
+    workspace = factories.refresh_workspace("workspace")
+    # Manifest contains highly sensitive and excluded outputs
+    assert "some_dir/excluded.csv" in workspace.manifest["outputs"]
+    assert "some_dir/excluded.csv.txt" not in workspace.manifest["outputs"]
 
     selected_path = UrlPath("some_dir/file_a.txt")
     tree = get_workspace_tree(workspace, selected_path)
-
-    # Manifest contains highly sensitive and excluded outputs which do not
-    # appear in the workspace tree
-    assert "output/highly_sensitive.txt" in workspace.manifest["outputs"]
-    assert "output/excluded.txt" in workspace.manifest["outputs"]
 
     # simple way to express the entire tree structure, including selected
     expected = textwrap.dedent(
@@ -84,6 +108,7 @@ def test_get_workspace_tree_general(release_request):
             manifest.json
           some_dir*
             .file.txt
+            excluded.csv.txt
             file_a.foo
             file_a.txt**
             file_b.txt
@@ -133,6 +158,7 @@ def test_get_workspace_tree_general(release_request):
     # valid
     assert tree.get_path("some_dir/file_a.txt").is_valid()
     assert tree.get_path("some_dir/file_b.txt").is_valid()
+    assert tree.get_path("some_dir/excluded.csv.txt").is_valid()
     assert not tree.get_path("some_dir/file_a.foo").is_valid()
     assert not tree.get_path("some_dir/.file.txt").is_valid()
 


### PR DESCRIPTION
We now build the workspace tree from the manifest outputs. However, highly sensitive and excluded L4 files are in the manifest outputs, but are not valid L4 files, don't exist on disk, and shouldn't be displayed in the workspace tree.