### PR TITLE
Upgrade django-coverage-plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ dev = [
     "responses",
     # Currently using our fork of django_coverage_plugin, pending
     # upstream PR https://github.com/nedbat/django_coverage_plugin/pull/93
-    "django_coverage_plugin@https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip",
+    "django_coverage_plugin@https://github.com/opensafely-core/django_coverage_plugin/archive/75209df74c37178666868abbd9687a41aaba0e13.zip",
     # Type-checking and type stubs
     "mypy",
     "django-stubs[compatible-mypy]",

--- a/requirements.uvmirror.txt
+++ b/requirements.uvmirror.txt
@@ -38,6 +38,7 @@ distro==1.9.0
 django==5.2.11 ; python_full_version < '3.12'
     # via
     #   airlock
+    #   django-coverage-plugin
     #   django-debug-toolbar
     #   django-extensions
     #   django-htmx
@@ -49,6 +50,7 @@ django==5.2.11 ; python_full_version < '3.12'
 django==6.0.2 ; python_full_version >= '3.12'
     # via
     #   airlock
+    #   django-coverage-plugin
     #   django-debug-toolbar
     #   django-extensions
     #   django-htmx
@@ -57,7 +59,7 @@ django==6.0.2 ; python_full_version >= '3.12'
     #   django-stubs-ext
     #   django-vite
     #   slippers
-django-coverage-plugin @ https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip
+django-coverage-plugin @ https://github.com/opensafely-core/django_coverage_plugin/archive/75209df74c37178666868abbd9687a41aaba0e13.zip
 django-debug-toolbar==6.2.0
     # via django-debug-toolbar-template-profiler
 django-debug-toolbar-template-profiler==2.1.0

--- a/uv.lock
+++ b/uv.lock
@@ -82,7 +82,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "django-coverage-plugin", url = "https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip" },
+    { name = "django-coverage-plugin", url = "https://github.com/opensafely-core/django_coverage_plugin/archive/75209df74c37178666868abbd9687a41aaba0e13.zip" },
     { name = "django-debug-toolbar" },
     { name = "django-debug-toolbar-template-profiler" },
     { name = "django-stubs", extras = ["compatible-mypy"] },
@@ -412,15 +412,20 @@ wheels = [
 
 [[package]]
 name = "django-coverage-plugin"
-version = "3.1.0"
-source = { url = "https://github.com/opensafely-core/django_coverage_plugin/archive/153a0ca6c02f7f01831568a546c848c4a3f082cd.zip" }
+version = "3.2.0"
+source = { url = "https://github.com/opensafely-core/django_coverage_plugin/archive/75209df74c37178666868abbd9687a41aaba0e13.zip" }
 dependencies = [
     { name = "coverage" },
+    { name = "django", version = "5.2.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "django", version = "6.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { hash = "sha256:db70db8737dd269c346f7af6e0c735a3d6462b944302f6bc0178c7bac9a4c7ee" }
+sdist = { hash = "sha256:3f03ec72e772b57f34ca6d66d91f5ba4266d811f59e1592e9b041501e1ade66d" }
 
 [package.metadata]
-requires-dist = [{ name = "coverage" }]
+requires-dist = [
+    { name = "coverage" },
+    { name = "django" },
+]
 
 [[package]]
 name = "django-debug-toolbar"


### PR DESCRIPTION
We maintain our own fork of django-coverage-plugin, with some modifications so that we can handle the component tags.

This pulls in the updates from the upstream repo: https://github.com/opensafely-core/django_coverage_plugin/pull/4