### PR TITLE
Add minimal changes to support running against Postgres

### DIFF
--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -16,6 +16,7 @@ import os
 import warnings
 from pathlib import Path
 
+import dj_database_url
 from django.contrib import messages
 
 
@@ -163,48 +164,53 @@ WSGI_APPLICATION = "airlock.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
+database_url = os.environ.get("DATABASE_URL")
+if not database_url:
+    # This is our current production config
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": WORK_DIR / "db.sqlite3",
+            "OPTIONS": {
+                # For details on these pragmas see: https://www.sqlite.org/pragma.html
+                "init_command": """
+                    /* These settings give much better write performance than the default
+                       without sacrificing consistency guarantees */
+                    PRAGMA journal_mode = WAL;
+                    PRAGMA synchronous = NORMAL;
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": WORK_DIR / "db.sqlite3",
-        "OPTIONS": {
-            # For details on these pragmas see: https://www.sqlite.org/pragma.html
-            "init_command": """
-                /* These settings give much better write performance than the default
-                   without sacrificing consistency guarantees */
-                PRAGMA journal_mode = WAL;
-                PRAGMA synchronous = NORMAL;
+                    /* Enforce foreign keys which SQLite doesn't do by default only for
+                       backwards compatibility reasons */
+                    PRAGMA foreign_keys = ON;
 
-                /* Enforce foreign keys which SQLite doesn't do by default only for
-                   backwards compatibility reasons */
-                PRAGMA foreign_keys = ON;
+                    /* How long (in ms) to let one write transaction wait for another */
+                    PRAGMA busy_timeout = 5000;
 
-                /* How long (in ms) to let one write transaction wait for another */
-                PRAGMA busy_timeout = 5000;
-
-                /* The default cache size is 2MB but we can afford more! Note negative
-                   values set cache size in KB, positive numbers set it by number of
-                   database pages */
-                PRAGMA cache_size = -256000;
-            """,
-            # Switch from SQLite's default DEFERRED transaction mode to IMMEDIATE. This
-            # has the effect that write transactions will respect the busy timeout,
-            # rather than failing immediately with "Database locked" if another write
-            # transaction is in progress.
-            # https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
-            "transaction_mode": "IMMEDIATE",
-        },
-        # Specify a test db so that django uses a filesystem db instead on an in-memory
-        # one. This means it can use WAL mode in tests and prevents the "table is locked"
-        # error when two threads read and write at the same time (i.e. in the functional
-        # tests, where we have htmx polling in the running liveserver browser, and we
-        # also update a release request in the test code)
-        "TEST": {
-            "NAME": WORK_DIR / "test_db.sqlite3",
-        },
+                    /* The default cache size is 2MB but we can afford more! Note negative
+                       values set cache size in KB, positive numbers set it by number of
+                       database pages */
+                    PRAGMA cache_size = -256000;
+                """,
+                # Switch from SQLite's default DEFERRED transaction mode to IMMEDIATE. This
+                # has the effect that write transactions will respect the busy timeout,
+                # rather than failing immediately with "Database locked" if another write
+                # transaction is in progress.
+                # https://www.sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions
+                "transaction_mode": "IMMEDIATE",
+            },
+            # Specify a test db so that django uses a filesystem db instead on an in-memory
+            # one. This means it can use WAL mode in tests and prevents the "table is locked"
+            # error when two threads read and write at the same time (i.e. in the functional
+            # tests, where we have htmx polling in the running liveserver browser, and we
+            # also update a release request in the test code)
+            "TEST": {
+                "NAME": WORK_DIR / "test_db.sqlite3",
+            },
+        }
     }
-}
+else:  # pragma: no cover
+    # We support Postgres so we can investigate alternative deployment scenarios
+    DATABASES = {"default": dj_database_url.parse(database_url)}  # type: ignore
 
 
 # ATOMIC_REQUESTS are disabled by default but we explicitly disable them here so we can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@
     "mkdocs<=1.6.1",
     "mkdocs-material<=9.7.6",
     "django-extensions<=4.1",
+    "dj-database-url>=3.1.2",
+    "psycopg2-binary>=2.9.12",
 ]
 
 [tool.ruff]

--- a/requirements.uvmirror
+++ b/requirements.uvmirror
@@ -37,9 +37,12 @@ coverage==7.14.0
     #   pytest-cov
 distro==1.9.0
     # via ruyaml
+dj-database-url==3.1.2
+    # via airlock
 django==5.2.14
     # via
     #   airlock
+    #   dj-database-url
     #   django-coverage-plugin
     #   django-debug-toolbar
     #   django-extensions
@@ -194,6 +197,8 @@ protobuf==6.33.6
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
+psycopg2-binary==2.9.12
+    # via airlock
 pydantic==2.13.4
     # via airlock
 pydantic-core==2.46.4

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ansi2html" },
+    { name = "dj-database-url" },
     { name = "django" },
     { name = "django-extensions" },
     { name = "django-htmx" },
@@ -21,6 +22,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-requests" },
     { name = "opentelemetry-sdk" },
+    { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "requests" },
     { name = "slippers" },
@@ -52,6 +54,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ansi2html", specifier = "<=1.9.2" },
+    { name = "dj-database-url", specifier = ">=3.1.2" },
     { name = "django", specifier = "<=5.2.14" },
     { name = "django-extensions", specifier = "<=4.1" },
     { name = "django-htmx", specifier = "<=1.27.0" },
@@ -65,6 +68,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-django", specifier = "<=0.61b0" },
     { name = "opentelemetry-instrumentation-requests", specifier = "<=0.61b0" },
     { name = "opentelemetry-sdk", specifier = "<=1.41.1" },
+    { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "pydantic", specifier = "<=2.13.4" },
     { name = "requests", specifier = "<=2.34.0" },
     { name = "slippers", specifier = "<=0.7.0" },
@@ -256,6 +260,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "dj-database-url"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/f6/00b625e9d371b980aa261011d0dc906a16444cb688f94215e0dc86996eb5/dj_database_url-3.1.2.tar.gz", hash = "sha256:63c20e4bbaa51690dfd4c8d189521f6bf6bc9da9fcdb23d95d2ee8ee87f9ec62", size = 11490, upload-time = "2026-02-19T15:30:23.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/a9/57c66006373381f1d3e5bd94216f1d371228a89f443d3030e010f73dd198/dj_database_url-3.1.2-py3-none-any.whl", hash = "sha256:544e015fee3efa5127a1eb1cca465f4ace578265b3671fe61d0ed7dbafb5ec8a", size = 8953, upload-time = "2026-02-19T15:30:39.37Z" },
 ]
 
 [[package]]
@@ -968,6 +984,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This gives us a docker image which we can use to test alternative deployments of Airlock. The changes here are so small that I think it's preferable to make them in the production image rather than incur the complexity of a separate build process.

As noted in the [original spike](https://github.com/opensafely-core/airlock/issues/1171) there are some small changes to the test suite needed to get things fully green under Postgres, but these are issues with the tests not the application itself. I don't propose doing this now.

It wouldn't be an enormous amount of effort to run the tests against both SQLite and Postgres in CI. Whatever we end up deciding to do about the existing deployments I anticipate at least some period where we're running against both databases and so we'll need to run CI against both. 