### PR TITLE
Rename DATABASE_URL env var to AIRLOCK_DATABASE_URL

### DIFF
--- a/airlock/settings.py
+++ b/airlock/settings.py
@@ -164,7 +164,7 @@ WSGI_APPLICATION = "airlock.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
-database_url = os.environ.get("DATABASE_URL")
+database_url = os.environ.get("AIRLOCK_DATABASE_URL")
 if not database_url:
     # This is our current production config
     DATABASES = {


### PR DESCRIPTION
For consistency with othe env var settings, which are prefixed with AIRLOCK_, and to avoid confusion with the ehrql db env variables in the backend.