### PR TITLE
Parallelise tests

### DIFF
--- a/airlock/lib/git.py
+++ b/airlock/lib/git.py
@@ -14,7 +14,8 @@ from urllib.parse import urlparse, urlunparse
 # from jobrunner import config
 # from jobrunner.lib.string_utils import project_name_from_url
 # from jobrunner.lib.subprocess_utils import subprocess_run
-from airlock import settings as config
+from django.conf import settings as config
+
 from airlock.types import UrlPath
 
 

--- a/docker/justfile
+++ b/docker/justfile
@@ -33,7 +33,7 @@ get-chromium:
 test *pytest_args="": _dotenv build get-chromium
     #!/bin/bash
     # Note, we do *not* run coverage in docker, as we want to use xdist, and coverage does not seem to work reliably.
-    docker compose run --rm test pytest {{ pytest_args }}
+    docker compose run --rm test pytest -n auto {{ pytest_args }}
 
 # run server in dev|prod container
 serve env="dev" *args="": _dotenv

--- a/justfile
+++ b/justfile
@@ -230,7 +230,7 @@ manage *ARGS: _checkenv
 
 # run tests
 test *ARGS: _checkenv _checksetup get-chromium
-    uv run python -m pytest "$@"
+    uv run python -m pytest -n auto "$@"
 
 # run tests as they will be in run CI (checking code coverage etc)
 @test-all: _checkenv assets docs-build get-chromium
@@ -238,6 +238,7 @@ test *ARGS: _checkenv _checksetup get-chromium
     set -euo pipefail
 
     uv run python -m pytest \
+      -n auto \
       --cov=airlock \
       --cov=assets \
       --cov=local_db \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,4 +153,5 @@ dev = [
     "mypy<=1.20.2",
     "django-stubs[compatible-mypy]<=6.0.4",
     "types-requests<=2.33.0.20260518",
+    "pytest-xdist<=3.8.0",
 ]

--- a/requirements.uvmirror
+++ b/requirements.uvmirror
@@ -68,6 +68,8 @@ django-stubs-ext==6.0.4
 django-vite==3.1.0
     # via airlock
 djhtml==3.0.11
+execnet==2.1.2
+    # via pytest-xdist
 freezegun==1.5.5
     # via pytest-freezer
 ghp-import==2.1.0
@@ -218,12 +220,14 @@ pytest==9.0.3
     #   pytest-django
     #   pytest-freezer
     #   pytest-playwright
+    #   pytest-xdist
 pytest-base-url==2.1.0
     # via pytest-playwright
 pytest-cov==7.1.0
 pytest-django==4.12.0
 pytest-freezer==0.4.9
 pytest-playwright==0.8.0
+pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
     # via
     #   freezegun

--- a/tests/functional/test_docs_screenshots.py
+++ b/tests/functional/test_docs_screenshots.py
@@ -155,7 +155,7 @@ def test_screenshot_from_creation_to_release(
     csv_summary_container = iframe_content.get_by_test_id("csv-summary")
     csv_summary_toggle = csv_summary_container.get_by_text("View summary stats")
 
-    page.wait_for_timeout(3000)
+    expect(csv_summary_toggle).to_be_visible()
     screenshot_element_with_padding(
         page,
         csv_summary_toggle,
@@ -273,7 +273,6 @@ def test_screenshot_from_creation_to_release(
             live_server.url
             + release_request.get_url(UrlPath("my-group/outputs/file1.csv"))
         )
-        page.wait_for_timeout(100)
         wait_for_table_load(page)
 
         if screenshot:

--- a/tests/functional/test_docs_screenshots.py
+++ b/tests/functional/test_docs_screenshots.py
@@ -15,11 +15,15 @@ from .utils import screenshot_element_with_padding, take_screenshot
 
 
 @pytest.fixture(autouse=True)
-def hide_nav_item_switch_user(monkeypatch):
-    def mockreturn(request):
-        return {"dev_users": False}
-
-    monkeypatch.setattr("airlock.nav.dev_users", mockreturn)
+def hide_nav_item_switch_user(settings):
+    # The switch-user nav item is rendered when settings.DEV_USERS is truthy.
+    # Override via settings (rather than patching airlock.nav.dev_users) because
+    # Django caches the resolved context-processor function; patching the module
+    # attribute after that cache is populated has no effect, and patching it before
+    # populates the cache with the mock, affecting other tests.
+    # This worked (possibly just by luck) when the tests were run serially, but
+    # causes failures when they'rerun in parallel
+    settings.DEV_USERS = {}
 
 
 def get_user_data():

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,7 @@ dev = [
     { name = "pytest-django" },
     { name = "pytest-freezer" },
     { name = "pytest-playwright" },
+    { name = "pytest-xdist" },
     { name = "responses" },
     { name = "ruff" },
     { name = "types-requests" },
@@ -92,6 +93,7 @@ dev = [
     { name = "pytest-django", specifier = "<=4.12.0" },
     { name = "pytest-freezer", specifier = "<=0.4.9" },
     { name = "pytest-playwright", specifier = "<=0.8.0" },
+    { name = "pytest-xdist", specifier = "<=3.8.0" },
     { name = "responses", specifier = "<=0.26.0" },
     { name = "ruff", specifier = "<=0.15.13" },
     { name = "types-requests", specifier = "<=2.33.0.20260518" },
@@ -421,6 +423,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/57/5771714b5961b7ee275a5696cabc3bd8c4a602d7cca103a44016109509fd/djhtml-3.0.11.tar.gz", hash = "sha256:dbaf55684294bda6486a094954e43847a1c0945e521282e008a9aabdac245688", size = 28615, upload-time = "2026-03-26T16:39:17.118Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/c0/8e1f10c58e03fddd1ff4c21a6c22be6cde72dd9cc85f101c2f55e803fd44/djhtml-3.0.11-py3-none-any.whl", hash = "sha256:0013d15d429eb34769aeaf6ea395ad278cf0b8ef35ad19d2cf0c1f214f2843ac", size = 26758, upload-time = "2026-03-26T16:39:15.99Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1165,6 +1176,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/58/ef/172eb8e23c80491fc72f1401c72f9305663873649351306a38b18406b0c9/pytest_playwright-0.8.0.tar.gz", hash = "sha256:7888d4a2443160c82e0c506c437076679f86b36d1910427250d90fbf1843a981", size = 17132, upload-time = "2026-05-18T10:16:15.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl", hash = "sha256:856aae6efd4bc055f2ef229c647768760bcaad5cd3a5983c314ac260a974a933", size = 17143, upload-time = "2026-05-18T10:16:18.226Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This adds pytest-xdist to the dev requirements and makes one bugfix and very minimal test changes to run the tests in parallel.

Locally (with 12 physical CPU cores), `just test-all` runs in ~1m 45s with `-n auto` and in ~6m with `-n 0`. In CI the improvement is less dramatic because we only have 2 CPUs available in the GHA workflow, but it's still running the full CI workflow in about 50% of its usual time (<5m vs ~8m)

Bugfix:
airlock/lib/git.py was importing the airlock settings module directly, instead of doing it the django way `from django.conf import settings`. This meant that the test fixture we have that's supposed to ensure isolated file storage for each test wasn't actually working for GIT_REPO_DIR, which didn't matter for serial tests, but does for parallel ones.

Test fixes:
Changed the way a setting is mocked in the screenshot tests to avoid template cache conflicts (again, only shows up in parallel tests ). Plus a couple of drive-by fixes to remove some redundant waits. 