### PR TITLE
Upgrade to django 6

### DIFF
--- a/airlock/templates/_components/list-group/list-group-item-dropdown.html
+++ b/airlock/templates/_components/list-group/list-group-item-dropdown.html
@@ -1,7 +1,7 @@
 <li {% if disabled %}class="block px-4 py-3 font-semibold cursor-not-allowed text-slate-700 break-words sm:px-6 {{ class }}"{% endif %}>
   <div class="flex items-center justify-between px-4 sm:px-6">
     {% if not disabled %}
-      <a class="transition-colors duration-200 px-2 py-3 font-semibold text-oxford-600 break-words sm:px-2 {{ class }}" {% attrs aria-checked aria-labelled-by href role %}>
+      <a class="transition-colors duration-200 px-2 py-3 font-semibold text-oxford-600 break-words sm:px-2 {{ class }}" {% attrs aria_checked aria_labelled_by href role %}>
         {{ children }}
       </a>
       {% if custom_button %}

--- a/airlock/templates/file_browser/request/request.html
+++ b/airlock/templates/file_browser/request/request.html
@@ -87,7 +87,7 @@
     {% endif %}
     {% if content_buttons.reject.show %}
       {% if content_buttons.reject.disabled %}
-        {% #button disabled=True class="relative group" small=True variant="danger" id="reject-request-button" data-modal="rejectRequest" %}
+        {% #button disabled=True class="relative group" small=True variant="danger" id="reject-request-button" data_modal="rejectRequest" %}
           Reject request
           {% tooltip class="airlock-tooltip" content=content_buttons.reject.tooltip %}
         {% /button %}

--- a/assets/fix_slippers_tags.py
+++ b/assets/fix_slippers_tags.py
@@ -1,0 +1,55 @@
+"""Rewrite hyphenated names in {% attrs %} and slippers component tags to use underscores.
+
+Django 6.0 disallows hyphens in template variable names. Slippers' {% attrs %} tag
+uses each listed name as both the HTML attribute key and the context variable to
+look up, and slippers component invocations ({% #name ... %}) resolve each kwarg
+name the same way, so hyphenated names raise TemplateSyntaxError at compile time.
+Slippers converts underscores back to hyphens in the rendered HTML, so this
+transformation is invisible to the browser.
+
+Only names are rewritten; values are left alone (e.g. data-table-pagination=id
+becomes data_table_pagination=id, but data_table_pagination="previous-page" keeps
+its hyphenated string value).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+TAG_RE = re.compile(
+    r"\{%\s*(attrs|#[A-Za-z_][A-Za-z0-9_]*)\s+([^%]+?)\s*%\}", re.DOTALL
+)
+TOKEN_RE = re.compile(r"""([^\s=]+)(=(?:"[^"]*"|'[^']*'|[^\s]+))?""")
+
+
+def fix_token(match):
+    name = match.group(1).replace("-", "_")
+    value = match.group(2) or ""
+    return name + value
+
+
+def fix_tag(match):
+    tag_name = match.group(1)
+    new_content = TOKEN_RE.sub(fix_token, match.group(2)).strip()
+    return "{% " + tag_name + " " + new_content + " %}"
+
+
+def fix_file(path):
+    text = path.read_text()
+    new_text = TAG_RE.sub(fix_tag, text)
+    if new_text == text:
+        return False
+    path.write_text(new_text)
+    return True
+
+
+def main(root):
+    print("Updating slippers components for Django 6 compatibility...")
+    for path in sorted(Path(root).rglob("*.html")):
+        if fix_file(path):
+            print(f"Fixed: {path}")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/assets/justfile
+++ b/assets/justfile
@@ -11,10 +11,34 @@ clean:
     rm -rf $ASSETS_DIST
 
 
+# Rewrite hyphenated names in {% attrs %} and {% #component %} tags to use
+# underscores, for Django 6.0 + Slippers compatibility (see commit d45574c9).
+
+fix-components:
+    uv run python fix_slippers_tags.py templates/_components
+
 # Update upstream assets from job-server
-update JOBSERVER_DIR="": clean
+update JOBSERVER_DIR="": && fix-components
     #!/bin/bash
     set -euo pipefail
+    # job-server is on tailwind v4; Airlock is currently pinned to 
+    # v3 due to the unsupported chrome version in L4
+    # Check for our tailwind version and warn if we're not yet on v4 
+    TAILWIND_VERSION=$(node -p "
+        const lock = require('../package-lock.json');
+        lock.packages['node_modules/tailwindcss'].version
+    ")
+
+    if [[ ! "$TAILWIND_VERSION" =~ ^4\. ]]; then
+        echo "Warning: Upstream assets use Tailwind v4 (we're using: $TAILWIND_VERSION)."
+        read -p "Continue anyway? [y/N] " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            echo "Aborting."
+            exit 1
+        fi
+    fi
+
+    just clean
 
     jobserver_dir={{ JOBSERVER_DIR }}
 

--- a/assets/templates/_components/button.html
+++ b/assets/templates/_components/button.html
@@ -1,13 +1,13 @@
 {% if type == "link" %}
   <a
-    {% attrs data-table-pagination href id %}
+    {% attrs data_table_pagination href id %}
     {% if external %}
       rel="noopener noreferrer"
       target="_blank"
     {% endif %}
 {% else %}
   <button
-    {% attrs data-expander-button data-modal data-title disabled id name type=type|default:"button" value form hx-post hx-get hx-trigger hx-swap hx-target %}
+    {% attrs data_expander_button data_modal data_title disabled id name type=type|default:"button" value form hx_post hx_get hx_trigger hx_swap hx_target %}
 
 {% endif %}
 

--- a/assets/templates/_components/index.html
+++ b/assets/templates/_components/index.html
@@ -862,7 +862,7 @@
                         </span>
                       </div>
                     {% /table_header %}
-                    {% #table_header data-type="date" data-format="DD MMM YYYY" %}
+                    {% #table_header data_type="date" data_format="DD MMM YYYY" %}
                       <div class="flex flex-row gap-2">
                         Job first run
                         <span class="ml-auto">
@@ -918,7 +918,7 @@
               {% filter force_escape %}</span>
             </div>{% endfilter %}
           {% verbatim %}{% /table_header %}{% endverbatim %}
-          {% verbatim %}{% #table_header data-type="date" data-format="DD MMM YYYY" %}{% endverbatim %}
+          {% verbatim %}{% #table_header data_type="date" data_format="DD MMM YYYY" %}{% endverbatim %}
             {% filter force_escape %}<div class="flex flex-row gap-2">
               Job first run
               <span class="ml-auto">{% endfilter %}

--- a/assets/templates/_components/link.html
+++ b/assets/templates/_components/link.html
@@ -5,7 +5,7 @@
     focus:decoration-transparent focus:text-oxford focus:bg-bn-sun-300
     {{ class }}
   "
-  {% attrs href hx-get hx-target hx-trigger %}
+  {% attrs href hx_get hx_target hx_trigger %}
   {% if new_tab %}
     target="_blank" rel="noopener noreferrer"
   {% endif %}

--- a/assets/templates/_components/list-group/list-group-empty.html
+++ b/assets/templates/_components/list-group/list-group-empty.html
@@ -1,5 +1,5 @@
 <li class="flex flex-col gap-y-2 text-center p-8 {{ class }}"
-  {% attrs data-filter-empty-state hidden %}
+  {% attrs data_filter_empty_state hidden %}
 >
   {% if icon %}
     {% icon_folder_open_outline class="mx-auto stroke-1 h-8 w-8 text-slate-400" %}

--- a/assets/templates/_components/list-group/list-group-item.html
+++ b/assets/templates/_components/list-group/list-group-item.html
@@ -13,7 +13,7 @@
       sm:px-6
       {{ class }}
     "
-    {% attrs aria-checked aria-labelled-by href role %}
+    {% attrs aria_checked aria_labelled_by href role %}
   >
   {% endif %}
     {{ children }}

--- a/assets/templates/_components/modal/modal.html
+++ b/assets/templates/_components/modal/modal.html
@@ -2,7 +2,7 @@
   {% if custom_button %}
     {{ custom_button }}
   {% else %}
-    {% #button class=button_class|default:"flex-shrink-0" small=button_small|default:False variant=button_variant|default:"primary" tooltip=button_tooltip data-modal=id %}
+    {% #button class=button_class|default:"flex-shrink-0" small=button_small|default:False variant=button_variant|default:"primary" tooltip=button_tooltip data_modal=id %}
     {{ button_text }}
     {% /button %}
   {% endif %}

--- a/assets/templates/_components/multiselect/multiselect.html
+++ b/assets/templates/_components/multiselect/multiselect.html
@@ -9,7 +9,7 @@
 {% var multiple=multiple|default:True %}
 
 <div class="multiselect {{ class }}">
-  <select data-multiselect data-placeholder="{{ placeholder }}" name="{{ input_name }}" id="{{ input_id }}" {% attrs multiple required data-max-items %}>
+  <select data-multiselect data-placeholder="{{ placeholder }}" name="{{ input_name }}" id="{{ input_id }}" {% attrs multiple required data_max_items %}>
     {% if custom_field == True %}
     {{ children }}
     {% else %}

--- a/assets/templates/_components/table/table-header.html
+++ b/assets/templates/_components/table/table-header.html
@@ -1,5 +1,5 @@
 <th
-  {% attrs data-type data-format data-searchable data-sortable data-hidden data-content data-order scope %}
+  {% attrs data_type data_format data_searchable data_sortable data_hidden data_content data_order scope %}
   class="
     py-3.5 px-2 text-left text-sm font-semibold text-slate-900
     {% if nowrap %}whitespace-nowrap{% endif %}

--- a/assets/templates/_components/table/table-pagination.html
+++ b/assets/templates/_components/table/table-pagination.html
@@ -16,12 +16,12 @@
   </div>
   <div class="flex flex-1 justify-between gap-4 sm:justify-end">
     {% if has_previous %}
-      {% #button data-table-pagination="previous-page" variant="secondary-outline" type="link" href=prev_url %}
+      {% #button data_table_pagination="previous-page" variant="secondary-outline" type="link" href=prev_url %}
         Previous
       {% /button %}
     {% endif %}
     {% if has_next %}
-      {% #button data-table-pagination="next-page" variant="secondary-outline" type="link" href=next_url %}
+      {% #button data_table_pagination="next-page" variant="secondary-outline" type="link" href=next_url %}
         Next
       {% /button %}
     {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
   
   dependencies = [
     "ansi2html<=1.9.2",
-    "Django<=5.2.14",
+    "Django<=6.0.5",
     "django-vite<=3.1.0",
     "slippers<=0.7.0",
     "django-htmx<=1.27.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ testpaths = [
 filterwarnings = [
     "ignore::DeprecationWarning:opentelemetry.*:",
     "ignore::DeprecationWarning:pytest_freezegun.*:",
+    # Slippers 0.7.0 deprecated underscore-to-hyphen conversion in attrs tags, but
+    # Django 6.0 rejects hyphens in template variable names, so we must use underscores.
+    "ignore:Underscores in attribute names are deprecated:DeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/renovate.json5
+++ b/renovate.json5
@@ -121,11 +121,6 @@
     // The locked version will correctly remain at the latest allowed version for python 3.11
     // i.e. <6, but the upper limit in pytproject.toml is confusing 
     {
-      "matchManagers": ["pep621"],
-      "matchDepNames": ["Django"],
-      "allowedVersions": "<6.0"
-    },
-    {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
       "addLabels": ["actions"],

--- a/requirements.uvmirror
+++ b/requirements.uvmirror
@@ -14,16 +14,16 @@ babel==2.18.0
     # via mkdocs-material
 backrefs==7.0
     # via mkdocs-material
-bleach==6.3.0
+bleach==6.4.0
     # via django-markdownify
-certifi==2026.4.22
+certifi==2026.5.20
     # via
     #   httpcore
     #   httpx
     #   requests
 charset-normalizer==3.4.7
     # via requests
-click==8.4.0
+click==8.4.1
     # via mkdocs
 colorama==0.4.6
     # via
@@ -31,7 +31,7 @@ colorama==0.4.6
     #   mkdocs
     #   mkdocs-material
     #   pytest
-coverage==7.14.0
+coverage==7.14.1
     # via
     #   django-coverage-plugin
     #   pytest-cov
@@ -39,7 +39,7 @@ distro==1.9.0
     # via ruyaml
 dj-database-url==3.1.2
     # via airlock
-django==5.2.14
+django==6.0.5
     # via
     #   airlock
     #   dj-database-url
@@ -63,7 +63,7 @@ django-htmx==1.27.0
 django-markdownify==0.9.7
     # via airlock
 django-stubs==6.0.4
-django-stubs-ext==6.0.4
+django-stubs-ext==6.0.5
     # via django-stubs
 django-vite==3.1.0
     # via airlock
@@ -76,7 +76,7 @@ ghp-import==2.1.0
     # via mkdocs
 googleapis-common-protos==1.75.0
     # via opentelemetry-exporter-otlp-proto-http
-greenlet==3.5.0
+greenlet==3.5.1
     # via playwright
 gunicorn==25.3.0
     # via airlock
@@ -86,7 +86,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
 hypothesis==6.152.9
-idna==3.15
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -187,7 +187,7 @@ pathspec==1.1.1
     # via
     #   mkdocs
     #   mypy
-platformdirs==4.9.6
+platformdirs==4.10.0
     # via mkdocs-get-deps
 playwright==1.60.0
     # via pytest-playwright
@@ -269,7 +269,7 @@ sqlparse==0.5.5
     #   django-debug-toolbar
 text-unidecode==1.3
     # via python-slugify
-tinycss2==1.4.0
+tinycss2==1.5.1
     # via bleach
 typeguard==2.13.3
     # via slippers

--- a/tests/unit/test_fix_slippers_tags.py
+++ b/tests/unit/test_fix_slippers_tags.py
@@ -1,0 +1,90 @@
+from assets.fix_slippers_tags import TAG_RE, fix_file, fix_tag, main
+
+
+def transform(text):
+    return TAG_RE.sub(fix_tag, text)
+
+
+def test_attrs_with_hyphenated_bare_names():
+    assert transform("{% attrs data-foo data-bar %}") == "{% attrs data_foo data_bar %}"
+
+
+def test_attrs_mixes_bare_and_kwarg_names():
+    text = '{% attrs href hx-get hx-target type=type|default:"button" %}'
+    expected = '{% attrs href hx_get hx_target type=type|default:"button" %}'
+    assert transform(text) == expected
+
+
+def test_component_tag_with_hyphenated_kwarg():
+    assert transform("{% #button data-modal=id %}") == "{% #button data_modal=id %}"
+
+
+def test_any_component_tag_is_rewritten_not_just_button():
+    text = '{% #table_header data-type="date" data-format="DD MMM YYYY" %}'
+    expected = '{% #table_header data_type="date" data_format="DD MMM YYYY" %}'
+    assert transform(text) == expected
+
+
+def test_hyphens_in_quoted_value_are_preserved():
+    text = '{% #button data-table-pagination="previous-page" %}'
+    expected = '{% #button data_table_pagination="previous-page" %}'
+    assert transform(text) == expected
+
+
+def test_quoted_value_with_internal_spaces_is_preserved():
+    text = '{% #button disabled=True class="hover:scale-110 transition-transform" %}'
+    assert transform(text) == text
+
+
+def test_argless_tag_is_left_alone():
+    assert transform("{% #breadcrumbs %}") == "{% #breadcrumbs %}"
+
+
+def test_non_slippers_tags_are_left_alone():
+    text = "{% url 'job-list' as foo %} {% if x %} {% endif %}"
+    assert transform(text) == text
+
+
+def test_hyphenated_html_attributes_outside_template_tags_are_preserved():
+    text = '<select data-multiselect data-placeholder="x" {% attrs multiple data-max-items %}>'
+    expected = '<select data-multiselect data-placeholder="x" {% attrs multiple data_max_items %}>'
+    assert transform(text) == expected
+
+
+def test_fix_file_writes_and_returns_true_when_changed(tmp_path):
+    f = tmp_path / "x.html"
+    f.write_text("{% attrs data-foo %}")
+    assert fix_file(f) is True
+    assert f.read_text() == "{% attrs data_foo %}"
+
+
+def test_fix_file_returns_false_and_does_not_rewrite_when_unchanged(tmp_path):
+    f = tmp_path / "x.html"
+    original = "{% attrs href %}"
+    f.write_text(original)
+    assert fix_file(f) is False
+    assert f.read_text() == original
+
+
+def test_fix_file_is_idempotent(tmp_path):
+    f = tmp_path / "x.html"
+    f.write_text("{% attrs data-foo %}\n{% #button data-bar=baz %}")
+    assert fix_file(f) is True
+    once = f.read_text()
+    assert fix_file(f) is False
+    assert f.read_text() == once
+
+
+def test_main_recurses_into_subdirs_and_skips_non_html(tmp_path, capsys):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "a.html").write_text("{% attrs data-foo %}")
+    (tmp_path / "sub" / "b.html").write_text("{% attrs data-bar %}")
+    (tmp_path / "c.txt").write_text("{% attrs data-baz %}")
+    main(str(tmp_path))
+    assert (tmp_path / "a.html").read_text() == "{% attrs data_foo %}"
+    assert (tmp_path / "sub" / "b.html").read_text() == "{% attrs data_bar %}"
+    assert (tmp_path / "c.txt").read_text() == "{% attrs data-baz %}"
+    out = capsys.readouterr().out
+    assert "a.html" in out
+    assert "b.html" in out
+    assert "c.txt" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ dev = [
 requires-dist = [
     { name = "ansi2html", specifier = "<=1.9.2" },
     { name = "dj-database-url", specifier = ">=3.1.2" },
-    { name = "django", specifier = "<=5.2.14" },
+    { name = "django", specifier = "<=6.0.5" },
     { name = "django-extensions", specifier = "<=4.1" },
     { name = "django-htmx", specifier = "<=1.27.0" },
     { name = "django-markdownify", specifier = "<=0.9.7" },
@@ -161,14 +161,14 @@ wheels = [
 
 [[package]]
 name = "bleach"
-version = "6.3.0"
+version = "6.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/18/3c8523962314be6bf4c8989c79ad9531c825210dd13a8669f6b84336e8bd/bleach-6.3.0.tar.gz", hash = "sha256:6f3b91b1c0a02bb9a78b5a454c92506aa0fdf197e1d5e114d2e00c6f64306d22", size = 203533, upload-time = "2025-10-27T17:57:39.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl", hash = "sha256:fe10ec77c93ddf3d13a73b035abaac7a9f5e436513864ccdad516693213c65d6", size = 164437, upload-time = "2025-10-27T17:57:37.538Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
 ]
 
 [package.optional-dependencies]
@@ -178,11 +178,11 @@ css = [
 
 [[package]]
 name = "certifi"
-version = "2026.4.22"
+version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
 ]
 
 [[package]]
@@ -212,14 +212,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -233,26 +233,26 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.0"
+version = "7.14.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/1e/2f996b2c8415cbb6f54b0f5ec1ee850c96d7911961afb4fc05f4a89d8c58/coverage-7.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ffd19fc8aed057fd686a17a4935eef5f9859d69208f96310e893e64b9b6ccf5", size = 219967, upload-time = "2026-05-10T18:00:13.756Z" },
-    { url = "https://files.pythonhosted.org/packages/34/23/35c7aea1274aef7525bdd2dc92f710bdde6d11652239d71d1ec450067939/coverage-7.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:829994cfe1aeb773ca27bf246d4badc1e764893e3bfb98fff820fcecd1ca4662", size = 220329, upload-time = "2026-05-10T18:00:15.264Z" },
-    { url = "https://files.pythonhosted.org/packages/75/cf/a8f4b43a16e194b0261257ad28ded5853ec052570afef4a84e1d81189f3b/coverage-7.14.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b4f07cf7edcb7ec39431a5074d7ea83b29a9f71fcfc494f0f40af4e65180420f", size = 251839, upload-time = "2026-05-10T18:00:17.16Z" },
-    { url = "https://files.pythonhosted.org/packages/69/ff/6699e7b71e60d3049eb2bdcbc95ee3f35707b2b0e48f32e9e63d3ce30c08/coverage-7.14.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ca3d9cf2c32b521bd9518385608787fa86f38daf993695307531822c3430ed67", size = 254576, upload-time = "2026-05-10T18:00:18.829Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ec/c936d495fcd67f48f03a9c4ad3297ff80d1f222a5df3980f15b34c186c21/coverage-7.14.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92af52828e7f29d827346b0294e5a0853fa206db77db0395b282918d41e28db9", size = 255690, upload-time = "2026-05-10T18:00:20.648Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/42/5af63f636cc62a4a2b1b3ba9146f6ee6f53a35a50d5cefc54d5670f60999/coverage-7.14.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7b2bb6c9d7e769360d0f20a0f219603fd64f0c8f97de17ab25853261602be0fb", size = 257949, upload-time = "2026-05-10T18:00:22.28Z" },
-    { url = "https://files.pythonhosted.org/packages/26/d3/a225317bd2012132a27e1176d51660b826f99bb975876463c44ea0d7ee5a/coverage-7.14.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c9ed6ef99f88fb8c14aa8e2bf8eb0fe55fa2edfea68f8675d78741df1a5ac0e", size = 252242, upload-time = "2026-05-10T18:00:24.076Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/7f/9e65495298c3ea414742998539c37d048b5e81cc818fb1828cc6b51d10bf/coverage-7.14.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8231ade007f37959fbf58acc677f26b922c02eda6f0428ea307da0fd39681bf3", size = 253608, upload-time = "2026-05-10T18:00:25.588Z" },
-    { url = "https://files.pythonhosted.org/packages/94/46/1522b524a35bdad22b2b8c4f9d32d0a104b524726ec380b2db68db1746f5/coverage-7.14.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d8b013632cc1ce1d09dbe4f32667b4d320ec2f54fc326ebeffcd0b0bcc2bb6c4", size = 251753, upload-time = "2026-05-10T18:00:27.104Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/e9/cdf00d38817742c541ade405e115a3f7bf36e6f2a8b99d4f209861b85a2d/coverage-7.14.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1733198802d71ec4c524f322e2867ee05c62e9e75df86bdca545407a221827d1", size = 255823, upload-time = "2026-05-10T18:00:29.038Z" },
-    { url = "https://files.pythonhosted.org/packages/38/fc/5e7877cf5f902d08a17ff1c532511476d87e1bea355bd5028cb97f902e79/coverage-7.14.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:72a305291fa8ee01332f1aaf38b348ca34097f6aa0b0ef627eef2837e57bbba5", size = 251323, upload-time = "2026-05-10T18:00:30.647Z" },
-    { url = "https://files.pythonhosted.org/packages/18/9d/50f05a72dff8487464fdd4178dda5daed642a060e60afb644e3d45123559/coverage-7.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcaba850dd317c65423a9d63d88f9573c53b00354d6dd95724576cc98a131595", size = 253197, upload-time = "2026-05-10T18:00:32.211Z" },
-    { url = "https://files.pythonhosted.org/packages/00/3f/6f61ffe6439df266c3cf60f5c99cfaa21103d0210d706a42fc6c30683ff8/coverage-7.14.0-cp312-cp312-win32.whl", hash = "sha256:5ac83957a80d0701310e96d8bec68cdcf4f90a7674b7d13f15a344315b41ab27", size = 222515, upload-time = "2026-05-10T18:00:33.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/19/93853133df2cb371083285ef6a93982a0173e7a233b0f61373ba9fd30eb2/coverage-7.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:70390b0da32cb90b501953716302906e8bcce087cb283e70d8c97729f22e92b2", size = 223324, upload-time = "2026-05-10T18:00:35.172Z" },
-    { url = "https://files.pythonhosted.org/packages/74/18/9f7fe62f659f24b7a82a0be56bf94c1bd0a89e0ae7ab4c668f6e82404294/coverage-7.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:91b993743d959b8be85b4abf9d5478216a69329c321efe5be0433c1a841d691d", size = 221944, upload-time = "2026-05-10T18:00:37.014Z" },
-    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
 ]
 
 [[package]]
@@ -278,16 +278,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.14"
+version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/95/95f7faa0950867afaa0bef2460c6263afd6a2c78cc9434046ed28160b015/django-5.2.14.tar.gz", hash = "sha256:58a63ba841662e5c686b57ba1fec52ddd68c0b93bd96ac3029d55728f00bf8a2", size = 10895118, upload-time = "2026-05-05T13:57:31.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f1/bf85f0d29ef76abf901f193fe8fef4769d3da7794197832bc30151c071d8/django-6.0.5.tar.gz", hash = "sha256:bc6d6872e98a2864c836e42edd644b362db311147dd5aa8d5b82ba7a032f5269", size = 10924131, upload-time = "2026-05-05T13:54:39.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/44/f172870cf87aa25afef48fb72adba89ee8b77fcab6f3b23d240b923f1528/django-5.2.14-py3-none-any.whl", hash = "sha256:6f712143bd3064310d1f50fac859c3e9a274bdcfc9595339853be7779297fc76", size = 8311320, upload-time = "2026-05-05T13:57:25.795Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5b/1328f8b84fce040c404f76822bf8c57d254e368e8cbd8bd67ec2b26d75f5/django-6.0.5-py3-none-any.whl", hash = "sha256:9d58a7cb49244e74c8e161d5e403a46d6209f1009ba40f5a66d6aa0d0786a8f0", size = 8368680, upload-time = "2026-05-05T13:54:33.532Z" },
 ]
 
 [[package]]
@@ -393,15 +393,15 @@ compatible-mypy = [
 
 [[package]]
 name = "django-stubs-ext"
-version = "6.0.4"
+version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/b0/94335dc59138483c2bd2edf81cb39240fdef5e72c8cf0a6c177db207617b/django_stubs_ext-6.0.4.tar.gz", hash = "sha256:ff21f7b4362928b56e18cda0595f296e33c665f3019f4e3e4231977385e76cac", size = 6684, upload-time = "2026-05-09T21:24:02.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/01/419bc3cd882f3ec645d5a4511085202dd6bd3ef8d385871dcd2d32cc15b3/django_stubs_ext-6.0.5.tar.gz", hash = "sha256:1cc325e991303849bce70e19748981b225ef08b37256f263e113caf97cd3bcc0", size = 6666, upload-time = "2026-05-25T08:46:36.012Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/42/7db8470c0e276e7c7763c468441381dfa8727a360c68473f33ef828422bb/django_stubs_ext-6.0.4-py3-none-any.whl", hash = "sha256:0434a912bb08a370afcac9e90305c53e6f4eed3c1d1d46962559da5f8dbb8f27", size = 10373, upload-time = "2026-05-09T21:24:01.291Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bf/7ee71071d84ad4e0efcd77e2681afed254a5f65c27524441a9caf8c60467/django_stubs_ext-6.0.5-py3-none-any.whl", hash = "sha256:a9932c8233d6dd4e34ae0b192026379c1a9be8f0b7c27aa1fa09ae215169773e", size = 10362, upload-time = "2026-05-25T08:46:34.467Z" },
 ]
 
 [[package]]
@@ -472,20 +472,20 @@ wheels = [
 
 [[package]]
 name = "greenlet"
-version = "3.5.0"
+version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
-    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
 ]
 
 [[package]]
@@ -551,11 +551,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -947,11 +947,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -1374,14 +1374,14 @@ wheels = [
 
 [[package]]
 name = "tinycss2"
-version = "1.4.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "webencodings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz", hash = "sha256:10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7", size = 87085, upload-time = "2024-10-24T14:58:29.895Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/34/ebdc18bae6aa14fbee1a08b63c015c72b64868ff7dae68808ab500c492e2/tinycss2-1.4.0-py3-none-any.whl", hash = "sha256:3a49cf47b7675da0b15d0c6e1df8df4ebd96e9394bb905a5775adb0d884c5289", size = 26610, upload-time = "2024-10-24T14:58:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Django 6.0 doesn't allow hyphens in template variable names. Slippers wants hyphens in its attrs and automatically converts underscores back to hyphens in the rendered HTML output, so the browser-visible markup is unchanged.

BUT using underscores is deprecated in Slippers, which says to use hyphens instead, so we also have to suppress the slippers deprecation warning.

There aren't a lot of changes needed, but it means that we're making changes to the components that we previously pulled from upstream job-server, which prevents us from updating them anymore.

Update: I've added a script at `just assets/fix-components` that will do the component fixes, and runs after `just assets/update`. However, job-server is now on tailwind 4, we're on tailwind 3 (because the chrome version on L4 doesn't support tailwind 4), so we can't (easily) update upstream assets anyway. Since we keep forgetting this (or at least I do), I've also added a warning to the `just assets/update` recipe.