### PR TITLE
Allow selecting previously released files as supporting files in a new request

### DIFF
--- a/airlock/actions/create_release_request.py
+++ b/airlock/actions/create_release_request.py
@@ -131,8 +131,13 @@ def create_release_request(
                 group_data.total_files += 1
                 state = workspace.get_workspace_file_status(relpath)
 
-                if policies.can_add_file_to_request(workspace, relpath):
-                    if str(relpath) in supporting_files:
+                filetype = (
+                    RequestFileType.SUPPORTING
+                    if str(relpath) in supporting_files
+                    else RequestFileType.OUTPUT
+                )
+                if policies.can_add_file_to_request(workspace, relpath, filetype):
+                    if filetype == RequestFileType.SUPPORTING:
                         group_data.supporting_files_to_add.append(relpath)
                     else:
                         group_data.files_to_add.append(relpath)

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -625,7 +625,7 @@ class BusinessLogicLayer:
         relpath = UrlPath(relpath)
         workspace = self.get_workspace(release_request.workspace, user)
         permissions.check_user_can_add_file_to_request(
-            user, release_request, workspace, relpath
+            user, release_request, workspace, relpath, filetype
         )
 
         src = workspace.abspath(relpath)
@@ -694,7 +694,7 @@ class BusinessLogicLayer:
         relpath = UrlPath(relpath)
         workspace = self.get_workspace(release_request.workspace, user)
         permissions.check_user_can_add_file_to_request(
-            user, release_request, workspace, relpath
+            user, release_request, workspace, relpath, filetype
         )
 
         return self.replace_file_in_request(
@@ -718,7 +718,7 @@ class BusinessLogicLayer:
         old_group = request_file.group
         old_filetype = request_file.filetype
         permissions.check_user_can_change_request_file_properties(
-            user, release_request, workspace, relpath, old_filetype
+            user, release_request, workspace, relpath, filetype, old_filetype
         )
 
         request_file = release_request.get_request_file_from_output_path(relpath)

--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -715,13 +715,13 @@ class BusinessLogicLayer:
         relpath = UrlPath(relpath)
         workspace = self.get_workspace(release_request.workspace, user)
         request_file = release_request.get_request_file_from_output_path(relpath)
+        old_group = request_file.group
+        old_filetype = request_file.filetype
         permissions.check_user_can_change_request_file_properties(
-            user, release_request, workspace, relpath, request_file.filetype
+            user, release_request, workspace, relpath, old_filetype
         )
 
         request_file = release_request.get_request_file_from_output_path(relpath)
-        old_group = request_file.group
-        old_filetype = request_file.filetype
 
         # Ensure we're actually changing something
         if old_group == group_name and old_filetype == filetype:

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -101,6 +101,13 @@ class FileTypeForm(forms.Form):
         ),
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.initial.get("allow_output_filetype", True):
+            assert isinstance(self.fields["filetype"], forms.ChoiceField)
+            self.fields["filetype"].choices = [self.FILETYPE_CHOICES[1]]
+            self.fields["filetype"].initial = RequestFileType.SUPPORTING.name
+
 
 class RequiredOneBaseFormSet(BaseFormSet):  # type: ignore
     def clean(self):

--- a/airlock/forms.py
+++ b/airlock/forms.py
@@ -102,11 +102,19 @@ class FileTypeForm(forms.Form):
     )
 
     def __init__(self, *args, **kwargs):
+        initial = kwargs.get("initial", {})
+        allow_output_filetype = initial.pop("allow_output_filetype", True)
+        filetype_help_text = initial.pop("filetype_help_text", "")
+
         super().__init__(*args, **kwargs)
-        if not self.initial.get("allow_output_filetype", True):
+
+        if not allow_output_filetype:
             assert isinstance(self.fields["filetype"], forms.ChoiceField)
             self.fields["filetype"].choices = [self.FILETYPE_CHOICES[1]]
             self.fields["filetype"].initial = RequestFileType.SUPPORTING.name
+
+        if filetype_help_text:
+            self.fields["filetype"].help_text = filetype_help_text
 
 
 class RequiredOneBaseFormSet(BaseFormSet):  # type: ignore

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -320,6 +320,9 @@ def check_user_can_change_request_file_properties(
             f"Cannot change file group or type for request file {relpath}"
         )
 
+    status = workspace.get_workspace_file_status(relpath)
+    policies.check_file_can_be_requested_filetype(status, new_filetype)
+
     # If the user has permission to edit the request, check that the file
     # is not withdrawn
     # Note this is dependent on the user's current request

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -285,11 +285,11 @@ def user_can_change_request_file_properties(
     request: "ReleaseRequest",
     workspace: "Workspace",
     relpath: UrlPath,
-    request_filetype: RequestFileType,
+    old_filetype: RequestFileType,
 ):
     try:
         check_user_can_change_request_file_properties(
-            user, request, workspace, relpath, request_filetype
+            user, request, workspace, relpath, old_filetype
         )
     except exceptions.RequestPermissionDenied:
         return False
@@ -301,7 +301,7 @@ def check_user_can_change_request_file_properties(
     request: "ReleaseRequest",
     workspace: "Workspace",
     relpath: UrlPath,
-    request_filetype: RequestFileType,
+    old_filetype: RequestFileType,
 ):
     assert workspace.name == request.workspace
 
@@ -313,7 +313,7 @@ def check_user_can_change_request_file_properties(
     # If the user has permission to edit the request, check that the file
     # is not withdrawn
     # Note this is dependent on the user's current request
-    if request_filetype == RequestFileType.WITHDRAWN:
+    if old_filetype == RequestFileType.WITHDRAWN:
         raise exceptions.RequestPermissionDenied(
             "Cannot change file group or type for a withdrawn file"
         )

--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -176,18 +176,26 @@ def user_can_edit_request(user: User, request: "ReleaseRequest"):
 
 
 def check_user_can_add_file_to_request(
-    user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
+    user: User,
+    request: "ReleaseRequest",
+    workspace: "Workspace",
+    relpath: UrlPath,
+    filetype: RequestFileType,
 ):
     assert workspace.name == request.workspace
     check_user_can_edit_request(user, request)
-    policies.check_can_add_file_to_request(workspace, relpath)
+    policies.check_can_add_file_to_request(workspace, relpath, filetype)
 
 
 def user_can_add_file_to_request(
-    user: User, request: "ReleaseRequest", workspace: "Workspace", relpath: UrlPath
+    user: User,
+    request: "ReleaseRequest",
+    workspace: "Workspace",
+    relpath: UrlPath,
+    filetype: RequestFileType,
 ):  # pragma: no cover; not currently used
     try:
-        check_user_can_add_file_to_request(user, request, workspace, relpath)
+        check_user_can_add_file_to_request(user, request, workspace, relpath, filetype)
     except exceptions.RequestPermissionDenied:
         return False
     return True
@@ -285,11 +293,12 @@ def user_can_change_request_file_properties(
     request: "ReleaseRequest",
     workspace: "Workspace",
     relpath: UrlPath,
+    new_filetype: RequestFileType,
     old_filetype: RequestFileType,
 ):
     try:
         check_user_can_change_request_file_properties(
-            user, request, workspace, relpath, old_filetype
+            user, request, workspace, relpath, new_filetype, old_filetype
         )
     except exceptions.RequestPermissionDenied:
         return False
@@ -301,6 +310,7 @@ def check_user_can_change_request_file_properties(
     request: "ReleaseRequest",
     workspace: "Workspace",
     relpath: UrlPath,
+    new_filetype: RequestFileType,
     old_filetype: RequestFileType,
 ):
     assert workspace.name == request.workspace

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -50,15 +50,19 @@ def check_can_edit_request(request: "ReleaseRequest"):
         )
 
 
-def can_add_file_to_request(workspace: "Workspace", relpath: UrlPath):
+def can_add_file_to_request(
+    workspace: "Workspace", relpath: UrlPath, filetype: RequestFileType
+):
     try:
-        check_can_add_file_to_request(workspace, relpath)
+        check_can_add_file_to_request(workspace, relpath, filetype)
     except exceptions.RequestPermissionDenied:
         return False
     return True
 
 
-def check_can_add_file_to_request(workspace: "Workspace", relpath: UrlPath):
+def check_can_add_file_to_request(
+    workspace: "Workspace", relpath: UrlPath, filetype: RequestFileType
+):
     """
     This file can be added to the request.
     We expect that check_can_edit_request has already been called.

--- a/airlock/policies.py
+++ b/airlock/policies.py
@@ -50,6 +50,15 @@ def check_can_edit_request(request: "ReleaseRequest"):
         )
 
 
+def check_file_can_be_requested_filetype(
+    status: WorkspaceFileStatus | None, filetype: RequestFileType
+):
+    if filetype == RequestFileType.OUTPUT and status == WorkspaceFileStatus.RELEASED:
+        raise exceptions.RequestPermissionDenied(
+            "Released files cannot be added as output files"
+        )
+
+
 def can_add_file_to_request(
     workspace: "Workspace", relpath: UrlPath, filetype: RequestFileType
 ):
@@ -74,12 +83,9 @@ def check_can_add_file_to_request(
         )
 
     status = workspace.get_workspace_file_status(relpath)
-
-    # The file hasn't already been released
-    if status == WorkspaceFileStatus.RELEASED:
-        raise exceptions.RequestPermissionDenied("Cannot add released file to request")
-
+    check_file_can_be_requested_filetype(status, filetype)
     if status not in [
+        WorkspaceFileStatus.RELEASED,
         WorkspaceFileStatus.UNRELEASED,
         WorkspaceFileStatus.WITHDRAWN,
     ]:
@@ -128,11 +134,6 @@ def check_can_replace_file_in_request(
         )
 
     status = workspace.get_workspace_file_status(relpath)
-
-    # The file hasn't already been released
-    if status == WorkspaceFileStatus.RELEASED:
-        raise exceptions.RequestPermissionDenied("Cannot add released file to request")
-
     if status not in [
         WorkspaceFileStatus.WITHDRAWN,
         WorkspaceFileStatus.CONTENT_UPDATED,
@@ -154,6 +155,10 @@ def check_can_replace_file_in_request(
                 "Cannot add or update file with same type and group in request "
                 f"if it is in status {status}"
             )
+
+        # Validate the new filetype if we're changing it
+        if filetype and request_file and filetype != request_file.filetype:
+            check_file_can_be_requested_filetype(status, filetype)
 
 
 def can_update_file_on_request(workspace: "Workspace", relpath: UrlPath):

--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -72,10 +72,14 @@ function toggleSelectAll(elem) {
   const checkboxes = getVisibleCheckboxes();
 
   checkboxes.forEach((checkbox) => {
+    // Skip checkboxes for released files that are currently unchecked
+    if (checkbox.closest('tr')?.dataset.released === 'true' && !checkbox.checked) {
+      return;
+    }
     checkbox.checked = elem.checked;
   });
-
   saveCheckboxSessionState();
+  updateSelectAllCheckbox();
 }
 
 // Update the state of the select all checkbox. Checked if

--- a/airlock/templates/add_or_change_files.html
+++ b/airlock/templates/add_or_change_files.html
@@ -22,10 +22,15 @@
         {% endfor %}
         {% for formset_form in formset %}
           {% #list_group_item %}
-            <div class="flex items-center gap-2 justify-between">
-              <span>{{ formset_form.file.value }}</span>
-              {{ formset_form.file }}
-              {% form_radios field=formset_form.filetype class="flex flex-row whitespace-nowrap gap-2" selected=formset_form.filetype.initial %}
+            <div class="flex flex-col gap-1">
+              <div class="flex items-center gap-2 justify-between">
+                <span>{{ formset_form.file.value }}</span>
+                {{ formset_form.file }}
+                {% form_radios field=formset_form.filetype class="flex flex-row whitespace-nowrap gap-2" selected=formset_form.filetype.initial %}
+              </div>
+              {% if formset_form.filetype.help_text %}
+                <div class="text-xs text-slate-600">{{ formset_form.filetype.help_text }}</div>
+              {% endif %}
             </div>
           {% /list_group_item %}
         {% endfor %}

--- a/airlock/templates/file_browser/workspace/dir.html
+++ b/airlock/templates/file_browser/workspace/dir.html
@@ -105,7 +105,7 @@
     {% endfragment %}
     {% #clusterize_table header_row=header_row %}
       {% for path in path_item.children %}
-        <tr>
+        <tr {% if path.workspace_status and path.workspace_status.value == "RELEASED" %}data-released="true"{% endif %}>
           <td class="name"><a class="{{ path.html_classes }}" href="{{ path.url }}">{{ path.name }}</a></td>
           <td>{{ path.display_status }}</td>
           <td data-order="{{ path.size }}">{{ path.size_mb }}</td>

--- a/airlock/templates/file_browser/workspace/file.html
+++ b/airlock/templates/file_browser/workspace/file.html
@@ -19,11 +19,11 @@
           hx-swap="outerHtml"
         >
           {% if content_buttons.add_file %}
-            {% #button type="submit" name="action" value="add_files" variant="success" id="add-file-modal-button" %}
+            {% #button type="submit" name="action" value="add_files" variant="success" id="add-file-modal-button" tooltip=content_buttons.add_file_button.tooltip %}
               Add File to Request
             {% /button %}
           {% else %}
-            {% #button type="submit" name="action" value="update_files" variant="success" id="update-file-modal-button" %}
+            {% #button type="submit" name="action" value="update_files" variant="success" id="update-file-modal-button" tooltip=content_buttons.add_file_button.tooltip %}
               Update File in Request
             {% /button %}
           {% endif %}

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -21,6 +21,7 @@ from airlock.enums import (
     RequestStatus,
     ReviewTurnPhase,
     Visibility,
+    WorkspaceFileStatus,
 )
 from airlock.file_browser_api import get_request_tree
 from airlock.forms import (
@@ -786,6 +787,7 @@ def multiselect_update_files(request, multiform, release_request):
                     "file": f,
                     "filetype": request_file.filetype.name,
                     "allow_output_filetype": True,
+                    "filetype_help_text": "",
                 }
             )
         elif permissions.user_can_change_request_file_properties(
@@ -796,11 +798,18 @@ def multiselect_update_files(request, multiform, release_request):
             RequestFileType.SUPPORTING,
             request_file.filetype,
         ):
+            # Currently only released files are restricted to the SUPPORTING filetype
+            state = workspace.get_workspace_file_status(request_file.relpath)
+            assert state == WorkspaceFileStatus.RELEASED
             files_to_add.append(
                 {
                     "file": f,
                     "filetype": request_file.filetype.name,
                     "allow_output_filetype": False,
+                    "filetype_help_text": (
+                        "This file was previously released as an output. "
+                        "It can only be a supporting file."
+                    ),
                 }
             )
         else:

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -236,7 +236,19 @@ def _get_file_button_context(user, release_request, workspace, path_item):
         withdraw_btn.tooltip = "Withdraw this file from this request"
 
     if permissions.user_can_change_request_file_properties(
-        user, release_request, workspace, relpath, path_item.request_filetype
+        user,
+        release_request,
+        workspace,
+        relpath,
+        RequestFileType.OUTPUT,
+        path_item.request_filetype,
+    ) or permissions.user_can_change_request_file_properties(
+        user,
+        release_request,
+        workspace,
+        relpath,
+        RequestFileType.SUPPORTING,
+        path_item.request_filetype,
     ):
         change_file_properties_button.show = True
         change_file_properties_button.disabled = False
@@ -766,6 +778,14 @@ def multiselect_update_files(request, multiform, release_request):
             release_request,
             workspace,
             request_file.relpath,
+            RequestFileType.OUTPUT,
+            request_file.filetype,
+        ) or permissions.user_can_change_request_file_properties(
+            request.user,
+            release_request,
+            workspace,
+            request_file.relpath,
+            RequestFileType.SUPPORTING,
             request_file.filetype,
         ):
             files_to_add[f] = request_file.filetype.name

--- a/airlock/views/request.py
+++ b/airlock/views/request.py
@@ -240,14 +240,14 @@ def _get_file_button_context(user, release_request, workspace, path_item):
         release_request,
         workspace,
         relpath,
-        RequestFileType.OUTPUT,
+        RequestFileType.SUPPORTING,
         path_item.request_filetype,
     ) or permissions.user_can_change_request_file_properties(
         user,
         release_request,
         workspace,
         relpath,
-        RequestFileType.SUPPORTING,
+        RequestFileType.OUTPUT,
         path_item.request_filetype,
     ):
         change_file_properties_button.show = True
@@ -761,7 +761,7 @@ def multiselect_withdraw_files(request, multiform, release_request):
 
 
 def multiselect_update_files(request, multiform, release_request):
-    files_to_add = {}
+    files_to_add = []
     files_ignored = {}
     filegroup = None
     # validate which files can be added
@@ -780,7 +780,15 @@ def multiselect_update_files(request, multiform, release_request):
             request_file.relpath,
             RequestFileType.OUTPUT,
             request_file.filetype,
-        ) or permissions.user_can_change_request_file_properties(
+        ):
+            files_to_add.append(
+                {
+                    "file": f,
+                    "filetype": request_file.filetype.name,
+                    "allow_output_filetype": True,
+                }
+            )
+        elif permissions.user_can_change_request_file_properties(
             request.user,
             release_request,
             workspace,
@@ -788,7 +796,13 @@ def multiselect_update_files(request, multiform, release_request):
             RequestFileType.SUPPORTING,
             request_file.filetype,
         ):
-            files_to_add[f] = request_file.filetype.name
+            files_to_add.append(
+                {
+                    "file": f,
+                    "filetype": request_file.filetype.name,
+                    "allow_output_filetype": False,
+                }
+            )
         else:
             files_ignored[f] = "cannot change file group or type"
 
@@ -800,11 +814,7 @@ def multiselect_update_files(request, multiform, release_request):
         },
     )
 
-    filetype_formset = FileTypeFormSet(
-        initial=[
-            {"file": f, "filetype": filetype} for f, filetype in files_to_add.items()
-        ],
-    )
+    filetype_formset = FileTypeFormSet(initial=files_to_add)
     return TemplateResponse(
         request,
         template="add_or_change_files.html",

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -358,15 +358,18 @@ def multiselect_add_files(request, multiform, workspace):
 
         relpath = UrlPath(f)
         state = workspace.get_workspace_file_status(relpath)
+        file_data = {"file": f}
         if policies.can_add_file_to_request(workspace, relpath, RequestFileType.OUTPUT):
-            files_to_add.append(f)
+            file_data["allow_output_filetype"] = True
+            files_to_add.append(file_data)
         elif policies.can_add_file_to_request(
             workspace, relpath, RequestFileType.SUPPORTING
         ):
-            files_to_add.append(f)
             # We will add a note on the form in a later commit to explain
             # that this is a released file. Only assert for now.
             assert state == WorkspaceFileStatus.RELEASED
+            file_data["allow_output_filetype"] = False
+            files_to_add.append(file_data)
         else:
             rfile = workspace.current_request.get_request_file_from_output_path(f)
             files_ignored[f] = f"already in group {rfile.group}"
@@ -376,9 +379,7 @@ def multiselect_add_files(request, multiform, workspace):
         initial={"next_url": multiform.cleaned_data["next_url"]},
     )
 
-    filetype_formset = FileTypeFormSet(
-        initial=[{"file": f} for f in files_to_add],
-    )
+    filetype_formset = FileTypeFormSet(initial=files_to_add)
 
     return TemplateResponse(
         request,

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -157,7 +157,7 @@ def _get_file_button_context(user, workspace, path_item):
                 add_file_btn.tooltip = "This file has already been released"
             else:
                 # if it's a valid file, and it's not already released,
-                # but the uer can's add or update it, it must already
+                # but the user can't add or update it, it must already
                 # be on the request
                 assert file_status == WorkspaceFileStatus.UNDER_REVIEW
                 add_file_btn.tooltip = (

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -153,18 +153,16 @@ def _get_file_button_context(user, workspace, path_item):
             workspace, path_item.relpath, RequestFileType.SUPPORTING
         ):
             add_file_btn.disabled = False
+            add_file_btn.tooltip = "This file can be added, but only as supporting"
         elif policies.can_replace_file_in_request(workspace, path_item.relpath):
             add_file_btn.disabled = False
         else:
             # disabled due to specific file state; update the tooltips to say why
             if not path_item.is_valid():
                 add_file_btn.tooltip = "This file type cannot be added to a request"
-            elif file_status == WorkspaceFileStatus.RELEASED:
-                add_file_btn.tooltip = "This file has already been released"
             else:
-                # if it's a valid file, and it's not already released,
-                # but the user can't add or update it, it must already
-                # be on the request
+                # if it's a valid file but the user can't add or update it,
+                # it must already be on the request
                 assert file_status == WorkspaceFileStatus.UNDER_REVIEW
                 add_file_btn.tooltip = (
                     "This file has already been added to the current request"
@@ -360,14 +358,15 @@ def multiselect_add_files(request, multiform, workspace):
 
         relpath = UrlPath(f)
         state = workspace.get_workspace_file_status(relpath)
-        if policies.can_add_file_to_request(
-            workspace, relpath, RequestFileType.OUTPUT
-        ) or policies.can_add_file_to_request(
+        if policies.can_add_file_to_request(workspace, relpath, RequestFileType.OUTPUT):
+            files_to_add.append(f)
+        elif policies.can_add_file_to_request(
             workspace, relpath, RequestFileType.SUPPORTING
         ):
             files_to_add.append(f)
-        elif state == WorkspaceFileStatus.RELEASED:
-            files_ignored[f] = "already released"
+            # We will add a note on the form in a later commit to explain
+            # that this is a released file. Only assert for now.
+            assert state == WorkspaceFileStatus.RELEASED
         else:
             rfile = workspace.current_request.get_request_file_from_output_path(f)
             files_ignored[f] = f"already in group {rfile.group}"

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -358,17 +358,20 @@ def multiselect_add_files(request, multiform, workspace):
 
         relpath = UrlPath(f)
         state = workspace.get_workspace_file_status(relpath)
-        file_data = {"file": f}
+        file_data = {"file": f, "filetype_help_text": ""}
         if policies.can_add_file_to_request(workspace, relpath, RequestFileType.OUTPUT):
             file_data["allow_output_filetype"] = True
             files_to_add.append(file_data)
         elif policies.can_add_file_to_request(
             workspace, relpath, RequestFileType.SUPPORTING
         ):
-            # We will add a note on the form in a later commit to explain
-            # that this is a released file. Only assert for now.
+            # Currently only released files are restricted to the SUPPORTING filetype
             assert state == WorkspaceFileStatus.RELEASED
             file_data["allow_output_filetype"] = False
+            file_data["filetype_help_text"] = (
+                "This file was previously released as an output. "
+                "It can be added, but only as a supporting file."
+            )
             files_to_add.append(file_data)
         else:
             rfile = workspace.current_request.get_request_file_from_output_path(f)

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -145,7 +145,13 @@ def _get_file_button_context(user, workspace, path_item):
         add_file_btn.tooltip = dir_button.tooltip
     else:
         # Check we can add or update the specific file
-        if policies.can_add_file_to_request(workspace, path_item.relpath):
+        if policies.can_add_file_to_request(
+            workspace, path_item.relpath, RequestFileType.OUTPUT
+        ):
+            add_file_btn.disabled = False
+        elif policies.can_add_file_to_request(
+            workspace, path_item.relpath, RequestFileType.SUPPORTING
+        ):
             add_file_btn.disabled = False
         elif policies.can_replace_file_in_request(workspace, path_item.relpath):
             add_file_btn.disabled = False
@@ -354,7 +360,11 @@ def multiselect_add_files(request, multiform, workspace):
 
         relpath = UrlPath(f)
         state = workspace.get_workspace_file_status(relpath)
-        if policies.can_add_file_to_request(workspace, relpath):
+        if policies.can_add_file_to_request(
+            workspace, relpath, RequestFileType.OUTPUT
+        ) or policies.can_add_file_to_request(
+            workspace, relpath, RequestFileType.SUPPORTING
+        ):
             files_to_add.append(f)
         elif state == WorkspaceFileStatus.RELEASED:
             files_ignored[f] = "already released"

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -778,6 +778,10 @@ def test_add_previously_released_txt_file_to_pending_request(
     add_file_modal_button.click()
     expect(page.get_by_role("radio", name="Output")).not_to_be_visible()
     expect(page.get_by_role("radio", name="Supporting")).to_be_checked()
+    expect(page.locator("body")).to_contain_text(
+        "This file was previously released as an output. "
+        "It can be added, but only as a supporting file."
+    )
 
     # Fill in a new group name
     page.locator("#id_new_filegroup").fill("new-group")
@@ -796,6 +800,10 @@ def test_add_previously_released_txt_file_to_pending_request(
     click_and_htmx(page, page.locator("#update-file-modal-button"))
     expect(page.get_by_role("radio", name="Output")).not_to_be_visible()
     expect(page.get_by_role("radio", name="Supporting")).to_be_checked()
+    expect(page.locator("body")).to_contain_text(
+        "This file was previously released as an output. "
+        "It can only be a supporting file."
+    )
 
     # Change the file group
     page.locator("#id_new_filegroup").fill("another-group")

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -776,11 +776,10 @@ def test_add_previously_released_txt_file_to_pending_request(
 
     # Click the add file button to open the modal
     add_file_modal_button.click()
-    expect(page.get_by_role("radio", name="Output")).to_be_checked()
-    expect(page.get_by_role("radio", name="Supporting")).to_be_visible()
+    expect(page.get_by_role("radio", name="Output")).not_to_be_visible()
+    expect(page.get_by_role("radio", name="Supporting")).to_be_checked()
 
-    # Select Supporting; fill in a new group name
-    click_and_htmx(page, page.get_by_role("radio", name="Supporting"))
+    # Fill in a new group name
     page.locator("#id_new_filegroup").fill("new-group")
 
     # Click the button to add the file to the release request
@@ -795,7 +794,7 @@ def test_add_previously_released_txt_file_to_pending_request(
 
     # Click the "Update file properties" button
     click_and_htmx(page, page.locator("#update-file-modal-button"))
-    expect(page.get_by_role("radio", name="Output")).to_be_visible()
+    expect(page.get_by_role("radio", name="Output")).not_to_be_visible()
     expect(page.get_by_role("radio", name="Supporting")).to_be_checked()
 
     # Change the file group

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -9,7 +9,7 @@ from airlock.enums import RequestStatus
 from airlock.types import UrlPath
 from tests import factories
 
-from .conftest import click_and_htmx
+from .conftest import click_and_htmx, login_as_user
 
 
 def login_as(live_server, page, username):
@@ -722,3 +722,85 @@ def test_e2e_filter_submit(page, live_server, dev_users):
     # Confirm that the two created requests are visible again
     expect(page.locator("body")).to_contain_text("by Researcher")
     expect(page.locator("body")).to_contain_text("All Reviews Submitted")
+
+
+@pytest.mark.parametrize(
+    "multiselect",
+    [True, False],
+)
+def test_add_previously_released_txt_file_to_pending_request(
+    mock_old_api,
+    live_server,
+    page,
+    context,
+    multiselect,
+):
+    user_data = factories.create_api_user(
+        username="author",
+        workspaces={"workspace": factories.create_api_workspace(project="Project 1")},
+        output_checker=False,
+    )
+    user = login_as_user(live_server, context, user_data)
+    workspace = factories.create_workspace("workspace", user)
+    filepath = "subdir/file.txt"
+    factories.write_workspace_file("workspace", path=filepath, contents="test")
+
+    # Create a previous release for this file
+    factories.create_request_at_status(
+        "workspace",
+        files=[factories.request_file(path=filepath, contents="test", approved=True)],
+        status=RequestStatus.RELEASED,
+    )
+
+    # Create a current pending request
+    factories.create_release_request("workspace", user)
+
+    if multiselect:
+        page.goto(live_server.url + workspace.get_url(UrlPath("subdir/")))
+        expect(page.locator(".clusterized")).to_be_visible()
+        page.locator("input.selectall").click()
+    else:
+        page.goto(live_server.url + workspace.get_url(UrlPath(filepath)))
+
+    # Verify the add file button is visible and enabled
+    add_file_modal_button = page.locator("#add-file-modal-button")
+    expect(add_file_modal_button).to_be_visible()
+    expect(add_file_modal_button).to_be_enabled()
+
+    if not multiselect:
+        # An explanatory tooltip is shown on hover
+        add_file_modal_button.hover()
+        expect(add_file_modal_button).to_contain_text(
+            "This file can be added, but only as supporting"
+        )
+
+    # Click the add file button to open the modal
+    add_file_modal_button.click()
+    expect(page.get_by_role("radio", name="Output")).to_be_checked()
+    expect(page.get_by_role("radio", name="Supporting")).to_be_visible()
+
+    # Select Supporting; fill in a new group name
+    click_and_htmx(page, page.get_by_role("radio", name="Supporting"))
+    page.locator("#id_new_filegroup").fill("new-group")
+
+    # Click the button to add the file to the release request
+    form_element = page.get_by_role("form")
+    click_and_htmx(page, form_element.locator("#add-or-change-file-button"))
+
+    # Go to the previously released file in the current request
+    click_and_htmx(page, page.locator("#current-request-button"))
+    current_request = bll.get_current_request("workspace", user)
+    assert current_request is not None
+    page.goto(live_server.url + current_request.get_url("new-group/subdir/file.txt"))
+
+    # Click the "Update file properties" button
+    click_and_htmx(page, page.locator("#update-file-modal-button"))
+    expect(page.get_by_role("radio", name="Output")).to_be_visible()
+    expect(page.get_by_role("radio", name="Supporting")).to_be_checked()
+
+    # Change the file group
+    page.locator("#id_new_filegroup").fill("another-group")
+    click_and_htmx(page, page.get_by_role("form").locator("#add-or-change-file-button"))
+    expect(page.locator("body")).to_contain_text(
+        "has been moved to new group another-group"
+    )

--- a/tests/functional/test_e2e.py
+++ b/tests/functional/test_e2e.py
@@ -758,7 +758,17 @@ def test_add_previously_released_txt_file_to_pending_request(
     if multiselect:
         page.goto(live_server.url + workspace.get_url(UrlPath("subdir/")))
         expect(page.locator(".clusterized")).to_be_visible()
+
+        # Select all does not select the file
         page.locator("input.selectall").click()
+        expect(
+            page.locator(f'input[name="selected"][value="{filepath}"]')
+        ).not_to_be_checked()
+
+        # Click on the checkbox for the file
+        click_and_htmx(
+            page, page.locator(f'input[name="selected"][value="{filepath}"]')
+        )
     else:
         page.goto(live_server.url + workspace.get_url(UrlPath(filepath)))
 

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -168,8 +168,16 @@ def test_content_buttons(
     [
         # no current request, button enabled
         (None, False, False, None, "txt", True, ""),
-        # no current request, previously released file, button disabled
-        (None, True, False, None, "txt", False, "This file has already been released"),
+        # no current request, previously released file, button enabled
+        (
+            None,
+            True,
+            False,
+            None,
+            "txt",
+            True,
+            "This file can be added, but only as supporting",
+        ),
         # no current request, invalid file type, button disabled
         (
             None,
@@ -192,15 +200,15 @@ def test_content_buttons(
             False,
             "This file type cannot be added to a request",
         ),
-        # current request, file not currently added, previously released, button disabled
+        # current request, file not currently added, previously released, button enabled
         (
             RequestStatus.PENDING,
             True,
             False,
             None,
             "txt",
-            False,
-            "This file has already been released",
+            True,
+            "This file can be added, but only as supporting",
         ),
         # current request, file already added, button disabled
         (

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -2374,7 +2374,7 @@ def test_workspace_multiselect_change_file_properties_released_file(
 
     assert response.status_code == 200
     assert "test/path1.txt" in response.rendered_content
-    assert response.rendered_content.count('value="OUTPUT"') == 1
+    assert response.rendered_content.count('value="OUTPUT"') == 0
     assert response.rendered_content.count('value="SUPPORTING"') == 1
 
 

--- a/tests/integration/views/test_request.py
+++ b/tests/integration/views/test_request.py
@@ -1884,6 +1884,66 @@ def test_file_change_file_properties(airlock_client, new_group, new_filetype):
     assert request_file.filetype == RequestFileType[new_filetype]
 
 
+def test_file_change_file_properties_released_file_change_group(
+    airlock_client, mock_old_api
+):
+    airlock_client.login(username="author", workspaces=["test1"], output_checker=False)
+    test_relpath = "path/test.txt"
+
+    # create a previously released request containing this file
+    factories.create_request_at_status(
+        "test1",
+        author=airlock_client.user,
+        status=RequestStatus.RELEASED,
+        files=[
+            factories.request_file(
+                "group", test_relpath, contents="test", approved=True
+            ),
+        ],
+    )
+    release_request = factories.create_request_at_status(
+        "test1",
+        author=airlock_client.user,
+        status=RequestStatus.PENDING,
+        files=[
+            factories.request_file(
+                "group", test_relpath, filetype=RequestFileType.SUPPORTING
+            ),
+        ],
+    )
+
+    # ensure it does exist
+    release_request.get_request_file_from_urlpath(f"group/{test_relpath}")
+    with pytest.raises(exceptions.FileNotFound):
+        release_request.get_request_file_from_urlpath(f"new-group/{test_relpath}")
+
+    response = airlock_client.post(
+        f"/requests/change-properties/{release_request.id}",
+        data={
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-0-file": f"group/{test_relpath}",
+            "form-0-filetype": "SUPPORTING",
+            "next_url": release_request.get_url(f"group/{test_relpath}"),
+            "filegroup": "group",
+            # new filegroup overrides a selected existing one (or the default)
+            "new_filegroup": "new-group",
+        },
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == release_request.get_url(
+        f"new-group/{test_relpath}"
+    )
+
+    persisted_request = factories.refresh_release_request(release_request)
+    request_file = persisted_request.get_request_file_from_urlpath(
+        f"new-group/{test_relpath}"
+    )
+    with pytest.raises(exceptions.FileNotFound):
+        persisted_request.get_request_file_from_urlpath(f"group/{test_relpath}")
+    assert request_file.filetype == RequestFileType.SUPPORTING
+
+
 def test_file_change_file_properties_multiple_files(airlock_client):
     airlock_client.login(username="author", workspaces=["test1"], output_checker=False)
     test_relpath = "path/test.txt"
@@ -1936,9 +1996,27 @@ def test_file_change_file_properties_multiple_files(airlock_client):
     assert request_file1.filetype == RequestFileType.OUTPUT
 
 
-def test_file_change_file_properties_no_changes(airlock_client):
+@pytest.mark.parametrize(
+    "is_previously_released_output",
+    [True, False],
+)
+def test_file_change_file_properties_no_changes(
+    is_previously_released_output, airlock_client, mock_old_api
+):
     airlock_client.login(username="author", workspaces=["test1"], output_checker=False)
     test_relpath = "path/test.txt"
+
+    if is_previously_released_output:
+        factories.create_request_at_status(
+            "test1",
+            author=airlock_client.user,
+            status=RequestStatus.RELEASED,
+            files=[
+                factories.request_file(
+                    "group", test_relpath, contents="test", approved=True
+                ),
+            ],
+        )
 
     release_request = factories.create_request_at_status(
         "test1",
@@ -1946,7 +2024,7 @@ def test_file_change_file_properties_no_changes(airlock_client):
         status=RequestStatus.PENDING,
         files=[
             factories.request_file(
-                "group", test_relpath, filetype=RequestFileType.OUTPUT
+                "group", test_relpath, filetype=RequestFileType.SUPPORTING
             ),
         ],
     )
@@ -1965,7 +2043,7 @@ def test_file_change_file_properties_no_changes(airlock_client):
             "form-TOTAL_FORMS": "1",
             "form-INITIAL_FORMS": "1",
             "form-0-file": f"group/{test_relpath}",
-            "form-0-filetype": "OUTPUT",
+            "form-0-filetype": "SUPPORTING",
             "next_url": release_request.get_url(f"group/{test_relpath}"),
             "filegroup": "group",
             "new_filegroup": "",
@@ -1981,7 +2059,7 @@ def test_file_change_file_properties_no_changes(airlock_client):
     request_file = persisted_request.get_request_file_from_urlpath(
         f"group/{test_relpath}"
     )
-    assert request_file.filetype == RequestFileType.OUTPUT
+    assert request_file.filetype == RequestFileType.SUPPORTING
     # Nothing to do, no new audit logs
     assert (
         len(bll.get_request_audit_log(airlock_client.user, persisted_request, "group"))
@@ -2252,6 +2330,52 @@ def test_request_multiselect_change_file_properties_not_permitted(airlock_client
         f'<form action="/requests/change-properties/{release_request.id}" method="POST"'
         in response.rendered_content
     )
+
+
+def test_workspace_multiselect_change_file_properties_released_file(
+    airlock_client, bll, mock_old_api
+):
+    airlock_client.login(workspaces=["test1"])
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path1.txt", "foo")
+
+    # create previously released request
+    factories.create_request_at_status(
+        workspace,
+        RequestStatus.RELEASED,
+        author=airlock_client.user,
+        files=[
+            factories.request_file(path="test/path1.txt", contents="foo", approved=True)
+        ],
+    )
+
+    # create current pending request with the file added as supporting
+    release_request = factories.create_request_at_status(
+        workspace,
+        RequestStatus.PENDING,
+        author=airlock_client.user,
+        files=[
+            factories.request_file(
+                path="test/path1.txt",
+                contents="foo",
+                filetype=RequestFileType.SUPPORTING,
+            )
+        ],
+    )
+
+    response = airlock_client.post(
+        f"/requests/multiselect/{release_request.id}",
+        data={
+            "action": "update_files",
+            "selected": ["group/test/path1.txt"],
+            "next_url": release_request.get_url("group"),
+        },
+    )
+
+    assert response.status_code == 200
+    assert "test/path1.txt" in response.rendered_content
+    assert response.rendered_content.count('value="OUTPUT"') == 1
+    assert response.rendered_content.count('value="SUPPORTING"') == 1
 
 
 @pytest.mark.parametrize("action", ["withdraw_files", "update_files"])

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -1000,7 +1000,7 @@ def test_workspace_multiselect_add_released_file(airlock_client, bll, mock_old_a
     assert response.status_code == 200
     assert "test/path1.txt" in response.rendered_content
     assert "test/path2.txt" in response.rendered_content
-    assert response.rendered_content.count('value="OUTPUT"') == 2
+    assert response.rendered_content.count('value="OUTPUT"') == 1
     assert response.rendered_content.count('value="SUPPORTING"') == 2
 
 

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -560,19 +560,27 @@ def test_workspace_view_file_add_to_request(airlock_client, user, can_see_form):
         (RequestStatus.APPROVED, False, [], True),
         (
             # In Approved status, files are released but may not be uploaded yet;
-            # Released files cannot be added to a new request as an output file
+            # Released files can be added to a new request as supporting files
             RequestStatus.APPROVED,
             False,
-            [factories.request_file(path="file.txt", approved=True)],
-            False,
+            [
+                factories.request_file(
+                    path="file.txt", filetype=RequestFileType.SUPPORTING
+                )
+            ],
+            True,
         ),
         (RequestStatus.RELEASED, False, [], True),
         (
-            # Released files cannot be added to a new request as an output file
+            # Released files can be added to a new request as supporting files
             RequestStatus.RELEASED,
             False,
-            [factories.request_file(path="file.txt", approved=True)],
-            False,
+            [
+                factories.request_file(
+                    path="file.txt", filetype=RequestFileType.SUPPORTING
+                )
+            ],
+            True,
         ),
     ],
 )
@@ -958,9 +966,7 @@ def test_workspace_multiselect_update_files(
     assert response.rendered_content.count("file cannot be updated") == ignored_count
 
 
-def test_workspace_multiselect_add_released_file_not_valid(
-    airlock_client, bll, mock_old_api
-):
+def test_workspace_multiselect_add_released_file(airlock_client, bll, mock_old_api):
     airlock_client.login(workspaces=["test1"])
     workspace = factories.create_workspace("test1")
     factories.write_workspace_file(workspace, "test/path1.txt", "foo")
@@ -994,8 +1000,8 @@ def test_workspace_multiselect_add_released_file_not_valid(
     assert response.status_code == 200
     assert "test/path1.txt" in response.rendered_content
     assert "test/path2.txt" in response.rendered_content
-    assert response.rendered_content.count("already released") == 1
-    assert response.rendered_content.count('value="OUTPUT"') == 1
+    assert response.rendered_content.count('value="OUTPUT"') == 2
+    assert response.rendered_content.count('value="SUPPORTING"') == 2
 
 
 def test_workspace_multiselect_bad_action(airlock_client, bll):
@@ -1283,6 +1289,50 @@ def test_workspace_request_file_invalid_formset(airlock_client, bll):
     message = all_messages[0]
     assert message.level == messages.ERROR
     assert "At least one form must be completed" in message.message
+
+
+@pytest.mark.parametrize(
+    "form_filetype,expected_level,expected_message",
+    [
+        ("SUPPORTING", messages.SUCCESS, "Supporting file has been added"),
+        ("OUTPUT", messages.ERROR, "Released files cannot be added as output files"),
+    ],
+)
+def test_workspace_request_file_add_released_file(
+    form_filetype, expected_level, expected_message, airlock_client, mock_old_api
+):
+    airlock_client.login(workspaces=["test1"])
+    workspace = factories.create_workspace("test1")
+    factories.write_workspace_file(workspace, "test/path.txt", "test")
+    # create previously released request
+    factories.create_request_at_status(
+        workspace,
+        RequestStatus.RELEASED,
+        author=airlock_client.user,
+        files=[
+            factories.request_file(path="test/path.txt", contents="test", approved=True)
+        ],
+    )
+    factories.create_release_request(workspace, airlock_client.user)
+
+    response = airlock_client.post(
+        "/workspaces/add-file-to-request/test1",
+        data={
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "1",
+            "form-0-file": "test/path.txt",
+            "form-0-filetype": form_filetype,
+            "filegroup": "default",
+            "next_url": workspace.get_url(UrlPath("test/path.txt")),
+        },
+        follow=True,
+    )
+
+    all_messages = [msg for msg in response.context["messages"]]
+    assert len(all_messages) == 1
+    message = all_messages[0]
+    assert message.level == expected_level
+    assert expected_message in message.message
 
 
 def test_workspace_request_update_file_invalid_status(airlock_client, bll):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1922,7 +1922,37 @@ def test_replace_unchanged_file_with_new_filegroup(bll):
     assert request_file.group == "new-group"
 
 
-def test_cannot_replace_unchanged_file_with_same_filegroup(bll):
+def test_replace_unchanged_file_with_new_filetype(bll):
+    author = factories.create_airlock_user(
+        username="author", workspaces=["workspace"], output_checker=False
+    )
+    relpath = UrlPath("path/file.txt")
+    workspace = factories.create_workspace("workspace")
+    factories.write_workspace_file(workspace, relpath)
+    release_request = factories.create_request_at_status(
+        "workspace",
+        author=author,
+        status=RequestStatus.RETURNED,
+        files=[
+            factories.request_file(
+                path=relpath,
+                group="group",
+                filetype=RequestFileType.OUTPUT,
+                approved=True,
+            )
+        ],
+    )
+
+    # No change to file content, same group
+    bll.replace_file_in_request(
+        release_request, relpath, author, "group", RequestFileType.SUPPORTING
+    )
+    release_request = factories.refresh_release_request(release_request)
+    request_file = release_request.get_request_file_from_output_path(relpath)
+    assert request_file.filetype == RequestFileType.SUPPORTING
+
+
+def test_cannot_replace_unchanged_file_with_same_filegroup_and_filetype(bll):
     author = factories.create_airlock_user(
         username="author", workspaces=["workspace"], output_checker=False
     )

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -1668,13 +1668,18 @@ def test_add_file_to_request_already_released(bll, mock_old_api):
     bll.add_file_to_request(
         release_request, "supporting.txt", user, filetype=RequestFileType.OUTPUT
     )
-    # Can't add the released file
+    # Can't add the released file as an output file
     with pytest.raises(
-        exceptions.RequestPermissionDenied, match=r"Cannot add released file"
+        exceptions.RequestPermissionDenied,
+        match=r"Released files cannot be added as output files",
     ):
         bll.add_file_to_request(
             release_request, "file.txt", user, filetype=RequestFileType.OUTPUT
         )
+    # but can add it as a supporting file
+    bll.add_file_to_request(
+        release_request, "file.txt", user, filetype=RequestFileType.SUPPORTING
+    )
 
 
 def test_add_file_to_request_with_audit_kwargs(bll):
@@ -1922,13 +1927,34 @@ def test_replace_unchanged_file_with_new_filegroup(bll):
     assert request_file.group == "new-group"
 
 
-def test_replace_unchanged_file_with_new_filetype(bll):
+def test_replace_unchanged_file_with_new_filetype(bll, mock_old_api):
     author = factories.create_airlock_user(
         username="author", workspaces=["workspace"], output_checker=False
     )
     relpath = UrlPath("path/file.txt")
+    released_relpath = UrlPath("path/released.txt")
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, relpath)
+    factories.write_workspace_file(
+        workspace, released_relpath, contents="released content"
+    )
+
+    # Create a previously released request containing released.txt as OUTPUT
+    factories.create_request_at_status(
+        "workspace",
+        author=author,
+        status=RequestStatus.RELEASED,
+        files=[
+            factories.request_file(
+                path=released_relpath,
+                group="group",
+                filetype=RequestFileType.OUTPUT,
+                contents="released content",
+                approved=True,
+            )
+        ],
+    )
+
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -1939,7 +1965,12 @@ def test_replace_unchanged_file_with_new_filetype(bll):
                 group="group",
                 filetype=RequestFileType.OUTPUT,
                 approved=True,
-            )
+            ),
+            factories.request_file(
+                path=released_relpath,
+                group="group",
+                filetype=RequestFileType.SUPPORTING,
+            ),
         ],
     )
 
@@ -1950,6 +1981,13 @@ def test_replace_unchanged_file_with_new_filetype(bll):
     release_request = factories.refresh_release_request(release_request)
     request_file = release_request.get_request_file_from_output_path(relpath)
     assert request_file.filetype == RequestFileType.SUPPORTING
+
+    # No change to file content, same group
+    # But previously released files cannot be changed to OUTPUT type
+    with pytest.raises(exceptions.RequestPermissionDenied):
+        bll.replace_file_in_request(
+            release_request, released_relpath, author, "group", RequestFileType.OUTPUT
+        )
 
 
 def test_cannot_replace_unchanged_file_with_same_filegroup_and_filetype(bll):
@@ -2453,6 +2491,59 @@ def test_change_file_properties_invalid_workspace_file(bll):
     )
     release_request = factories.refresh_release_request(release_request)
     request_file = release_request.get_request_file_from_output_path(path)
+    assert request_file.group == "new-group"
+    assert request_file.filetype == RequestFileType.SUPPORTING
+
+
+def test_change_file_properties_released_file(bll, mock_old_api):
+    author = factories.create_airlock_user(username="author", workspaces=["workspace"])
+    path = "path/file1.txt"
+    # release the file
+    factories.create_request_at_status(
+        "workspace",
+        RequestStatus.RELEASED,
+        author=author,
+        files=[
+            factories.request_file(path=path, contents="foo", approved=True),
+        ],
+    )
+    # make a new request with the released file as a supporting file
+    release_request = factories.create_request_at_status(
+        "workspace",
+        author=author,
+        status=RequestStatus.PENDING,
+        files=[
+            factories.request_file(
+                path=path, contents="foo", filetype=RequestFileType.SUPPORTING
+            ),
+        ],
+    )
+
+    # We CAN change the file group on a released file
+    bll.change_file_properties_in_request(
+        release_request,
+        path,
+        group_name="new-group",
+        user=author,
+        filetype=RequestFileType.SUPPORTING,
+    )
+    release_request = factories.refresh_release_request(release_request)
+    request_file = release_request.get_request_file_from_output_path(path)
+    assert request_file.group == "new-group"
+    assert request_file.filetype == RequestFileType.SUPPORTING
+
+    # but we cannot change the filetype to OUTPUT
+    with pytest.raises(
+        exceptions.RequestPermissionDenied,
+        match=r"Released files cannot be added as output files",
+    ):
+        bll.change_file_properties_in_request(
+            release_request,
+            path,
+            group_name="new-group",
+            user=author,
+            filetype=RequestFileType.OUTPUT,
+        )
     assert request_file.group == "new-group"
     assert request_file.filetype == RequestFileType.SUPPORTING
 

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -158,13 +158,34 @@ def test_user_can_review_request(output_checker, author, workspaces, can_review)
             permissions.check_user_can_review_request(user, release_request)
 
 
-def test_user_can_change_request_file_properties(bll):
+def test_user_can_change_request_file_properties(bll, mock_old_api):
     author = factories.create_airlock_user(
         username="author", workspaces=["workspace"], output_checker=False
     )
     relpath = UrlPath("path/file.txt")
+    released_relpath = UrlPath("path/released.txt")
     workspace = factories.create_workspace("workspace")
     factories.write_workspace_file(workspace, relpath)
+    factories.write_workspace_file(
+        workspace, released_relpath, contents="released content"
+    )
+
+    # Create a previously released request containing released.txt as OUTPUT
+    factories.create_request_at_status(
+        "workspace",
+        author=author,
+        status=RequestStatus.RELEASED,
+        files=[
+            factories.request_file(
+                path=released_relpath,
+                group="group",
+                filetype=RequestFileType.OUTPUT,
+                contents="released content",
+                approved=True,
+            )
+        ],
+    )
+
     release_request = factories.create_request_at_status(
         "workspace",
         author=author,
@@ -175,7 +196,12 @@ def test_user_can_change_request_file_properties(bll):
                 group="group",
                 filetype=RequestFileType.OUTPUT,
                 approved=True,
-            )
+            ),
+            factories.request_file(
+                path=released_relpath,
+                group="group",
+                filetype=RequestFileType.SUPPORTING,
+            ),
         ],
     )
 
@@ -241,4 +267,37 @@ def test_user_can_change_request_file_properties(bll):
     # File cannot be updated because there is no valid workspace file
     assert not permissions.user_can_update_file_on_request(
         author, release_request, workspace, relpath
+    )
+
+    # Previously released files cannot be changed to OUTPUT type
+    assert not permissions.user_can_change_request_file_properties(
+        author,
+        release_request,
+        workspace,
+        released_relpath,
+        RequestFileType.OUTPUT,
+        RequestFileType.SUPPORTING,
+    )
+
+    # change released file content in workspace
+    factories.write_workspace_file(
+        workspace, released_relpath, contents="changed content"
+    )
+
+    # refresh workspace
+    workspace = bll.get_workspace("workspace", author)
+
+    # Released file can be updated because its content has changed
+    assert permissions.user_can_update_file_on_request(
+        author, release_request, workspace, released_relpath
+    )
+
+    # Can change from SUPPORTING to OUTPUT when content has changed
+    assert permissions.user_can_change_request_file_properties(
+        author,
+        release_request,
+        workspace,
+        released_relpath,
+        RequestFileType.OUTPUT,
+        RequestFileType.SUPPORTING,
     )

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -184,7 +184,12 @@ def test_user_can_change_request_file_properties(bll):
 
     # File properties can be changed
     assert permissions.user_can_change_request_file_properties(
-        author, release_request, workspace, relpath, RequestFileType.OUTPUT
+        author,
+        release_request,
+        workspace,
+        relpath,
+        RequestFileType.OUTPUT,
+        RequestFileType.OUTPUT,
     )
     # File cannot be updated because its content hasn't changed
     assert not permissions.user_can_update_file_on_request(
@@ -203,7 +208,12 @@ def test_user_can_change_request_file_properties(bll):
 
     # File properties can be changed
     assert permissions.user_can_change_request_file_properties(
-        author, release_request, workspace, relpath, RequestFileType.OUTPUT
+        author,
+        release_request,
+        workspace,
+        relpath,
+        RequestFileType.OUTPUT,
+        RequestFileType.OUTPUT,
     )
     # File can be updated because its content has changed
     assert permissions.user_can_update_file_on_request(
@@ -221,7 +231,12 @@ def test_user_can_change_request_file_properties(bll):
 
     # File properties can be changed
     assert permissions.user_can_change_request_file_properties(
-        author, release_request, workspace, relpath, RequestFileType.OUTPUT
+        author,
+        release_request,
+        workspace,
+        relpath,
+        RequestFileType.OUTPUT,
+        RequestFileType.OUTPUT,
     )
     # File cannot be updated because there is no valid workspace file
     assert not permissions.user_can_update_file_on_request(


### PR DESCRIPTION
Closes #961 .

There are two main parts to this change:
- A policy change such that adding previously released output files to new requests is permissible, subject to a filetype check that they are not being added as output files
- A UI change that varies the filetype options available for selection by the user depending on whether the file is allowed to be an output file (since released files aren't).

Consulted with users on [whether the select all button should skip over previously released files to not cause annoyances](https://bennettoxford.slack.com/archives/C02HJTL065A/p1773927504499389). 
We didn't get a lot of feedback; I discussed with @suzannehamilton and we thought that we can proceed with skipping over released files in the select-all (i.e. Option 2 in the poll). If users get confused, presumably we will hear from them.