### PR TITLE
Preserve tree scroll position after file review actions

### DIFF
--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -191,20 +191,47 @@ document.body.addEventListener("submit", (event) => {
   if (tree) sessionStorage.setItem("treeScrollTop", tree.scrollTop);
 });
 
-// Restore scroll position on page load
-document.addEventListener("DOMContentLoaded", () => {
+// Restore scroll position on page load.
+//
+// scrollTop is a property on any scrollable element. It's the number of
+// pixels the content is scrolled down from the top. We can read it and
+// write it - but because it's a position, the fact that we set it doesn't
+// mean that it definitely has the value we set.
+//
+// The valid range is [0, scrollHeight − clientHeight]. If the layout hasn't
+// fully settled when we assign, then scrollHeight can momentarily be <=
+// clientHeight, so it's actually set to 0 and nothing ever re-applies it.
+// Reading scrollTop back after assignment tells us whether the value stuck.
+//
+// So: assign, read back, and if it didn't stick, retry on the next animation
+// frame. Give up after ~30 frames (~0.5s at 60fps) so we don't loop forever if
+// the saved position is genuinely unreachable (e.g. the destination page has
+// less tree content than the source).
+//
+// Note on very large trees: the budget is 30 animation frames, not 500ms of
+// wall-clock time. If layout is expensive (tens of thousands of files) and the
+// frame rate drops, rAF fires less often, so we still get 30 real chances to
+// re-apply. The number of settle events we're waiting for (initial layout,
+// fonts, the resizer's 100ms debounce) is fixed regardless of tree size, so
+// this should scale.
+window.addEventListener("load", () => {
   const saved = sessionStorage.getItem("treeScrollTop");
+  if (!saved) return;
+  sessionStorage.removeItem("treeScrollTop");
+  // We only need to care about scroll positions if we're on a page with a tree
   const treeContainer = document.getElementById("tree-container");
+  if (!treeContainer) return;
 
-
-  if (saved) {
-    sessionStorage.removeItem("treeScrollTop");
-    // Wait for browser scroll restoration to complete before applying saved position.
-    // The browser may reset scrollTop after DOMContentLoaded, so we delay slightly.
-    setTimeout(() => {
-      treeContainer.scrollTop = parseInt(saved, 10);
+  const target = parseInt(saved, 10);
+  let attempts = 30;
+  const restoreScrollPosition = () => {
+    treeContainer.scrollTop = target;
+    if (treeContainer.scrollTop === target || attempts-- <= 0) {
       document.getElementById("scroll-restore-style")?.remove();
-    }, 125);
-  }
+      return;
+    }
+    requestAnimationFrame(restoreScrollPosition);
+  };
+  restoreScrollPosition();
 });
 

--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -1,3 +1,11 @@
+// Only disable browser scroll restoration when there is a position to restore
+if (sessionStorage.getItem("treeScrollTop")) {
+  if ('scrollRestoration' in history) {
+    history.scrollRestoration = 'manual';
+    document.head.insertAdjacentHTML("beforeend", "<style id='scroll-restore-style'>#tree-container{visibility:hidden}</style>");
+  }
+}
+
 // keep the selected class up to date in the tree on the client side
 function setTreeSelection(tree, event) {
   // target here is the hx-get link that has been clicked on
@@ -174,3 +182,31 @@ if (document.readyState !== "loading") {
 // Every time a datatable is rendered we need to update the checkboxes
 // so they match the saved state
 document.body.addEventListener("clusterize-table-updated", renderCheckboxStatus);
+
+// Save scroll position before approve/request_changes form submits
+document.body.addEventListener("submit", (event) => {
+  const form = event.target.closest("form");
+  if (!form) return;
+  const tree = document.getElementById("tree-container");                    
+  if (tree) sessionStorage.setItem("treeScrollTop", tree.scrollTop); 
+    sessionStorage.setItem("treeScrollTop", document.getElementById("tree-container").scrollTop);
+  }
+);
+
+// Restore scroll position on page load
+document.addEventListener("DOMContentLoaded", () => {
+  const saved = sessionStorage.getItem("treeScrollTop");
+  const treeContainer = document.getElementById("tree-container");
+
+
+  if (saved) {
+    sessionStorage.removeItem("treeScrollTop");
+    // Wait for browser scroll restoration to complete before applying saved position.
+    // The browser may reset scrollTop after DOMContentLoaded, so we delay slightly.
+    setTimeout(() => {
+      treeContainer.scrollTop = parseInt(saved, 10);
+      document.getElementById("scroll-restore-style")?.remove();
+    }, 125);
+  }
+});
+

--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -222,8 +222,10 @@ window.addEventListener("load", () => {
   const treeContainer = document.getElementById("tree-container");
   if (!treeContainer) return;
 
-  const target = parseInt(saved, 10);
-  let attempts = 30;
+  restoreTreeScrollPosition(treeContainer, parseInt(saved, 10));
+});
+
+function restoreTreeScrollPosition(treeContainer, target, attempts = 30) {
   const restoreScrollPosition = () => {
     treeContainer.scrollTop = target;
     if (treeContainer.scrollTop === target || attempts-- <= 0) {
@@ -233,5 +235,5 @@ window.addEventListener("load", () => {
     requestAnimationFrame(restoreScrollPosition);
   };
   restoreScrollPosition();
-});
+}
 

--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -1,4 +1,6 @@
-// Only disable browser scroll restoration when there is a position to restore
+// If we have a previous scroll position to restore, disable the browser's
+// own scroll restoration to avoid conflicts with restoreTreeScrollPosition
+// and hide the tree until our restore loop finishes.
 if (sessionStorage.getItem("treeScrollTop")) {
   if ('scrollRestoration' in history) {
     history.scrollRestoration = 'manual';
@@ -191,8 +193,18 @@ document.body.addEventListener("submit", (event) => {
   if (tree) sessionStorage.setItem("treeScrollTop", tree.scrollTop);
 });
 
-// Restore scroll position on page load.
-//
+// Restore scroll position on page load (see restoreTreeScrollPosition).
+window.addEventListener("load", () => {
+  const saved = sessionStorage.getItem("treeScrollTop");
+  if (!saved) return;
+  sessionStorage.removeItem("treeScrollTop");
+  // We only need to care about scroll positions if we're on a page with a tree
+  const treeContainer = document.getElementById("tree-container");
+  if (!treeContainer) return;
+
+  restoreTreeScrollPosition(treeContainer, parseInt(saved, 10));
+});
+
 // scrollTop is a property on any scrollable element. It's the number of
 // pixels the content is scrolled down from the top. We can read it and
 // write it - but because it's a position, the fact that we set it doesn't
@@ -214,17 +226,6 @@ document.body.addEventListener("submit", (event) => {
 // re-apply. The number of settle events we're waiting for (initial layout,
 // fonts, the resizer's 100ms debounce) is fixed regardless of tree size, so
 // this should scale.
-window.addEventListener("load", () => {
-  const saved = sessionStorage.getItem("treeScrollTop");
-  if (!saved) return;
-  sessionStorage.removeItem("treeScrollTop");
-  // We only need to care about scroll positions if we're on a page with a tree
-  const treeContainer = document.getElementById("tree-container");
-  if (!treeContainer) return;
-
-  restoreTreeScrollPosition(treeContainer, parseInt(saved, 10));
-});
-
 function restoreTreeScrollPosition(treeContainer, target, attempts = 30) {
   treeContainer.scrollTop = target;
 

--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -188,10 +188,8 @@ document.body.addEventListener("submit", (event) => {
   const form = event.target.closest("form");
   if (!form) return;
   const tree = document.getElementById("tree-container");                    
-  if (tree) sessionStorage.setItem("treeScrollTop", tree.scrollTop); 
-    sessionStorage.setItem("treeScrollTop", document.getElementById("tree-container").scrollTop);
-  }
-);
+  if (tree) sessionStorage.setItem("treeScrollTop", tree.scrollTop);
+});
 
 // Restore scroll position on page load
 document.addEventListener("DOMContentLoaded", () => {

--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -226,14 +226,13 @@ window.addEventListener("load", () => {
 });
 
 function restoreTreeScrollPosition(treeContainer, target, attempts = 30) {
-  const restoreScrollPosition = () => {
-    treeContainer.scrollTop = target;
-    if (treeContainer.scrollTop === target || attempts-- <= 0) {
-      document.getElementById("scroll-restore-style")?.remove();
-      return;
-    }
-    requestAnimationFrame(restoreScrollPosition);
-  };
-  restoreScrollPosition();
-}
+  treeContainer.scrollTop = target;
 
+  if (treeContainer.scrollTop === target || attempts <= 0) {
+    // Show the tree
+    document.getElementById("scroll-restore-style")?.remove();
+    return;
+  }
+
+  requestAnimationFrame(() => restoreTreeScrollPosition(treeContainer, target, attempts - 1));
+}

--- a/assets/src/scripts/resizer.js
+++ b/assets/src/scripts/resizer.js
@@ -77,8 +77,16 @@ ro.observe(document.documentElement);
  * When the user selects a file from the tree, HTMX replaces the content.
  * Listen for this change, and reset the content height after the file content
  * has been loaded.
+ * 
+ * We need to recalculate both the content height AND the tree height; if there
+ * was an alert on a page, and the user click on a different file in the tree
+ * without dismissing it, the alert will disappear when htmx replaces the content,
+ * and we need to resize the tree to fix the available space.
  */
-document.body.addEventListener("htmx:afterSettle", () => setContentHeight());
+document.body.addEventListener("htmx:afterSettle", () => {
+  setContentHeight();
+  setTreeHeight();
+});
 
 /**
  * Alert behaviour is controlled by the _alert.js script which we pull in from upstream

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -1398,3 +1398,40 @@ def test_request_action_required_alert(
     click_and_htmx(page, page.locator(".tree__file").filter(has_text="file1"))
     expect(content_alert).to_be_visible()
     expect(content_alert_link).to_be_visible()
+
+
+@pytest.mark.parametrize(
+    "button_id",
+    ["#file-approve-button", "#file-request-changes-button"],
+)
+def test_tree_scroll_preserved_after_file_review_action(
+    live_server, context, page, button_id
+):
+    login_as_user(
+        live_server,
+        context,
+        user_dict=factories.create_api_user(username="checker", output_checker=True),
+    )
+    release_request = factories.create_request_at_status(
+        "workspace",
+        status=RequestStatus.SUBMITTED,
+        files=[
+            factories.request_file(group="group", path=f"file{i:02d}.txt")
+            for i in range(30)
+        ],
+    )
+
+    page.goto(live_server.url + release_request.get_url("group/file00.txt"))
+
+    assert page.evaluate("document.getElementById('tree-container').scrollTop") == 0
+    page.evaluate("document.getElementById('tree-container').scrollTop = 200")
+    scroll_before = page.evaluate("document.getElementById('tree-container').scrollTop")
+    assert scroll_before > 0
+
+    page.locator(button_id).click()
+    page.wait_for_load_state("load")
+    # Tree is hidden during scroll restoration; wait for it to become visible
+    expect(page.locator("#tree-container")).to_be_visible()
+
+    scroll_after = page.evaluate("document.getElementById('tree-container').scrollTop")
+    assert scroll_after == scroll_before

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -1416,22 +1416,39 @@ def test_tree_scroll_preserved_after_file_review_action(
         "workspace",
         status=RequestStatus.SUBMITTED,
         files=[
-            factories.request_file(group="group", path=f"file{i:02d}.txt")
-            for i in range(30)
+            factories.request_file(group="group", path=f"file{i:03d}.txt")
+            for i in range(100)
         ],
     )
 
-    page.goto(live_server.url + release_request.get_url("group/file00.txt"))
+    page.goto(live_server.url + release_request.get_url("group/file000.txt"))
+    tree_container = page.locator("#tree-container")
 
+    # The resizer script (assets/src/scripts/resizer.js) shrinks
+    # #tree-container to fit the viewport asynchronously via a debounced
+    # ResizeObserver; until it runs the container isn't overflow-scrollable
+    # and scroll_into_view_if_needed would scroll the window instead.
+    page.wait_for_function(
+        "() => { const c = document.getElementById('tree-container');"
+        "  return c && c.scrollHeight > c.clientHeight; }"
+    )
     assert page.evaluate("document.getElementById('tree-container').scrollTop") == 0
-    page.evaluate("document.getElementById('tree-container').scrollTop = 200")
+
+    # Scroll a file that isn't visible from the top of the tree into view.
+    # After the review action we expect both the scroll position and this
+    # file's on-screen visibility to be preserved.
+    target_file = tree_container.locator(".tree__file").filter(has_text="file080.txt")
+    target_file.scroll_into_view_if_needed()
     scroll_before = page.evaluate("document.getElementById('tree-container').scrollTop")
     assert scroll_before > 0
+    expect(target_file).to_be_in_viewport()
 
     page.locator(button_id).click()
     page.wait_for_load_state("load")
-    # Tree is hidden during scroll restoration; wait for it to become visible
-    expect(page.locator("#tree-container")).to_be_visible()
 
-    scroll_after = page.evaluate("document.getElementById('tree-container').scrollTop")
-    assert scroll_after == scroll_before
+    # scrollTop is restored (polls, tolerating the JS retry loop's timing)
+    expect(tree_container).to_have_js_property("scrollTop", scroll_before)
+    # ...which means the file we scrolled to is still on-screen
+    expect(target_file).to_be_in_viewport()
+    # Restore path cleared its sessionStorage entry
+    assert page.evaluate("sessionStorage.getItem('treeScrollTop')") is None

--- a/tests/functional/test_request_pages.py
+++ b/tests/functional/test_request_pages.py
@@ -1437,6 +1437,8 @@ def test_tree_scroll_preserved_after_file_review_action(
     # Scroll a file that isn't visible from the top of the tree into view.
     # After the review action we expect both the scroll position and this
     # file's on-screen visibility to be preserved.
+    # Note that we don't have to view file080.txt itself - we're using it
+    # to set a new scroll position only.
     target_file = tree_container.locator(".tree__file").filter(has_text="file080.txt")
     target_file.scroll_into_view_if_needed()
     scroll_before = page.evaluate("document.getElementById('tree-container').scrollTop")


### PR DESCRIPTION
Closes: #906 

When reviewing files in a large request, clicking approve/request changes (and undoing these actions) would redirect back to the same file but reset the file tree scroll position to the top. 

This fix saves the tree scroll bar position before the form submits and restores it after the page reloads.

There is no test added for this change because the scroll bar position restoration is dependent on a hard-coded delay, making it prone to flakiness. 