### PR TITLE
Add docs for released files as supporting files

### DIFF
--- a/docs/how-tos/create-and-submit-a-release-request.md
+++ b/docs/how-tos/create-and-submit-a-release-request.md
@@ -33,6 +33,10 @@ select the type of file (output file or supporting file).
     already have an active release request, the file will be added to it. If you do not have
     an active release request, a new one will be created.
 
+Note that if there are files that have previously been released in your workspace,
+you can add them to a new request only as supporting files.
+When you try to add the file, the dialogue will only show "Supporting" as an option.
+
 If you added a file that you did not intend to, you can
 [withdraw the file](edit-file-on-request.md#withdraw-a-file) prior to submitting the release request.
 

--- a/docs/how-tos/edit-file-on-request.md
+++ b/docs/how-tos/edit-file-on-request.md
@@ -50,3 +50,6 @@ within the release request, and use "Change File Properties". You will have the 
 change the file type, select an existing file group, or create a new one to move the file to.
 
 ![Change file properties](../screenshots/update_file_properties.png)
+
+Note that previously released files can only be added as supporting files in a new release request.
+For previously released files, you will not see the option to change the file's type to "Output".

--- a/justfile
+++ b/justfile
@@ -392,7 +392,6 @@ assets-run: assets-install
 
     npm run dev
 
-
 check-renovate-config:
     npx --yes --package renovate -- renovate-config-validator
 


### PR DESCRIPTION
Released files can be added as supporting files but not output files.
Clarify this in the docs for:
- adding files to a release request
- changing the file type of a file on a release request

Previews:
https://aw-add-docs-for-selecting-re.airlock.pages.dev/how-tos/create-and-submit-a-release-request/#adding-files
https://aw-add-docs-for-selecting-re.airlock.pages.dev/how-tos/edit-file-on-request/#move-a-file-to-a-different-group-or-change-file-type

I have not included screenshots. I did consider - but I don't expect this feature to be used very often, and so I'd rather not clutter up the pages.