### PR TITLE
All Workspaces page for readonly users

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -322,6 +322,15 @@ class BusinessLogicLayer:
         """Get all the local workspace directories that a user is a copilot for."""
         return self._build_workspace_list(user, user.copiloted_workspaces)
 
+    def get_all_workspaces(self, user: User) -> list[Workspace]:
+        """Get all workspace directories present on the filesystem."""
+        workspace_names = [
+            workspace_dir.name
+            for workspace_dir in settings.WORKSPACE_DIR.iterdir()
+            if workspace_dir.is_dir()
+        ]
+        return self._build_workspace_list(user, workspace_names)
+
     def get_release_request(self, request_id: str, user: User) -> ReleaseRequest:
         """Get a ReleaseRequest object for an id."""
 

--- a/airlock/nav.py
+++ b/airlock/nav.py
@@ -51,6 +51,14 @@ def menu(request):
                 url_name="copiloted_workspace_index",
             )
             items.insert(nav_index, copiloted_workspaces_menu)
+        if request.user.readonly_access:
+            items.insert(
+                nav_index,
+                NavItem(
+                    name="All Workspaces",
+                    url_name="all_workspaces_index",
+                ),
+            )
     return {"nav": list(iter_nav(items, request))}
 
 

--- a/airlock/templates/all_workspaces.html
+++ b/airlock/templates/all_workspaces.html
@@ -1,10 +1,32 @@
 {% extends "base.html" %}
 
+{% load django_vite %}
+{% load django_htmx %}
+
 {% block metatitle %}All Workspaces | Airlock{% endblock metatitle %}
 
 {% block content %}
   <div class="flex flex-col gap-4 max-w-3xl">
     {% airlock_header title="All Workspaces" %}
+
+    <input
+      type="text"
+      name="q"
+      value="{{ query }}"
+      placeholder="Search workspaces…"
+      class="border border-gray-300 rounded px-3 py-2 w-full"
+      hx-get="{% url 'all_workspaces_index' %}"
+      hx-trigger="input changed delay:200ms"
+      hx-target="#workspace-results"
+      hx-swap="outerHTML"
+      hx-include="[name='q']"
+    >
+
     {% include "all_workspaces_results.html" %}
   </div>
 {% endblock content %}
+
+{% block extra_js %}
+  {% vite_asset "assets/src/scripts/htmx.js" %}
+  {% django_htmx_script %}
+{% endblock %}

--- a/airlock/templates/all_workspaces.html
+++ b/airlock/templates/all_workspaces.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block metatitle %}All Workspaces | Airlock{% endblock metatitle %}
+
+{% block content %}
+  <div class="flex flex-col gap-4 max-w-3xl">
+    {% airlock_header title="All Workspaces" %}
+    {% include "all_workspaces_results.html" %}
+  </div>
+{% endblock content %}

--- a/airlock/templates/all_workspaces_results.html
+++ b/airlock/templates/all_workspaces_results.html
@@ -1,0 +1,11 @@
+<div id="workspace-results">
+  {% #card %}
+    {% #list_group id="workspaces" %}
+      {% for workspace in workspaces %}
+        {% #list_group_item href=workspace.get_url %}{{ workspace.display_name }}{% /list_group_item %}
+      {% empty %}
+        {% list_group_empty title="No workspaces found" description="No workspaces match your search" %}
+      {% endfor %}
+    {% /list_group %}
+  {% /card %}
+</div>

--- a/airlock/urls.py
+++ b/airlock/urls.py
@@ -41,6 +41,11 @@ urlpatterns = [
         name="copiloted_workspace_index",
     ),
     path(
+        "workspaces/all/",
+        airlock.views.all_workspaces_index,
+        name="all_workspaces_index",
+    ),
+    path(
         "workspaces/view/<str:workspace_name>/",
         airlock.views.workspace_view,
         kwargs={"path": ""},

--- a/airlock/views/__init__.py
+++ b/airlock/views/__init__.py
@@ -26,6 +26,7 @@ from .request import (
     uploaded_files_count,
 )
 from .workspace import (
+    all_workspaces_index,
     copilot_workspace_index,
     workspace_add_file_to_request,
     workspace_contents,
@@ -40,6 +41,7 @@ __all__ = [
     "login",
     "logout",
     "index",
+    "all_workspaces_index",
     "file_approve",
     "file_change_properties",
     "file_request_changes",

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -84,18 +84,43 @@ def copilot_workspace_index(request):
     )
 
 
+@vary_on_headers("HX-Request")
 @instrument
 def all_workspaces_index(request):
     if not request.user.readonly_access:
         raise PermissionDenied()
 
+    query = request.GET.get("q", "").strip()
     all_workspaces = bll.get_all_workspaces(request.user)
-    workspaces = sorted(all_workspaces, key=lambda workspace: workspace.name)
+
+    if query:
+        filtered_workspaces = sorted(
+            [
+                workspace
+                for workspace in all_workspaces
+                if query.lower() in workspace.name.lower()
+            ],
+            key=lambda workspace: workspace.name,
+        )
+    else:
+        filtered_workspaces = sorted(
+            all_workspaces, key=lambda workspace: workspace.name
+        )
+
+    if request.htmx:
+        return TemplateResponse(
+            request,
+            "all_workspaces_results.html",
+            {"workspaces": filtered_workspaces},
+        )
 
     return TemplateResponse(
         request,
         "all_workspaces.html",
-        {"workspaces": workspaces},
+        {
+            "workspaces": filtered_workspaces,
+            "query": query,
+        },
     )
 
 

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from django.contrib import messages
+from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
@@ -80,6 +81,21 @@ def copilot_workspace_index(request):
             "workspace_type": "copiloted workspaces",
             "workspace_header": workspace_header,
         },
+    )
+
+
+@instrument
+def all_workspaces_index(request):
+    if not request.user.readonly_access:
+        raise PermissionDenied()
+
+    all_workspaces = bll.get_all_workspaces(request.user)
+    workspaces = sorted(all_workspaces, key=lambda workspace: workspace.name)
+
+    return TemplateResponse(
+        request,
+        "all_workspaces.html",
+        {"workspaces": workspaces},
     )
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -101,6 +101,20 @@ def login_as_user(live_server, context, user_dict):
 
 
 @pytest.fixture
+def readonly_user(live_server, context):
+    login_as_user(
+        live_server,
+        context,
+        factories.create_api_user(
+            username="test_readonly",
+            fullname="Test Readonly",
+            workspaces={},
+            readonly_access=True,
+        ),
+    )
+
+
+@pytest.fixture
 def output_checker_user(live_server, context):
     login_as_user(
         live_server,

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -7,7 +7,7 @@ from airlock.enums import RequestFileType, RequestStatus
 from airlock.types import UrlPath
 from tests import factories
 
-from .conftest import click_and_htmx, login_as_user
+from .conftest import click_and_htmx, login_as_user, wait_for_htmx
 
 
 @pytest.fixture(autouse=True)
@@ -846,3 +846,20 @@ def test_alert_dismiss_resizes_content(page, context, live_server):
 
     assert tree_height_after > tree_height_with_alert
     assert content_height_after > content_height_with_alert
+
+
+def test_all_workspaces_index_nav_visible_for_readonly(
+    live_server, page, readonly_user
+):
+    page.goto(live_server.url + "/workspaces/")
+    expect(page.get_by_role("navigation")).to_contain_text("All Workspaces")
+
+
+def test_all_workspaces_index_nav_not_visible_for_researcher(
+    live_server, page, researcher_user
+):
+    page.goto(live_server.url + "/workspaces/")
+    expect(page.get_by_role("navigation")).not_to_contain_text("All Workspaces")
+
+
+

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -862,4 +862,12 @@ def test_all_workspaces_index_nav_not_visible_for_researcher(
     expect(page.get_by_role("navigation")).not_to_contain_text("All Workspaces")
 
 
+def test_all_workspaces_index_search_filters_list(live_server, page, readonly_user):
+    page.goto(live_server.url + "/workspaces/all/")
 
+    search_input = page.get_by_placeholder("Search workspaces…")
+    search_input.fill("test-dir1")
+    wait_for_htmx(page)
+
+    expect(page.locator("#workspace-results")).to_contain_text("test-dir1")
+    expect(page.locator("#workspace-results")).not_to_contain_text("test-dir2")

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -831,7 +831,11 @@ def test_all_workspaces_index(airlock_client):
 @pytest.mark.parametrize(
     "user_kwargs",
     [
-        {"workspaces": ["workspace"], "output_checker": False, "readonly_access": False},
+        {
+            "workspaces": ["workspace"],
+            "output_checker": False,
+            "readonly_access": False,
+        },
         {"workspaces": [], "output_checker": True, "readonly_access": False},
     ],
 )
@@ -840,6 +844,62 @@ def test_all_workspaces_index_permission_denied(airlock_client, user_kwargs):
     response = airlock_client.get("/workspaces/all/")
     assert response.status_code == 403
 
+
+def test_all_workspaces_index_filter(airlock_client):
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={},
+        readonly_access=True,
+    )
+    airlock_client.login_with_user(user)
+    factories.create_workspace("matching-workspace")
+    factories.create_workspace("other-workspace")
+
+    response = airlock_client.get(
+        "/workspaces/all/?q=matching",
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    assert "matching-workspace" in response.rendered_content
+    assert "other-workspace" not in response.rendered_content
+
+
+def test_all_workspaces_index_filter_no_results(airlock_client):
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={},
+        readonly_access=True,
+    )
+    airlock_client.login_with_user(user)
+    factories.create_workspace("some-workspace")
+
+    response = airlock_client.get(
+        "/workspaces/all/?q=nomatch",
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    assert "No workspaces found" in response.rendered_content
+
+
+def test_all_workspaces_index_htmx_partial(airlock_client):
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={},
+        readonly_access=True,
+    )
+    airlock_client.login_with_user(user)
+    factories.create_workspace("some-workspace")
+
+    response = airlock_client.get(
+        "/workspaces/all/?q=some",
+        HTTP_HX_REQUEST="true",
+    )
+
+    assert response.status_code == 200
+    assert response.templates[0].name == "all_workspaces_results.html"
+    assert "some-workspace" in response.rendered_content
 
 
 def test_workspace_multiselect_add_files_all_valid(airlock_client, bll):

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -810,6 +810,38 @@ def test_copiloted_workspaces_index(airlock_client):
     assert [ws.name for ws in projects[inactive_project1]] == ["test2a", "test2b"]
 
 
+def test_all_workspaces_index(airlock_client):
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={},
+        readonly_access=True,
+    )
+    airlock_client.login_with_user(user)
+    factories.create_workspace("alpha")
+    factories.create_workspace("beta")
+
+    response = airlock_client.get("/workspaces/all/")
+
+    assert response.status_code == 200
+    assert "alpha" in response.rendered_content
+    assert "beta" in response.rendered_content
+    assert [ws.name for ws in response.context["workspaces"]] == ["alpha", "beta"]
+
+
+@pytest.mark.parametrize(
+    "user_kwargs",
+    [
+        {"workspaces": ["workspace"], "output_checker": False, "readonly_access": False},
+        {"workspaces": [], "output_checker": True, "readonly_access": False},
+    ],
+)
+def test_all_workspaces_index_permission_denied(airlock_client, user_kwargs):
+    airlock_client.login(**user_kwargs)
+    response = airlock_client.get("/workspaces/all/")
+    assert response.status_code == 403
+
+
+
 def test_workspace_multiselect_add_files_all_valid(airlock_client, bll):
     airlock_client.login(workspaces=["test1"])
     workspace = factories.create_workspace("test1")

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -122,6 +122,34 @@ def test_provider_get_copiloted_workspaces_for_user(bll, output_checker):
     ]
 
 
+def test_provider_get_all_workspaces(bll):
+    factories.create_workspace("foo")
+    factories.create_workspace("bar")
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={},
+        readonly_access=True,
+    )
+
+    result = bll.get_all_workspaces(user)
+    assert sorted(ws.name for ws in result) == ["bar", "foo"]
+
+
+def test_provider_get_all_workspaces_skips_missing(bll):
+    factories.create_workspace("exists")
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={
+            "exists": factories.create_api_workspace(),
+            "not-on-disk": factories.create_api_workspace(),
+        },
+        readonly_access=True,
+    )
+
+    result = bll.get_all_workspaces(user)
+    assert [ws.name for ws in result] == ["exists"]
+
+
 def test_provider_request_release_files_request_not_approved(bll, mock_notifications):
     author = factories.create_airlock_user(username="author", workspaces=["workspace"])
     checker = factories.create_airlock_user(username="checker", output_checker=True)

--- a/tests/unit/test_nav.py
+++ b/tests/unit/test_nav.py
@@ -65,3 +65,19 @@ def test_iter_nav_copilot(rf):
             "is_active": True,
         }
     ]
+
+
+def test_iter_nav_readonly(rf):
+    factories.create_airlock_user(username="user", workspaces=[], readonly_access=True)
+    items = [
+        nav.NavItem("All Workspaces", "all_workspaces_index"),
+    ]
+
+    request = rf.get("/workspaces/all/")
+    assert list(nav.iter_nav(items, request)) == [
+        {
+            "name": "All Workspaces",
+            "url": "/workspaces/all/",
+            "is_active": True,
+        }
+    ]


### PR DESCRIPTION
Follow on from #1176 

  We now have users with a "readonly_access" role, who have view-only access to all workspaces and their release requests,
                                                                                                               
  Readonly users already have permission to view any workspace, but had no way to discover workspaces they   
  hadn't been explicitly assigned to. This PR adds a dedicated All Workspaces page that lists every workspace  
  present on the filesystem. It also adds a search input that filters the list by workspace name as you type (as the list of workspaces may be very long)                                                                         
                                                                                                               
  Note: workspaces are not in the DB, so we have to scan the workspace dir to retrieve them all. On the all workspaces page, workspaces are listed alphabetically with no project grouping since we only get project metadata for workspaces that users have explict access to.

Screen recording to demo new nav, page and search:
[Screencast from 2026-05-11 16-14-24.webm](https://github.com/user-attachments/assets/b0867a6e-e3bc-4a14-86b4-59d94d91a1e6)
