### PR TITLE
Disable renovate updates to requires-python

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -54,6 +54,11 @@
       "matchManagers": ["pyenv", "nodenv"],
       "enabled": false
     },
+    // don't auto-update requires-python in pyproject.toml
+    {
+      matchDepTypes: ["requires-python"],
+      enabled: false,
+    },
     // We handle github runners (ubuntu versions etc) manually
     {
       "matchDatasources": ["github-runners"],


### PR DESCRIPTION
Setting an upper range for requires-python in
https://github.com/opensafely-core/airlock/pull/1163 had the inadvertent side-effect of enabling renovate updates to it. We want to handle python version updates manually.