### PR TITLE
Fix resizing bug after alert dismissal

### DIFF
--- a/assets/src/scripts/clusterize-table.js
+++ b/assets/src/scripts/clusterize-table.js
@@ -127,6 +127,9 @@ function initializeClusterize() {
   // We need to update all the cell widths whenever the window resizes. But
   // we use a debounce function so that the update is not called continuously
   window.addEventListener('resize', debounce(updateCellWidths, 150));
+  // When an alert is dismissed, the available vertical space increases.
+  // Re-run fitHeight so #scrollArea's max-height reflects the new layout.
+  document.body.addEventListener('alert-dismissed', fitHeight);
 }
 
 initializeClusterize();

--- a/assets/src/scripts/resizer.js
+++ b/assets/src/scripts/resizer.js
@@ -79,3 +79,33 @@ ro.observe(document.documentElement);
  * has been loaded.
  */
 document.body.addEventListener("htmx:afterSettle", () => setContentHeight());
+
+/**
+ * Alert behaviour is controlled by the _alert.js script which we pull in from upstream
+ * job-server: https://github.com/opensafely-core/job-server/blob/df4531db14f53f016f5919d12871ad457f9911f1/assets/src/scripts/_alert.js
+ * 
+ * Alerts may be injected into the DOM after initial page load (e.g. via HTMX),
+ * so we cannot attach listeners at startup. 
+ * Instead, watch for alert elements being removed from the DOM (which is how _alert.js
+ * dismisses them) and trigger a resize. The 300ms delay matches the CSS transition duration in
+ * _alert.js so that the layout has fully settled before we recalculate.
+ *
+ * We also dispatch a custom "alert-dismissed" event so that other scripts
+ * (e.g. clusterize-table.js) can react to the layout change.
+ */
+const alertObserver = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    for (const node of mutation.removedNodes) {
+      if (node instanceof Element && node.matches('[role="alert"]')) {
+        setTimeout(() => {
+          setContentHeight();
+          setTreeHeight();
+          document.body.dispatchEvent(new CustomEvent("alert-dismissed"));
+        }, 300);
+        return;
+      }
+    }
+  }
+});
+
+alertObserver.observe(document.body, { childList: true, subtree: true });

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -759,3 +759,82 @@ def test_manifest_file_changes(live_server, page, context):
     # alert shown
     expect(content_alert).to_be_visible()
     expect(content_alert).to_contain_text("Selected path is not a valid output path")
+
+
+def get_element_height(page, selector):
+    """Return the rendered height of an element in pixels via getBoundingClientRect."""
+    return page.evaluate(
+        f"document.querySelector('{selector}').getBoundingClientRect().height"
+    )
+
+
+def test_alert_dismiss_resizes_content(page, context, live_server):
+    """
+    Test that dismissing an alert after adding files to a release request correctly
+    resizes both the file tree and the selected content area.
+
+    The alert is injected into the DOM by HTMX after the multiselect form is
+    submitted. Dismissing it frees up vertical space. We verify that both
+    #tree-container and #selected-contents grow to fill that space after dismissal.
+    """
+    # Set up a workspace with multiple files we can add to a request
+    workspace = factories.create_workspace("test-workspace")
+    for i in range(10):
+        factories.write_workspace_file(workspace, f"subdir/file{i}.txt")
+
+    # Log in as a researcher and navigate to the workspace subdirectory
+    login_as_user(
+        live_server,
+        context,
+        user_dict={
+            "username": "researcher",
+            "workspaces": {
+                "test-workspace": {
+                    "project_details": {"name": "Project 1", "ongoing": True},
+                    "archived": False,
+                },
+            },
+        },
+    )
+
+    page.goto(live_server.url + workspace.get_url())
+
+    # Expand the subdir in the tree
+    click_and_htmx(page, page.get_by_role("link", name="subdir"))
+
+    # Confirm we're viewing the directory listing in #selected-contents
+    expect(page.locator("#selected-contents")).to_contain_text("file1.txt")
+
+    # Use the select-all checkbox to select all files
+    page.check("input.selectall")
+    expect(page.locator("input.selectall")).to_be_checked()
+
+    # Submit via the multiselect form
+    click_and_htmx(page, page.locator("button[value=add_files]"))
+    click_and_htmx(page, page.get_by_role("form").locator("#add-or-change-file-button"))
+
+    # The alert should now be visible, confirming files were added
+    alert = page.locator('[role="alert"]')
+    expect(alert).to_be_visible()
+
+    # Record heights while the alert is present
+    tree_height_with_alert = get_element_height(page, "#tree-container")
+    content_height_with_alert = get_element_height(page, "#selected-contents")
+
+    # Dismiss the alert
+    alert.get_by_label("Close").click()
+
+    # Wait for the alert to be removed from the DOM
+    expect(alert).not_to_be_visible()
+
+    # Wait for the 300ms transition (from _alert.js in upstream jobserver -
+    # https://github.com/opensafely-core/job-server/blob/df4531db14f53f016f5919d12871ad457f9911f1/assets/src/scripts/_alert.js)
+    # + 100ms for resize to settle
+    page.wait_for_timeout(400)
+
+    # Both elements should have grown to fill the space freed by the alert
+    tree_height_after = get_element_height(page, "#tree-container")
+    content_height_after = get_element_height(page, "#selected-contents")
+
+    assert tree_height_after > tree_height_with_alert
+    assert content_height_after > content_height_with_alert


### PR DESCRIPTION
Closes #1146 

We have resizing logic that ensures that the filebrowser tree and page contents fit the available vertical space. However, this wasn't re-running after an alert was dismissed, leading to empty space remaining.  We watch for alerts being dismissed, and trigger the resize js again. CSV (clusterize) tables have their own resize logic, and also need to be handled on alert dismissal.

Screencast of behaviour before
[Screencast from 2026-04-13 08-15-03.webm](https://github.com/user-attachments/assets/61b2e0a5-5a9d-442d-96f0-857ff0ad8065)

And after
[Screencast from 2026-04-13 08-16-57.webm](https://github.com/user-attachments/assets/f7444b20-9afe-4390-b4b0-20290a0832a3)
