### PR TITLE
Handle users who no longer have workspace access

### DIFF
--- a/local_db/management/commands/backpopulate_project_and_orgs_on_request_metadata.py
+++ b/local_db/management/commands/backpopulate_project_and_orgs_on_request_metadata.py
@@ -23,9 +23,9 @@ class Command(BaseCommand):
             user = retrieved_users.get(request.author)
             if user is None:
                 user = auth_backend.create_or_update(request.author, force_refresh=True)
-                if user is None:
+                if user is None or request.workspace not in user.workspaces:
                     self.stdout.write(
-                        f"Error updating request {request.id}: Could not retrieve user information from API for user '{request.author}'"
+                        f"Error updating request {request.id}: Could not retrieve information for workspace from API for user '{request.author}'"
                     )
                     continue
                 retrieved_users[user.user_id] = user

--- a/tests/integration/management/commands/test_backpopulate_project_and_orgs_on_request_metadata.py
+++ b/tests/integration/management/commands/test_backpopulate_project_and_orgs_on_request_metadata.py
@@ -129,6 +129,43 @@ def test_command_no_user_in_db(bll, auth_api_stubber):
 
 
 @pytest.mark.django_db
+def test_command_no_workspace_information_from_API(bll, auth_api_stubber):
+    author = factories.create_airlock_user(
+        username="testuser",
+        workspaces={
+            "workspace": {
+                "project_details": {"name": "Project 1", "ongoing": True},
+                "archived": False,
+            }
+        },
+    )
+    # Mock response from auth endpoint for a user who no longer has access to
+    # the workspace
+    auth_api_stubber(
+        "authorise",
+        json={
+            "username": "testuser",
+            "output_checker": False,
+            "workspaces": {},
+        },
+    )
+
+    release_request = factories.create_release_request("workspace", user=author)
+
+    # Set release request project/orgs to "" to replicate state after initial migration
+    request_from_db = RequestMetadata.objects.get(id=release_request.id)
+    request_from_db.project = ""
+    request_from_db.organisations = ""
+    request_from_db.save()
+
+    call_command("backpopulate_project_and_orgs_on_request_metadata")
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.project == ""
+    assert release_request.organisations == []
+
+
+@pytest.mark.django_db
 def test_create_release_request_api_auth_error(bll, auth_api_stubber, capsys):
     auth_api_stubber("authorise", status=400)
 


### PR DESCRIPTION
If a past author no longer has access to a workspace, warn and skip attempting to update the request when backpopulating orgs and project.