### PR TITLE
Have buttons for adding content be always visible

### DIFF
--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -89,13 +89,17 @@ def _get_dir_button_context(user, workspace):
     )
     context = {"multiselect_add": multiselect_add_btn}
 
-    # We always show the button unless the workspace is inactive (but it may be disabled)
-    if not workspace.is_active():
-        return context
-
+    # We always show the button to avoid confusion (but it may be disabled)
     multiselect_add_btn.show = True
 
-    if permissions.user_can_action_request_for_workspace(user, workspace.name):
+    if not workspace.is_active():
+        tooltip_lines = []
+        if not workspace.project.is_ongoing:
+            tooltip_lines.append("the project is not ongoing")
+        if workspace.is_archived():
+            tooltip_lines.append("this workspace is archived")
+        multiselect_add_btn.tooltip = " and ".join(tooltip_lines).capitalize() + "."
+    elif permissions.user_can_action_request_for_workspace(user, workspace.name):
         if workspace.current_request is None or workspace.current_request.is_editing():
             multiselect_add_btn.disabled = False
         else:
@@ -127,10 +131,7 @@ def _get_file_button_context(user, workspace, path_item):
         "update_file": update_file,
         "add_file_button": add_file_btn,
     }
-    # We always show the button unless the workspace is inactive (but it may be disabled)
-    if not workspace.is_active():
-        return context
-
+    # We always show the button to avoid confusion (but it may be disabled)
     add_file_btn.show = True
     # Enable the add file form button if the user has permission to add a
     # file and/or create a request

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -57,35 +57,40 @@ def test_copiloted_workspaces_index_as_copilot(live_server, page, copilot_user):
 
 
 @pytest.mark.parametrize(
-    "archived,ongoing,login_as,request_status,is_visible,is_enabled,tooltip",
+    "archived,ongoing,login_as,request_status,is_enabled,tooltip",
     [
-        # archived workspace and project not ongoing, button not shown
-        (True, False, "researcher", None, False, False, ""),
-        # archived workspace in ongoing project, button not shown
-        (True, True, "researcher", None, False, False, ""),
-        # not archived but project not ongoing, button not shown
-        (False, False, "researcher", None, False, False, ""),
-        # active project, checker with no role, shown disabled
+        # archived workspace and project not ongoing, disabled
+        (
+            True,
+            False,
+            "researcher",
+            None,
+            False,
+            "The project is not ongoing and this workspace is archived.",
+        ),
+        # archived workspace in ongoing project, disabled
+        (True, True, "researcher", None, False, "This workspace is archived."),
+        # not archived but project not ongoing, disabled
+        (False, False, "researcher", None, False, "The project is not ongoing."),
+        # active project, checker with no role, disabled
         (
             False,
             True,
             "checker",
             None,
-            True,
             False,
             "You do not have permission to add files to a request.",
         ),
-        # active project, user with role, shown enabled
-        (False, True, "researcher", None, True, True, ""),
-        # active project, current request editable, shown enabled
-        (False, True, "researcher", RequestStatus.PENDING, True, True, ""),
-        # active project, current request under review, shown disabled
+        # active project, user with role, enabled
+        (False, True, "researcher", None, True, ""),
+        # active project, current request editable, enabled
+        (False, True, "researcher", RequestStatus.PENDING, True, ""),
+        # active project, current request under review, disabled
         (
             False,
             True,
             "researcher",
             RequestStatus.SUBMITTED,
-            True,
             False,
             (
                 "There is currently a request under review for this workspace and you "
@@ -102,7 +107,6 @@ def test_content_buttons(
     ongoing,
     login_as,
     request_status,
-    is_visible,
     is_enabled,
     tooltip,
 ):
@@ -141,7 +145,7 @@ def test_content_buttons(
     update_is_visible = is_enabled
     assert_button_status(
         page,
-        add_is_visible=is_visible,
+        add_is_visible=True,
         add_is_enabled=is_enabled,
         update_is_visible=update_is_visible,
         update_is_enabled=is_enabled,
@@ -151,7 +155,7 @@ def test_content_buttons(
     page.goto(live_server.url + workspace.get_url(UrlPath("subdir/file.txt")))
     assert_button_status(
         page,
-        add_is_visible=is_visible,
+        add_is_visible=True,
         add_is_enabled=is_enabled,
         update_is_visible=False,
         update_is_enabled=False,


### PR DESCRIPTION
Fixes #1058 

The construction of the tooltip uses some branching logic - I have written it this way because I think it would be useful to inform the user exactly why the workspace is inactive.
If the workspace is archived and the project is not ongoing, as a user I presumably would want to know both reasons instead of just one. 