### PR TITLE
Ignore workspaces with no/bad manifest files in all workspaces view

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -12,6 +12,7 @@ from typing import Protocol, cast
 from django.conf import settings
 from django.utils.functional import SimpleLazyObject
 from django.utils.module_loading import import_string
+from opentelemetry import trace
 
 import old_api
 from airlock import exceptions, permissions, policies
@@ -307,6 +308,15 @@ class BusinessLogicLayer:
             try:
                 workspace = self.get_workspace(workspace_name, user)
             except exceptions.WorkspaceNotFound:
+                continue
+            except exceptions.ManifestFileError as error:
+                if workspace_name in user.workspaces:
+                    # only send telemetry for this error if it's one of the user's
+                    # workspaces; readonly_users try to access all workspaces from the
+                    # workspace dir on disk and are likely to encounter some that are
+                    # old and have no/bad manifest files which we don't care about
+                    span = trace.get_current_span()
+                    span.record_exception(error)
                 continue
 
             valid_workspaces.append(workspace)

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from django.utils.dateparse import parse_datetime
+from opentelemetry import trace
 
 import old_api
 from airlock import exceptions
@@ -24,6 +25,7 @@ from airlock.models import (
 from airlock.types import UrlPath
 from airlock.visibility import RequestFileStatus
 from tests import factories
+from tests.conftest import get_trace
 
 
 pytestmark = pytest.mark.django_db
@@ -148,6 +150,35 @@ def test_provider_get_all_workspaces_skips_missing(bll):
 
     result = bll.get_all_workspaces(user)
     assert [ws.name for ws in result] == ["exists"]
+
+
+def test_provider_get_all_workspaces_skips_missing_manifest_file(bll):
+    factories.create_workspace("exists")
+    bad_workspace = factories.create_workspace("no-manifest")
+    bad_workspace.manifest_path().unlink()
+    bad_workspace1 = factories.create_workspace("bad-manifest")
+    bad_workspace1.manifest_path().unlink()
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={"bad-manifest": factories.create_api_workspace()},
+        readonly_access=True,
+    )
+
+    tracer = trace.get_tracer("test")
+    with tracer.start_as_current_span("test_span"):
+        result = bll.get_all_workspaces(user)
+
+    assert [ws.name for ws in result] == ["exists"]
+    spans = get_trace()
+    assert len(spans) == 1
+    assert len(spans[0].events) == 1
+    event = spans[0].events[0]
+    assert event.name == "exception"
+    assert "ManifestFileError" in event.attributes["exception.type"]
+    assert (
+        "workspaces/bad-manifest/metadata/manifest.json does not exist"
+        in event.attributes["exception.message"]
+    )
 
 
 def test_provider_request_release_files_request_not_approved(bll, mock_notifications):


### PR DESCRIPTION
The all-workspaces view builds the workspaces from the workspace directory, which contains some workspaces with no manifest.json (and probably some with a bad/old manifest.json that we can't parse). We now catch any manifest errors, and send telemetry for them only if they relate to a user's workspace. We don't want to send errors every time a readonly user tries to access a bad workspace.