### PR TITLE
Add management command to change request status

### DIFF
--- a/airlock/actions/__init__.py
+++ b/airlock/actions/__init__.py
@@ -1,3 +1,6 @@
+from airlock.actions.change_release_request_status import (
+    change_release_request_status as change_release_request_status,
+)
 from airlock.actions.create_release_request import (
     create_release_request as create_release_request,
 )

--- a/airlock/actions/change_release_request_status.py
+++ b/airlock/actions/change_release_request_status.py
@@ -1,0 +1,66 @@
+import logging
+
+from airlock.business_logic import bll
+from airlock.enums import RequestStatus
+from airlock.exceptions import ActionDenied, ReleaseRequestNotFound
+from airlock.models import AuditEvent
+from users.auth import Level4AuthenticationBackend
+from users.models import User
+
+
+logger = logging.getLogger(__name__)
+
+
+def change_release_request_status(
+    request_id: str,
+    *,
+    username: str,
+    to_status: RequestStatus,
+    **kwargs,
+) -> str:
+    # Extra audit log kwargs to indicate actions performed by this code were automated
+    audit_extra = {"automated_action": "true"}
+
+    user = Level4AuthenticationBackend().get_user(username)
+    if user is None:
+        raise ActionDenied(f"No user found with username '{username}'")
+
+    # The user being used for this action does not necessarily have access to the
+    # workspace, which we need in order to retrieve the request
+    # Note that this user is ephemeral, it does not get persisted to the db
+    system_user = User(
+        user_id="system", api_data={"username": "system", "output_checker": True}
+    )
+    try:
+        release_request = bll.get_release_request(request_id, system_user)
+    except ReleaseRequestNotFound:
+        raise ActionDenied(f"No release request found with id {request_id}")
+
+    if release_request.status == to_status:
+        raise ActionDenied(f"Release request is already in status {to_status.value}")
+
+    confirm = input(
+        f"Request ID: {release_request.id}\n"
+        f"Workspace: {release_request.workspace}\n"
+        f"Changing release request status from {release_request.status.value} to {to_status.value}\n"
+        f"Confirm: y/n\n"
+    )
+    if confirm.strip().lower() == "y":
+        audit = AuditEvent.from_request(
+            release_request,
+            type=bll.STATUS_AUDIT_EVENT[to_status],
+            user=user,
+            path=None,
+            **audit_extra,
+        )
+        # Set status using the DAL to bypass the usual workflow; this means we can
+        # move a "stuck" author-owned request (i.e. a request where the author has since lost
+        # relevant access to the workspace or to Airlock itself.)
+        bll._dal.set_status(release_request.id, to_status, audit)
+        # Send a notification to close the GitHub issue
+        bll.send_notification(
+            release_request, bll.STATUS_EVENT_NOTIFICATION[to_status], user
+        )
+
+        return "Succeeded"
+    return "Aborted"

--- a/airlock/management/commands/change_release_request_status.py
+++ b/airlock/management/commands/change_release_request_status.py
@@ -1,0 +1,44 @@
+"""
+Update a release request's status outside of the UI.
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+
+from airlock import actions
+from airlock.enums import RequestStatus
+from airlock.exceptions import ActionDenied
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Update a release request's status outside of the UI. This is only intended for withdrawing or
+    rejecting release requests that can no longer be accessed by their original author.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("request_id", help="release request ID")
+        parser.add_argument(
+            "--user",
+            help="username of user to modify this release request",
+        )
+        parser.add_argument(
+            "--status",
+            help="request status to change to",
+            type=RequestStatus,
+            choices=[RequestStatus.REJECTED, RequestStatus.WITHDRAWN],
+        )
+
+    def handle(self, request_id, user, status, **options):
+        try:
+            result = actions.change_release_request_status(
+                request_id, username=user, to_status=status, **options
+            )
+        except ActionDenied as e:
+            self.stdout.write(f"Error: {str(e)}")
+        else:
+            self.stdout.write(result)

--- a/tests/integration/actions/test_change_release_request_status.py
+++ b/tests/integration/actions/test_change_release_request_status.py
@@ -1,0 +1,108 @@
+import json
+
+import pytest
+
+from airlock.actions import change_release_request_status
+from airlock.enums import AuditEventType, NotificationEventType, RequestStatus
+from airlock.exceptions import ActionDenied, RequestPermissionDenied
+from tests import factories
+
+
+@pytest.mark.django_db
+def test_change_release_request_status(bll, monkeypatch, mock_notifications):
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.RETURNED,
+        files=[factories.request_file(changes_requested=True)],
+    )
+    action_user = factories.create_airlock_user(username="testuser")
+
+    # action user can't withdraw this request in the usual way
+    with pytest.raises(RequestPermissionDenied):
+        bll.set_status(release_request, RequestStatus.WITHDRAWN, action_user)
+
+    result = change_release_request_status(
+        release_request.id, username="testuser", to_status=RequestStatus.WITHDRAWN
+    )
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.status == RequestStatus.WITHDRAWN
+    assert result == "Succeeded"
+
+    audit_log = bll._dal.get_audit_log(request=release_request.id)
+
+    latest_log = audit_log[0]
+    assert latest_log.type == AuditEventType.REQUEST_WITHDRAW
+    assert latest_log.extra["automated_action"] == "true"
+
+    last_notification = mock_notifications.calls[-1]
+    notification_request_body = json.loads(last_notification.request.body)
+    assert (
+        notification_request_body["event_type"]
+        == NotificationEventType.REQUEST_WITHDRAWN.value
+    )
+
+
+@pytest.mark.django_db
+def test_change_release_request_status_aborted(bll, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.RETURNED,
+        files=[factories.request_file(changes_requested=True)],
+    )
+    factories.create_airlock_user(username="testuser")
+
+    result = change_release_request_status(
+        release_request.id, username="testuser", to_status=RequestStatus.WITHDRAWN
+    )
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.status == RequestStatus.RETURNED
+    assert result == "Aborted"
+
+
+@pytest.mark.django_db
+def test_change_release_request_status_no_user(bll):
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.RETURNED,
+        files=[factories.request_file(changes_requested=True)],
+    )
+
+    with pytest.raises(ActionDenied, match="No user"):
+        change_release_request_status(
+            release_request.id, username="testuser", to_status=RequestStatus.WITHDRAWN
+        )
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.status == RequestStatus.RETURNED
+
+
+@pytest.mark.django_db
+def test_change_release_request_status_no_request(bll):
+    factories.create_airlock_user(username="testuser")
+
+    with pytest.raises(ActionDenied, match="No release request"):
+        change_release_request_status(
+            "FOO", username="testuser", to_status=RequestStatus.WITHDRAWN
+        )
+
+
+@pytest.mark.django_db
+def test_change_release_request_status_no_status_change(bll):
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.RETURNED,
+        files=[factories.request_file(changes_requested=True)],
+    )
+    factories.create_airlock_user(username="testuser")
+
+    with pytest.raises(ActionDenied, match="already in status RETURNED"):
+        change_release_request_status(
+            release_request.id, username="testuser", to_status=RequestStatus.RETURNED
+        )
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.status == RequestStatus.RETURNED

--- a/tests/integration/management/commands/test_change_release_request_status.py
+++ b/tests/integration/management/commands/test_change_release_request_status.py
@@ -1,0 +1,66 @@
+import pytest
+from django.core.management import call_command
+
+from airlock.enums import RequestStatus
+from tests import factories
+
+
+@pytest.mark.django_db
+def test_change_release_request_status(bll, monkeypatch, capsys, mock_notifications):
+    """
+    Test that we can change a release request's status using the management command.
+    """
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.RETURNED,
+        files=[factories.request_file(changes_requested=True)],
+    )
+    factories.create_airlock_user(username="testuser")
+
+    call_command(
+        "change_release_request_status",
+        release_request.id,
+        user="testuser",
+        status=RequestStatus.WITHDRAWN,
+    )
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.status == RequestStatus.WITHDRAWN
+    assert "Succeeded" in capsys.readouterr().out
+
+
+@pytest.mark.django_db
+def test_change_release_request_status_aborted(bll, monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.RETURNED,
+        files=[factories.request_file(changes_requested=True)],
+    )
+    factories.create_airlock_user(username="testuser")
+
+    call_command(
+        "change_release_request_status",
+        release_request.id,
+        user="testuser",
+        status=RequestStatus.WITHDRAWN,
+    )
+
+    release_request = factories.refresh_release_request(release_request)
+    assert release_request.status == RequestStatus.RETURNED
+    assert "Aborted" in capsys.readouterr().out
+
+
+@pytest.mark.django_db
+def test_change_release_request_status_with_error(bll, capsys):
+    factories.create_airlock_user(username="testuser")
+
+    call_command(
+        "change_release_request_status",
+        "bad_request_id",
+        user="testuser",
+        status=RequestStatus.WITHDRAWN,
+    )
+
+    assert "Error: No release request" in capsys.readouterr().out


### PR DESCRIPTION
Adds a management command and corresponding action to change a request's status outside of the UI.

This is only runnable by developers with L3 access and allows for requests that are "stuck" in an author-owned state (because the author is unavailable or has lost Airlock permission to access the workspace). These requests will never be advanced, so we allow for a developer to reject or withdraw them. An audit event is created and noted as an "automated_action", as with the automated release requests.

(In Airlock, we currently have one real release request which has been stuck in the Returned status for 11 months now). It appears in the list of pending release requests, but currently via the UI, only the author can change its status, and the author no longer has the project developer role on the project, so can't access it.)

Closes #1089 