### PR TITLE
Add renovate config to set Django upper limit

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -116,6 +116,15 @@
         "* 0-3 * * WED"
       ],
     },
+    // Fix Django to <6.0 due to current python verion (3.11)
+    // Otherwise renovate will use the general "widen" strategy to change the upper limit in pyproject.toml
+    // The locked version will correctly remain at the latest allowed version for python 3.11
+    // i.e. <6, but the upper limit in pytproject.toml is confusing 
+    {
+      "matchManagers": ["pep621"],
+      "matchDepNames": ["Django"],
+      "allowedVersions": "<6.0"
+    },
     {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
@@ -132,14 +141,6 @@
       "matchUpdateTypes": ["pinDigest"],
       "minimumReleaseAge": null,
     },
-    // EXAMPLE: If required, pin a specific dependency to an upper allowed version
-    // Otherwise renovate will use the general "widen" strategy to change the upper limit in pyproject.toml
-    // and will bump it anyway
-    // {
-    //   "matchManagers": ["pep621"],
-    //   "matchDepNames": ["Django"],
-    //   "allowedVersions": "<6.0"
-    // },
   ],
   // Include vulnerability alerts; this uses dependabot and requires that depenency graph and
   // dependabot alerts are enabled in the repo


### PR DESCRIPTION
Fix Django to <6.0 due to current python verion (3.11) Otherwise renovate will use the general "widen" strategy to change the upper limit in pyproject.toml The locked version will correctly remain at the latest allowed version for python 3.11 i.e. <6, but the upper limit in pytproject.toml is confusing

After various experiments with renovate config/range strategies, I'm coming to the conclusion that there's no way to make it only expand the pyproject.toml range to the version it's actually updating. I think it uses the pyproject.toml range to decide how to expand it and then updates the locked version to whatever is compatible with that range, taking into account the python version, other dependencies etc, so the locked version is correct, but the pyproject.toml may be misleadingly greater than the locked version.

I think it's better to  pin the upper limit in renovate config until we're ready to update it. If we don't, and we let reonovate change pyproject.toml to <=6.04, we won't get new updates for 5.x because it won't constitute a change to the upper limit in the pyproject.toml