### PR TITLE
Exclude out of date outputs from the workspace tree

### DIFF
--- a/airlock/models.py
+++ b/airlock/models.py
@@ -275,7 +275,9 @@ class Workspace:
     @staticmethod
     def get_valid_filepaths_from_manifest_outputs(outputs):
         for filename, output in outputs.items():
-            if output["level"] == "moderately_sensitive":
+            if output["level"] == "moderately_sensitive" and not output.get(
+                "out_of_date_output", False
+            ):
                 if not output["excluded"]:
                     yield filename
                 else:

--- a/tests/unit/test_file_browser_api.py
+++ b/tests/unit/test_file_browser_api.py
@@ -65,10 +65,16 @@ def test_get_workspace_tree_general(release_request):
         workspace, "metadata/metadata_subdir/file.log", manifest=False
     )
 
-    # Write a file produced by an out of date action
+    # Write out of date files
+    # 1) produced by an out of date action
     factories.write_workspace_file(workspace, "some_dir/out_of_date.txt", "out_of_date")
+    # 2) an out of date output. This exists inthe manifest but does NOT get included in the tree.
+    factories.write_workspace_file(
+        workspace, "some_dir/out_of_date_output.txt", "out_of_date_output"
+    )
     manifest = workspace.manifest
     manifest["outputs"]["some_dir/out_of_date.txt"]["out_of_date_action"] = True
+    manifest["outputs"]["some_dir/out_of_date_output.txt"]["out_of_date_output"] = True
 
     # Write a workspace file for an excluded L4 file
     # These are replaced by the RAP agent with a message file that contains the reason for the exclusion
@@ -176,6 +182,7 @@ def test_get_workspace_tree_general(release_request):
         "no_dir",
         "output/highly_sensitive.txt",
         "output/excluded.txt",
+        "output/out_of_date_output.txt",
     ]:
         with pytest.raises(tree.PathNotFound):
             tree.get_path(bad_file)


### PR DESCRIPTION
job-runner will shortly start to include out-of-date outputs in the manifest.json (https://github.com/opensafely-core/job-runner/pull/1339). 

For now, we exclude those from the workspace tree, so the workspace still shows only the most recent outputs for each action in the project.yaml. It continues to show outputs produced for now out-of-date actions.