### PR TITLE
Create user if necessary in project/org backpopulation

### DIFF
--- a/local_db/management/commands/backpopulate_project_and_orgs_on_request_metadata.py
+++ b/local_db/management/commands/backpopulate_project_and_orgs_on_request_metadata.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         ):
             user = retrieved_users.get(request.author)
             if user is None:
-                user = auth_backend.update(auth_backend.get_user(request.author))
+                user = auth_backend.create_or_update(request.author, force_refresh=True)
                 if user is None:
                     self.stdout.write(
                         f"Error updating request {request.id}: Could not retrieve user information from API for user '{request.author}'"

--- a/tests/integration/management/commands/test_backpopulate_project_and_orgs_on_request_metadata.py
+++ b/tests/integration/management/commands/test_backpopulate_project_and_orgs_on_request_metadata.py
@@ -3,6 +3,8 @@ from django.core.management import call_command
 
 from local_db.models import RequestMetadata
 from tests import factories
+from users.auth import Level4AuthenticationBackend
+from users.models import User
 
 
 @pytest.mark.django_db
@@ -73,6 +75,57 @@ def test_command(bll, auth_api_stubber):
 
     # Author has 2 requests, but we only call the auth API once
     assert len(auth_responses.calls) == 1
+
+
+@pytest.mark.django_db
+def test_command_no_user_in_db(bll, auth_api_stubber):
+    author = factories.create_airlock_user(
+        username="testuser",
+        workspaces={
+            "workspace": {
+                "project_details": {"name": "Project 1", "ongoing": True},
+                "archived": False,
+            }
+        },
+    )
+    # Mock response from auth endpoint with new workspace data including orgs
+    auth_api_stubber(
+        "authorise",
+        json={
+            "username": "testuser",
+            "output_checker": False,
+            "workspaces": {
+                "workspace": {
+                    "archived": False,
+                    "project_details": {
+                        "name": "Project 1",
+                        "ongoing": True,
+                        "orgs": ["Organisation 1"],
+                    },
+                }
+            },
+        },
+    )
+
+    release_request = factories.create_release_request("workspace", user=author)
+
+    # Set release request project/orgs to "" to replicate state after initial migration
+    request_from_db = RequestMetadata.objects.get(id=release_request.id)
+    request_from_db.project = ""
+    request_from_db.organisations = ""
+    request_from_db.save()
+
+    # delete the author to mock a release request create before the User model existed
+    author.delete()
+    assert Level4AuthenticationBackend().get_user(request_from_db.author) is None
+
+    call_command("backpopulate_project_and_orgs_on_request_metadata")
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.project == "Project 1"
+    assert release_request.organisations == ["Organisation 1"]
+
+    assert release_request.author == User.objects.get(user_id="testuser")
 
 
 @pytest.mark.django_db

--- a/users/auth.py
+++ b/users/auth.py
@@ -43,7 +43,7 @@ class Level4AuthenticationBackend(BaseBackend):
         time_since_authz = time.time() - user.last_refresh
         return time_since_authz > settings.AIRLOCK_AUTHZ_TIMEOUT
 
-    def create_or_update(self, username: str) -> User | None:
+    def create_or_update(self, username: str, force_refresh=False) -> User | None:
         """
         Create a user and/or update their data via the API.
         Note: does not authenticate the user.
@@ -56,7 +56,7 @@ class Level4AuthenticationBackend(BaseBackend):
             user = User.from_api_data({"username": username}, last_refresh=0)
 
         # Only update the user if last refresh was longer ago than the allowed web timeout
-        if self.needs_refresh(user):
+        if self.needs_refresh(user) or force_refresh:
             return self.update(user)
 
         return user


### PR DESCRIPTION
It's possible to have a request user who doesn't exist in the Airlock db (presumably because the request predates the User model, and this user was missed by the user model population). If they exist in the job-server db, we create them and use their info to populate the request org/project.