### PR TITLE
Fix select / deselect all behaviour when released files are present

### DIFF
--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -67,13 +67,17 @@ function saveCheckboxSessionState() {
   sessionStorage.setItem("checkbox-cache", JSON.stringify(currentState));
 }
 
+function isReleasedFile(checkbox) {
+  return checkbox.closest('tr')?.dataset.released === 'true';
+}
+
 // implement select all checkbox
 function toggleSelectAll(elem) {
   const checkboxes = getVisibleCheckboxes();
 
   checkboxes.forEach((checkbox) => {
     // Skip checkboxes for released files that are currently unchecked
-    if (checkbox.closest('tr')?.dataset.released === 'true' && !checkbox.checked) {
+    if (isReleasedFile(checkbox) && !checkbox.checked) {
       return;
     }
     checkbox.checked = elem.checked;
@@ -83,9 +87,9 @@ function toggleSelectAll(elem) {
 }
 
 // Update the state of the select all checkbox. Checked if
-// all other checkboxes are checked, unchecked if none of the
-// others are checked, and "intermediate" (visual only) if some
-// of them are checked
+// all unreleased files are checked; unchecked otherwise
+// Then, set visual state to "indeterminate" if any box (released file or not)
+// is checked but not all of them
 function updateSelectAllCheckbox() {
   const selectAllCheckboxEl = document.querySelector(".selectall");
   if (!selectAllCheckboxEl) return;
@@ -95,8 +99,22 @@ function updateSelectAllCheckbox() {
 
   const areAllChecked = selected.length === checkboxes.length;
   const areNoneChecked = selected.length === 0;
+
+  if (areNoneChecked) {
+    selectAllCheckboxEl.checked = false;
+    selectAllCheckboxEl.indeterminate = false;
+    return;
+  }
+
+  const released = checkboxes.filter(isReleasedFile);
+
+  if (released.length === 0) {
   selectAllCheckboxEl.checked = areAllChecked;
-  selectAllCheckboxEl.indeterminate = !(areAllChecked || areNoneChecked);
+  } else {
+    // Checked if all unreleased files are selected (released files don't count)
+    selectAllCheckboxEl.checked = selected.filter(cb => !isReleasedFile(cb)).length === checkboxes.length - released.length;
+  }
+  selectAllCheckboxEl.indeterminate = !areAllChecked;
 }
 
 

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -690,6 +690,97 @@ def test_select_all(live_server, page, context):
     expect(page.locator("input.selectall")).not_to_be_checked()
 
 
+@pytest.mark.parametrize(
+    # `initial_state` and `final_state` here are tuples of booleans representing
+    # the file checkboxes where True=checked, False=unchecked, in the order of
+    # (released_file_1, released_file_2, unreleased_file_1, unreleased_file_2)
+    "initial_state,final_state",
+    [
+        # Not all unreleased checked - select all unreleased
+        ((False, False, False, False), (False, False, True, True)),
+        ((True, False, False, False), (True, False, True, True)),
+        ((True, True, False, False), (True, True, True, True)),
+        ((False, False, True, False), (False, False, True, True)),
+        ((True, False, True, False), (True, False, True, True)),
+        ((True, True, True, False), (True, True, True, True)),
+        # BUG: Not all checked but all unreleased checked - do nothing
+        ((False, False, True, True), (False, False, True, True)),
+        ((True, False, True, True), (True, False, True, True)),
+        # All checked - deselect all
+        ((True, True, True, True), (False, False, False, False)),
+    ],
+)
+def test_select_all_with_released_files_in_directory(
+    mock_old_api, live_server, page, context, initial_state, final_state
+):
+    workspace = factories.create_workspace("my-workspace")
+    factories.write_workspace_file(workspace, "output/released_file_1.csv")
+    factories.write_workspace_file(workspace, "output/released_file_2.csv")
+    user = login_as_user(
+        live_server,
+        context,
+        user_dict={
+            "username": "author",
+            "workspaces": {
+                "my-workspace": {
+                    "project_details": {"name": "Project 1", "ongoing": True},
+                    "archived": False,
+                },
+            },
+        },
+    )
+
+    # Release the files
+    factories.create_request_at_status(
+        "my-workspace",
+        files=[
+            factories.request_file(
+                path="output/released_file_1.csv", contents="Released 1", approved=True
+            ),
+            factories.request_file(
+                path="output/released_file_2.csv", contents="Released 2", approved=True
+            ),
+        ],
+        status=RequestStatus.RELEASED,
+    )
+
+    # Create a current pending request
+    factories.create_release_request("my-workspace", user)
+
+    # Have some unreleased files in the directory
+    factories.write_workspace_file(
+        "my-workspace", path="output/unreleased_file_1.txt", contents="Unreleased 1"
+    )
+    factories.write_workspace_file(
+        "my-workspace", path="output/unreleased_file_2.txt", contents="Unreleased 2"
+    )
+
+    # goto page with files
+    page.goto(live_server.url + workspace.get_url(UrlPath("output")))
+
+    filepaths = [
+        "output/released_file_1.csv",
+        "output/released_file_2.csv",
+        "output/unreleased_file_1.txt",
+        "output/unreleased_file_2.txt",
+    ]
+    # Set and assert initial state
+    for file, checked in zip(filepaths, initial_state):
+        locator = page.locator(f'input[name="selected"][value="{file}"]')
+        if checked:
+            click_and_htmx(page, locator)
+        expect(locator).to_be_checked(checked=checked)
+
+    # Click the select all checkbox
+    page.locator("input.selectall").click()
+
+    # Assert the final state
+    for file, checked in zip(filepaths, final_state):
+        expect(page.locator(f'input[name="selected"][value="{file}"]')).to_be_checked(
+            checked=checked
+        )
+
+
 def test_manifest_file_changes(live_server, page, context):
     workspace = factories.create_workspace("my-workspace")
     file_1 = "outputs/file1.txt"

--- a/tests/functional/test_workspace_pages.py
+++ b/tests/functional/test_workspace_pages.py
@@ -703,10 +703,9 @@ def test_select_all(live_server, page, context):
         ((False, False, True, False), (False, False, True, True)),
         ((True, False, True, False), (True, False, True, True)),
         ((True, True, True, False), (True, True, True, True)),
-        # BUG: Not all checked but all unreleased checked - do nothing
-        ((False, False, True, True), (False, False, True, True)),
-        ((True, False, True, True), (True, False, True, True)),
-        # All checked - deselect all
+        # All unreleased checked - deselect all (incl. released)
+        ((False, False, True, True), (False, False, False, False)),
+        ((True, False, True, True), (False, False, False, False)),
         ((True, True, True, True), (False, False, False, False)),
     ],
 )


### PR DESCRIPTION
When implementing #961, we conducted a poll for the desired behaviour of the select-all checkbox when there are previously released files in a directory. Based on the poll results, we then decided to leave previously released files unselected upon clicking select all.

When the checkbox logic was implemented in ec69771, the deselect all behaviour became counter-intuitive, in that the checkbox does nothing when all unreleased files are selected but not all released files are. This odd behaviour was reported by a user as a bug and subsequently discussed in [this Slack thread](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1779878129565449). This PR re-introduces more user-friendly deselection logic covered by parametrised functional tests.