### PR TITLE
Add a read-only access user role

### DIFF
--- a/airlock/permissions.py
+++ b/airlock/permissions.py
@@ -50,6 +50,7 @@ def check_user_can_view_workspace(user: User | None, workspace_name: str):
     """
     if user is None or (
         not user.output_checker
+        and not user.readonly_access
         and workspace_name not in (user.workspaces | user.copiloted_workspaces)
     ):
         raise exceptions.WorkspacePermissionDenied(

--- a/example-data/dev_users.json
+++ b/example-data/dev_users.json
@@ -5,7 +5,6 @@
       "username": "output_checker_1",
       "fullname": "Output Checker 1",
       "output_checker": true,
-      "staff": true,
       "workspaces": {
         "example-workspace": {
           "project_details": {"name": "Project 1", "ongoing": true, "orgs": ["Org 1"]},
@@ -32,7 +31,6 @@
       "username": "output_checker_2",
       "fullname": "Output Checker 2",
       "output_checker": true,
-      "staff": true,
       "workspaces": {
         "example-workspace": {
           "project_details": {"name": "Project 1", "ongoing": true, "orgs": ["Org 1"]},
@@ -59,7 +57,6 @@
       "username": "researcher_1",
       "fullname": "Researcher 1",
       "output_checker": false,
-      "staff": false,
       "workspaces": {
         "example-workspace": {
           "project_details": {"name": "Project 1", "ongoing": true, "orgs": ["Org 1"]},
@@ -86,7 +83,6 @@
       "username": "copilot",
       "fullname": "Copilot",
       "output_checker": true,
-      "staff": true,
       "workspaces": {},
       "copiloted_workspaces": {
         "example-workspace": {
@@ -106,6 +102,17 @@
           "archived": false
         }
       }
+    }
+  },
+  "techsupport": {
+    "token": "techsupport",
+    "details": {
+      "username": "techsupport",
+      "fullname": "Tech Support",
+      "output_checker": false,
+      "readonly_access": true,
+      "workspaces": {},
+      "copiloted_workspaces": {}
     }
   }
 }

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -53,6 +53,7 @@ def create_api_user(
     workspaces: dict[str, typing.Any] | list[str] | None = None,
     copiloted_workspaces: dict[str, typing.Any] | list[str] | None = None,
     output_checker: bool | None = None,
+    readonly_access: bool | None = None,
 ):
     """Test factory to create a user from the Auth API
 
@@ -77,6 +78,7 @@ def create_api_user(
         workspaces=_create_workspaces(workspaces),
         copiloted_workspaces=_create_workspaces(copiloted_workspaces),
         output_checker=output_checker or False,
+        readonly_access=readonly_access or False,
     )
 
 
@@ -100,11 +102,12 @@ def create_airlock_user(
     workspaces: dict[str, typing.Any] | list[str] | None = None,
     copiloted_workspaces: dict[str, typing.Any] | list[str] | None = None,
     output_checker: bool | None = None,
+    readonly_access: bool | None = None,
     last_refresh: float | None = None,
 ) -> User:
     """Factory to create an Airlock User in the db.
 
-    The username, workspaces,copiloted_workspaces, and output_checker, are all
+    The username, workspaces,copiloted_workspaces, output_checker, and readonly_access are all
     just passed through to create_api_user.
     """
     api_user = create_api_user(
@@ -113,6 +116,7 @@ def create_airlock_user(
         workspaces=workspaces,
         copiloted_workspaces=copiloted_workspaces,
         output_checker=output_checker,
+        readonly_access=readonly_access,
     )
     return User.from_api_data(api_user, last_refresh)
 
@@ -123,6 +127,7 @@ def get_or_create_airlock_user(
     workspaces: dict[str, typing.Any] | list[str] | None = None,
     copiloted_workspaces: dict[str, typing.Any] | list[str] | None = None,
     output_checker: bool | None = None,
+    readonly_access: bool | None = None,
     last_refresh: float | None = None,
 ) -> User:
     """Get or create an airlock user.
@@ -140,14 +145,14 @@ def get_or_create_airlock_user(
     workspaces needed explilcitly ahead of time - when calling a factory
     function, it will ensure the user has the right workspace permissions.
 
-    However, for output_checker, we are stricter, or else we could accidentally
-    change that.
+    However, for output_checker and readonly_access, we are stricter, or else
+    we could accidentally change that.
 
-    The output_checker default is now None, and if so, we do nothing, as the the
-    call or this function expressed no opinion about whether this user should
-    be an output checker or not.  However, if it is set to True or False, we
-    assert that the pre-existing user is set the same, to help us catch logic
-    errors in our tests or test factories.
+    The output_checker/readonly_access default is None, and if so, we do nothing,
+    as the call or this function expressed no opinion about whether this user should
+    be an output checker/readonly_access user or not.  However, if it is set to True
+    or False, we assert that the pre-existing user is set the same, to help us catch
+    logic errors in our tests or test factories.
 
     Hopefully, this complexity will be short lived. Once we have users that can
     be looked up, I (smd) expect the BLL interface may change to need username,
@@ -160,11 +165,12 @@ def get_or_create_airlock_user(
         workspaces=workspaces,
         copiloted_workspaces=copiloted_workspaces,
         output_checker=output_checker,
+        readonly_access=readonly_access,
     )
     try:
         user = User.objects.get(pk=username)
     except User.DoesNotExist:
-        return User.from_api_data(api_user)
+        return User.from_api_data(api_user, last_refresh=last_refresh)
 
     # ok we have an existing user
     #
@@ -189,6 +195,11 @@ def get_or_create_airlock_user(
     if output_checker is not None:  # pragma: nocover
         # check that we are not accidentally expecting different roles
         assert user.output_checker is output_checker
+
+    # readonly_access=None means the caller did not specify
+    if readonly_access is not None:  # pragma: nocover
+        # check that we are not accidentally expecting different roles
+        assert user.readonly_access is readonly_access
 
     return user
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,8 +13,12 @@ class AirlockClient(Client):
         username = user_data.get("username", "testuser")
         workspaces = user_data.get("workspaces")
         output_checker = user_data.get("output_checker", False)
+        readonly_access = user_data.get("readonly_access", False)
         user = factories.create_airlock_user(
-            username=username, workspaces=workspaces, output_checker=output_checker
+            username=username,
+            workspaces=workspaces,
+            output_checker=output_checker,
+            readonly_access=readonly_access,
         )
         # bypass authentication, just set up the session
         self.force_login(user)

--- a/tests/integration/test_auth_views.py
+++ b/tests/integration/test_auth_views.py
@@ -34,6 +34,7 @@ def test_login(client, auth_api_stubber):
     assert user.is_authenticated
     assert user.username == "testuser"
     assert user.output_checker is False
+    assert user.readonly_access is False
     assert user.workspaces == {
         "workspace": {
             "project_details": {"name": "project", "ongoing": True, "orgs": []},

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -489,14 +489,41 @@ def test_workspace_view_excluded_l4_output_path(airlock_client):
     "user,can_see_form",
     [
         (
-            factories.create_api_user(workspaces=["workspace"], output_checker=True),
+            factories.create_api_user(
+                workspaces=["workspace"], output_checker=True, readonly_access=False
+            ),
             True,
         ),
         (
-            factories.create_api_user(workspaces=["workspace"], output_checker=False),
+            factories.create_api_user(
+                workspaces=["workspace"], output_checker=False, readonly_access=False
+            ),
             True,
         ),
-        (factories.create_api_user(workspaces=[], output_checker=True), False),
+        (
+            factories.create_api_user(
+                workspaces=[], output_checker=True, readonly_access=False
+            ),
+            False,
+        ),
+        (
+            factories.create_api_user(
+                workspaces=["workspace"], output_checker=False, readonly_access=True
+            ),
+            True,
+        ),
+        (
+            factories.create_api_user(
+                workspaces=["workspace"], output_checker=False, readonly_access=False
+            ),
+            True,
+        ),
+        (
+            factories.create_api_user(
+                workspaces=[], output_checker=False, readonly_access=True
+            ),
+            False,
+        ),
     ],
 )
 def test_workspace_view_file_add_to_request(airlock_client, user, can_see_form):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -64,8 +64,10 @@ def setup_empty_release_request():
     return release_request, path, author
 
 
-@pytest.mark.parametrize("output_checker", [False, True])
-def test_provider_get_workspaces_for_user(bll, output_checker):
+@pytest.mark.parametrize(
+    "output_checker,readonly_access", [(False, True), (True, False)]
+)
+def test_provider_get_workspaces_for_user(bll, output_checker, readonly_access):
     factories.create_workspace("foo")
     factories.create_workspace("bar")
     factories.create_workspace("not-allowed")
@@ -75,7 +77,10 @@ def test_provider_get_workspaces_for_user(bll, output_checker):
         "not-exists": factories.create_api_workspace(project="project 3"),
     }
     user = factories.create_airlock_user(
-        username="testuser", workspaces=workspaces, output_checker=output_checker
+        username="testuser",
+        workspaces=workspaces,
+        output_checker=output_checker,
+        readonly_access=readonly_access,
     )
 
     assert bll.get_workspaces_for_user(user) == [

--- a/tests/unit/test_permissions.py
+++ b/tests/unit/test_permissions.py
@@ -9,26 +9,34 @@ from tests import factories
 
 
 @pytest.mark.parametrize(
-    "output_checker,workspaces,copiloted_workspaces,can_view",
+    "output_checker,readonly_access,workspaces,copiloted_workspaces,can_view",
     [
-        (True, {}, {}, True),
-        (True, {"other": {}, "other1": {}}, {}, True),
-        (True, {"other": {}, "other1": {}}, {"test1": {}}, True),
-        (True, {"other": {}, "other1": {}}, {"test": {}}, True),
-        (False, {"test": {}, "other": {}, "other1": {}}, {}, True),
-        (False, {"other": {}, "other1": {}}, {}, False),
-        (False, {"other": {}, "other1": {}}, {"test1": {}}, False),
-        (False, {"other": {}, "other1": {}}, {"test": {}}, True),
+        # output-checker
+        (True, False, {}, {}, True),
+        (True, False, {"other": {}, "other1": {}}, {}, True),
+        (True, False, {"other": {}, "other1": {}}, {"test1": {}}, True),
+        (True, False, {"other": {}, "other1": {}}, {"test": {}}, True),
+        # standard user
+        (False, False, {"test": {}, "other": {}, "other1": {}}, {}, True),
+        (False, False, {"other": {}, "other1": {}}, {}, False),
+        (False, False, {"other": {}, "other1": {}}, {"test1": {}}, False),
+        (False, False, {"other": {}, "other1": {}}, {"test": {}}, True),
+        # readonly_access user
+        (False, True, {}, {}, True),
+        (False, True, {"other": {}, "other1": {}}, {}, True),
+        (False, True, {"other": {}, "other1": {}}, {"test1": {}}, True),
+        (False, True, {"other": {}, "other1": {}}, {"test": {}}, True),
     ],
 )
 def test_user_can_view_workspace(
-    output_checker, workspaces, copiloted_workspaces, can_view
+    output_checker, readonly_access, workspaces, copiloted_workspaces, can_view
 ):
     user = factories.create_airlock_user(
         username="test",
         workspaces=workspaces,
         copiloted_workspaces=copiloted_workspaces,
         output_checker=output_checker,
+        readonly_access=readonly_access,
     )
     assert permissions.user_can_view_workspace(user, "test") == can_view
 

--- a/users/models.py
+++ b/users/models.py
@@ -54,6 +54,10 @@ class User(AbstractBaseUser):
     def output_checker(self):
         return self.api_data.get("output_checker", False)
 
+    @property
+    def readonly_access(self):
+        return self.api_data.get("readonly_access", False)
+
     @classmethod
     def from_api_data(cls, api_data, last_refresh: float | None = None) -> Self:
         user, _ = cls.objects.get_or_create(user_id=api_data["username"])


### PR DESCRIPTION
Add a `readonly_access` property to the User model, which allows users to view any workspace (and any release requests), but not to create release requests for it or perform any other actions on it. This will allow developers with L4 access to view files and logs for any workspace, which is useful when responding to tech support questions.

The `readonly_access` property will be passed from job-server in future, and defaults to False.

Part of #1176 