### PR TITLE
Fix slow all-workspaces page by using lightweight WorkspaceListing objects

### DIFF
--- a/airlock/business_logic.py
+++ b/airlock/business_logic.py
@@ -30,6 +30,7 @@ from airlock.models import (
     ReleaseRequest,
     RequestFile,
     Workspace,
+    WorkspaceListing,
 )
 from airlock.notifications import send_notification_event
 from airlock.types import UrlPath
@@ -310,13 +311,8 @@ class BusinessLogicLayer:
             except exceptions.WorkspaceNotFound:
                 continue
             except exceptions.ManifestFileError as error:
-                if workspace_name in user.workspaces:
-                    # only send telemetry for this error if it's one of the user's
-                    # workspaces; readonly_users try to access all workspaces from the
-                    # workspace dir on disk and are likely to encounter some that are
-                    # old and have no/bad manifest files which we don't care about
-                    span = trace.get_current_span()
-                    span.record_exception(error)
+                span = trace.get_current_span()
+                span.record_exception(error)
                 continue
 
             valid_workspaces.append(workspace)
@@ -332,14 +328,20 @@ class BusinessLogicLayer:
         """Get all the local workspace directories that a user is a copilot for."""
         return self._build_workspace_list(user, user.copiloted_workspaces)
 
-    def get_all_workspaces(self, user: User) -> list[Workspace]:
-        """Get all workspace directories present on the filesystem."""
-        workspace_names = [
-            workspace_dir.name
-            for workspace_dir in settings.WORKSPACE_DIR.iterdir()
-            if workspace_dir.is_dir()
-        ]
-        return self._build_workspace_list(user, workspace_names)
+    def get_all_workspaces(self) -> list[WorkspaceListing]:
+        """Get lightweight WorkspaceListing objects for all workspace directories.
+
+        Scans WORKSPACE_DIR once and checks only whether metadata/manifest.json
+        exists. Skips directories with no manifest file.
+        """
+        workspaces = []
+        for workspace_dir in settings.WORKSPACE_DIR.iterdir():
+            if not workspace_dir.is_dir():
+                continue
+            if not (workspace_dir / "metadata" / "manifest.json").exists():
+                continue
+            workspaces.append(WorkspaceListing(name=workspace_dir.name))
+        return workspaces
 
     def get_release_request(self, request_id: str, user: User) -> ReleaseRequest:
         """Get a ReleaseRequest object for an id."""

--- a/airlock/models.py
+++ b/airlock/models.py
@@ -159,6 +159,24 @@ class Project:
         return ", ".join(self.orgs)
 
 
+@dataclass(frozen=True, order=True)
+class WorkspaceListing:
+    """Lightweight workspace representation for the all-workspaces listing page.
+
+    Avoids reading manifest.json, computing hashes, building file trees, or
+    making database queries. Provides the same interface as Workspace for the
+    methods used by the all_workspaces_results.html template.
+    """
+
+    name: str
+
+    def get_url(self) -> str:
+        return reverse("workspace_view", kwargs={"workspace_name": self.name})
+
+    def display_name(self) -> str:
+        return self.name
+
+
 @dataclass(order=True)
 class Workspace:
     """Simple wrapper around a workspace directory on disk.

--- a/airlock/views/workspace.py
+++ b/airlock/views/workspace.py
@@ -91,7 +91,7 @@ def all_workspaces_index(request):
         raise PermissionDenied()
 
     query = request.GET.get("q", "").strip()
-    all_workspaces = bll.get_all_workspaces(request.user)
+    all_workspaces = bll.get_all_workspaces()
 
     if query:
         filtered_workspaces = sorted(

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.api import get_messages
 from django.urls import reverse
@@ -900,6 +901,23 @@ def test_all_workspaces_index_htmx_partial(airlock_client):
     assert response.status_code == 200
     assert response.templates[0].name == "all_workspaces_results.html"
     assert "some-workspace" in response.rendered_content
+
+
+def test_all_workspaces_index_skips_directory_without_manifest(airlock_client):
+    user = factories.create_airlock_user(
+        username="testuser",
+        workspaces={},
+        readonly_access=True,
+    )
+    airlock_client.login_with_user(user)
+    factories.create_workspace("good-workspace")
+    no_manifest_dir = settings.WORKSPACE_DIR / "no-manifest"
+    no_manifest_dir.mkdir()
+
+    response = airlock_client.get("/workspaces/all/")
+
+    assert response.status_code == 200
+    assert [ws.name for ws in response.context["workspaces"]] == ["good-workspace"]
 
 
 def test_workspace_multiselect_add_files_all_valid(airlock_client, bll):

--- a/tests/unit/test_business_logic.py
+++ b/tests/unit/test_business_logic.py
@@ -3,6 +3,8 @@ import json
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
+from django.urls import reverse
 from django.utils.dateparse import parse_datetime
 from opentelemetry import trace
 
@@ -21,6 +23,7 @@ from airlock.enums import (
 )
 from airlock.models import (
     AuditEvent,
+    WorkspaceListing,
 )
 from airlock.types import UrlPath
 from airlock.visibility import RequestFileStatus
@@ -124,60 +127,68 @@ def test_provider_get_copiloted_workspaces_for_user(bll, output_checker):
     ]
 
 
-def test_provider_get_all_workspaces(bll):
-    factories.create_workspace("foo")
-    factories.create_workspace("bar")
-    user = factories.create_airlock_user(
-        username="testuser",
-        workspaces={},
-        readonly_access=True,
-    )
-
-    result = bll.get_all_workspaces(user)
-    assert sorted(ws.name for ws in result) == ["bar", "foo"]
-
-
-def test_provider_get_all_workspaces_skips_missing(bll):
-    factories.create_workspace("exists")
+def test_provider_get_workspaces_for_user_skips_bad_manifest(bll):
+    factories.create_workspace("good")
+    bad_workspace = factories.create_workspace("bad-manifest")
+    bad_workspace.manifest_path().unlink()
     user = factories.create_airlock_user(
         username="testuser",
         workspaces={
-            "exists": factories.create_api_workspace(),
-            "not-on-disk": factories.create_api_workspace(),
+            "good": factories.create_api_workspace(),
+            "bad-manifest": factories.create_api_workspace(),
         },
-        readonly_access=True,
-    )
-
-    result = bll.get_all_workspaces(user)
-    assert [ws.name for ws in result] == ["exists"]
-
-
-def test_provider_get_all_workspaces_skips_missing_manifest_file(bll):
-    factories.create_workspace("exists")
-    bad_workspace = factories.create_workspace("no-manifest")
-    bad_workspace.manifest_path().unlink()
-    bad_workspace1 = factories.create_workspace("bad-manifest")
-    bad_workspace1.manifest_path().unlink()
-    user = factories.create_airlock_user(
-        username="testuser",
-        workspaces={"bad-manifest": factories.create_api_workspace()},
-        readonly_access=True,
     )
 
     tracer = trace.get_tracer("test")
     with tracer.start_as_current_span("test_span"):
-        result = bll.get_all_workspaces(user)
+        result = bll.get_workspaces_for_user(user)
 
-    assert [ws.name for ws in result] == ["exists"]
+    assert [ws.name for ws in result] == ["good"]
     spans = get_trace()
     assert len(spans) == 1
     assert len(spans[0].events) == 1
     event = spans[0].events[0]
     assert event.name == "exception"
     assert "ManifestFileError" in event.attributes["exception.type"]
-    assert (
-        "workspaces/bad-manifest/metadata/manifest.json does not exist"
-        in event.attributes["exception.message"]
+
+
+def test_provider_get_all_workspaces(bll):
+    factories.create_workspace("foo")
+    factories.create_workspace("bar")
+
+    result = bll.get_all_workspaces()
+    assert sorted(ws.name for ws in result) == ["bar", "foo"]
+
+
+def test_provider_get_all_workspaces_skips_no_manifest(bll):
+    factories.create_workspace("exists")
+    bad_workspace = factories.create_workspace("no-manifest")
+    bad_workspace.manifest_path().unlink()
+
+    result = bll.get_all_workspaces()
+    assert [ws.name for ws in result] == ["exists"]
+
+
+def test_provider_get_all_workspaces_skips_files(bll):
+    factories.create_workspace("real-workspace")
+    stray_file = settings.WORKSPACE_DIR / "stray-file.txt"
+    stray_file.write_text("not a workspace")
+
+    result = bll.get_all_workspaces()
+    assert [ws.name for ws in result] == ["real-workspace"]
+
+
+def test_provider_get_all_workspaces_returns_workspace_listings(bll):
+    factories.create_workspace("my-workspace")
+
+    result = bll.get_all_workspaces()
+    assert len(result) == 1
+    listing = result[0]
+    assert isinstance(listing, WorkspaceListing)
+    assert listing.name == "my-workspace"
+    assert listing.display_name() == "my-workspace"
+    assert listing.get_url() == reverse(
+        "workspace_view", kwargs={"workspace_name": "my-workspace"}
     )
 
 


### PR DESCRIPTION
The all-workspaces page was unusably slow in production, because there are so many workspaces, and it was calling get_workspace() for every directory, triggering manifest.json reads, hashing, file tree construction, and DB queries for every workspace, most of which it did't need to do.

Add a WorkspaceListing dataclass that just has the get_url()/display_name() interface the template needs, and refactor get_all_workspaces() to only scan the WORKSPACE_DIR and check for directories and for the existence of a manifest file.

Also simplify _build_workspace_list() to always record ManifestFileError telemetry unconditionally, since it is now only ever called with a user's own workspaces and copiloted workspaces rather than arbitrary filesystem directories.