### PR TITLE
Fix the upgrade-pipeline script and update pipeline to v2026.04.22.171515

### DIFF
--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ prodenv:
     uv sync --no-dev
 
 # update to the latest version of the internal pipeline library
-update-pipeline:
+update-pipeline: && devenv uvmirror
     ./scripts/upgrade-pipeline.sh pyproject.toml
 
 # && dependencies are run after the recipe has run. Needs just>=0.9.9. This is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
     "django-markdownify<=0.9.6",
     "whitenoise<=6.12.0",
     "gunicorn<=25.3.0",
-    "opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.17.132418.zip",
+    "opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip",
     "requests<=2.33.1",
     "pydantic<=2.13.0",
     "ulid<=1.1",

--- a/requirements.uvmirror
+++ b/requirements.uvmirror
@@ -124,7 +124,7 @@ mypy==1.20.1
     # via django-stubs
 mypy-extensions==1.1.0
     # via mypy
-opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip
+opensafely-pipeline @ https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip
     # via airlock
 opentelemetry-api==1.40.0
     # via

--- a/scripts/upgrade-pipeline.sh
+++ b/scripts/upgrade-pipeline.sh
@@ -2,7 +2,7 @@
 set -eu
 
 file=$1
-github_package_url="opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/"
+github_package_url="@https://github.com/opensafely-core/pipeline/archive/refs/tags/"
 latest=$(git ls-remote -h --refs --tags --heads https://github.com/opensafely-core/pipeline | grep -o "v20.*$" | sort | tail -1)
 echo "Latest version of pipeline is $latest"
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,6 @@ version = 1
 revision = 3
 requires-python = "==3.11.*"
 
-[options]
-exclude-newer = "2026-04-15T10:59:03.036081888Z"
-exclude-newer-span = "-P7D"
-
 [[package]]
 name = "airlock"
 version = "0.1.0"
@@ -64,7 +60,7 @@ requires-dist = [
     { name = "gunicorn", specifier = "<=25.3.0" },
     { name = "mkdocs", specifier = "<=1.6.1" },
     { name = "mkdocs-material", specifier = "<=9.7.6" },
-    { name = "opensafely-pipeline", url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip" },
+    { name = "opensafely-pipeline", url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "<=1.41.0" },
     { name = "opentelemetry-instrumentation-django", specifier = "<=0.61b0" },
     { name = "opentelemetry-instrumentation-requests", specifier = "<=0.61b0" },
@@ -733,12 +729,12 @@ wheels = [
 
 [[package]]
 name = "opensafely-pipeline"
-version = "2026.3.12.140752"
-source = { url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.03.12.140752.zip" }
+version = "2026.4.22.171515"
+source = { url = "https://github.com/opensafely-core/pipeline/archive/refs/tags/v2026.04.22.171515.zip" }
 dependencies = [
     { name = "ruyaml" },
 ]
-sdist = { hash = "sha256:e6e45b5b17f884af263a4c01ead72347d0e63899a0eb1811d7c3d0d5e802401b" }
+sdist = { hash = "sha256:37a8ba18be79e604913da616904ae093f19c1f0d6869dd3165601e3c5bfe706b" }
 
 [package.metadata]
 requires-dist = [


### PR DESCRIPTION
The upgrade-pipeline script was broken if the pipeline dependency in pyproject.toml was referenced as `opensafely-pipeline[fastparser]@` rather than just `opensafely-pipeline@`. We only use the pipeline library for it's list of allowed L4 filetypes, so we don't install the fastparser version, but this keeps the script consistent with other repos