### PR TITLE
Fix package rule for python-version and node-version

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -51,7 +51,7 @@
   "packageRules": [
     // don't auto-update python-version or node-version, we want to manage these updates ourselves
     {
-      "matchDatasources": ["python-version", "node-version"],
+      "matchManagers": ["pyenv", "nodenv"],
       "enabled": false
     },
     // We handle github runners (ubuntu versions etc) manually


### PR DESCRIPTION
We need to match the package managers to exclude updates to .python-version and .node-version