### PR TITLE
Improve workspace performance

### DIFF
--- a/airlock/file_browser_api.py
+++ b/airlock/file_browser_api.py
@@ -341,14 +341,18 @@ def get_workspace_tree(
         if not workspace.is_valid_tree_path(selected_path):
             raise PathItem.PathNotFound(f"not current output {selected_path}")
 
-        for child in workspace.workspace_child_map[selected_path]:
+        # workspace_child_map is keyed by str, not UrlPath, for performance reasons, using "." for the root;
+        # str(UrlPath()) == "." so if we have the ROOT_PATH here, this lookup still works.
+        for child_str in workspace.workspace_child_map[str(selected_path)]:
+            child = UrlPath(child_str)
             pathlist.append(child)
             if workspace.workspace_child_map[
-                child
+                child_str
             ]:  # has children, therefore is directory
                 leaf_directories.add(child)
     else:
-        pathlist = list(set(workspace.workspace_child_map) - {ROOT_PATH})
+        # Convert at the boundary; "." is the internal root key, excluded here.
+        pathlist = [UrlPath(p) for p in workspace.workspace_child_map if p != "."]
 
     root_node = PathItem(
         container=workspace,

--- a/airlock/models.py
+++ b/airlock/models.py
@@ -204,7 +204,7 @@ class Workspace:
         return dict(json.loads(self.manifest_text))
 
     @cached_property
-    def _tree_map(self) -> tuple[dict[UrlPath, set[UrlPath]], set[UrlPath]]:
+    def _tree_map(self) -> tuple[dict[str, set[str]], set[str]]:
         """Build (workspace_child_map, workspace_files) on first access.
 
         This is the most expensive thing for large workspaces, and is only
@@ -216,11 +216,11 @@ class Workspace:
         )
 
     @property
-    def workspace_child_map(self) -> dict[UrlPath, set[UrlPath]]:
+    def workspace_child_map(self) -> dict[str, set[str]]:
         return self._tree_map[0]
 
     @property
-    def workspace_files(self) -> set[UrlPath]:
+    def workspace_files(self) -> set[str]:
         return self._tree_map[1]
 
     @classmethod
@@ -297,24 +297,27 @@ class Workspace:
         We are only really interested in file paths - those include any parent
         directories we need for the tree for free.
         """
-        root = settings.WORKSPACE_DIR / name
-        paths = set()
+        # Note: these are strings rather than UrlPaths to match get_workspace_child_map
+        # which is much more efficiently built with strings and only converted to
+        # UrlPath in the filebrowser when needed
+        root = str(settings.WORKSPACE_DIR / name) + "/"
+        paths: set[str] = set()
 
         def scan(current: str) -> int:
             children = 0
 
             for entry in os.scandir(current):
                 children += 1
-                path = UrlPath(entry.path).relative_to(root)
-
                 if entry.is_dir():
                     scan(entry.path)
                 else:
-                    paths.add(path)
+                    # Strip the workspace-root prefix for a workspace-relative
+                    # path.
+                    paths.add(entry.path[len(root) :])
 
             return children
 
-        scan(str(root / "metadata"))
+        scan(root + "metadata")
 
         return paths
 
@@ -345,28 +348,35 @@ class Workspace:
     @staticmethod
     def get_workspace_child_map(
         workspace_file_paths: set[str],
-    ) -> tuple[dict[UrlPath, set[UrlPath]], set[UrlPath]]:
-        """
-        Return a map of every valid path in the workspace and its children
-        This includes output paths from the manifest file and any files in the
-        metadata directory (i.e. the manifest itself and log files)
+    ) -> tuple[dict[str, set[str]], set[str]]:
+        """Build a map of every valid path in the workspace and its children.
+
+        Includes output paths from the manifest file and any files in the
+        metadata directory (the manifest itself and log files).
+
+        Returned as plain strings rather than UrlPath: PurePosixPath/UrlPath
+        construction for large workspaces was expensive. The string are now
+        convert where needed (i.e. in file_browser_api). The root is represented
+        as "." to match str(ROOT_PATH).
         """
         # every path is a child of at least the root path
-        workspace_child_map: dict[UrlPath, set[UrlPath]] = {
-            UrlPath(workspace_file_path): set()
-            for workspace_file_path in workspace_file_paths
+        workspace_child_map: dict[str, set[str]] = {
+            p: set() for p in workspace_file_paths
         }
-        workspace_files = set(workspace_child_map)
-        for child in list(workspace_child_map):
-            parent = child.parent
-            while parent != ROOT_PATH:
+        for path in workspace_file_paths:
+            child = path
+            idx = child.rfind("/")
+            while idx >= 0:
+                parent = child[:idx]
                 workspace_child_map.setdefault(parent, set()).add(child)
                 child = parent
-                parent = child.parent
-            # Add the child to the root path
-            assert parent == ROOT_PATH
-            workspace_child_map.setdefault(parent, set()).add(child)
-        return workspace_child_map, workspace_files
+                idx = child.rfind("/")
+
+            # Add the final child to the root path (which now we're at idx < 0
+            # has no parents and sits directly under the root)
+            workspace_child_map.setdefault(".", set()).add(child)
+
+        return workspace_child_map, workspace_file_paths
 
     @property
     def project(self) -> Project:
@@ -515,7 +525,7 @@ class Workspace:
         Is this path a valid workspace file (i.e. an output file from the manifest, or a
         file in the metadata directory)?
         """
-        return UrlPath(relpath) in self.workspace_files
+        return str(UrlPath(relpath)) in self.workspace_files
 
     def is_valid_tree_path(self, relpath: UrlPath | str) -> bool:
         """
@@ -526,7 +536,7 @@ class Workspace:
         Outputs from previous jobs which are not part of the current manifest may still
         exist on disk but are not displayed in the tree.
         """
-        return UrlPath(relpath) in self.workspace_child_map
+        return str(UrlPath(relpath)) in self.workspace_child_map
 
 
 @dataclass(frozen=True)

--- a/airlock/models.py
+++ b/airlock/models.py
@@ -186,7 +186,7 @@ class Workspace:
     """
 
     name: str
-    manifest_text: str
+    manifest: dict[str, Any]
     metadata: dict[str, Any]
     # Valid file paths from the manifest. The workspace_child_map /
     # workspace_files properties below build the tree from this lazily on
@@ -196,12 +196,6 @@ class Workspace:
     released_files: set[str]
     manifest_hash: str
     out_of_date_action_count: int
-
-    @cached_property
-    def manifest(self) -> dict[str, Any]:
-        """Lazily parsed manifest dict. The workspace-index hot path doesn't
-        touch this and so avoids the JSON parse entirely."""
-        return dict(json.loads(self.manifest_text))
 
     @cached_property
     def _tree_map(self) -> tuple[dict[str, set[str]], set[str]]:
@@ -243,9 +237,8 @@ class Workspace:
         # Read once, then both parse and hash from the same bytes
         data = manifest_path.read_bytes()
         manifest_hash = hashlib.sha256(data).hexdigest()
-        manifest_text = data.decode()
         try:
-            manifest = json.loads(manifest_text)
+            manifest = json.loads(data)
         except json.JSONDecodeError as exc:
             raise exceptions.ManifestFileError(
                 f"Could not parse manifest.json file: {manifest_path}:\n{exc}"
@@ -274,7 +267,7 @@ class Workspace:
 
         return cls(
             name,
-            manifest_text=manifest_text,
+            manifest=manifest,
             metadata=metadata,
             valid_paths=sorted(valid_paths),
             current_request=current_request,

--- a/airlock/models.py
+++ b/airlock/models.py
@@ -188,8 +188,10 @@ class Workspace:
     name: str
     manifest_text: str
     metadata: dict[str, Any]
-    workspace_child_map: dict[UrlPath, set[UrlPath]]
-    workspace_files: set[UrlPath]
+    # Valid file paths from the manifest. The workspace_child_map /
+    # workspace_files properties below build the tree from this lazily on
+    # first access (combined with a live scan of the metadata directory).
+    valid_paths: list[str]
     current_request: ReleaseRequest | None
     released_files: set[str]
     manifest_hash: str
@@ -200,6 +202,26 @@ class Workspace:
         """Lazily parsed manifest dict. The workspace-index hot path doesn't
         touch this and so avoids the JSON parse entirely."""
         return dict(json.loads(self.manifest_text))
+
+    @cached_property
+    def _tree_map(self) -> tuple[dict[UrlPath, set[UrlPath]], set[UrlPath]]:
+        """Build (workspace_child_map, workspace_files) on first access.
+
+        This is the most expensive thing for large workspaces, and is only
+        needed for views that render the file browser do, so this lets views
+        that don't need it skip doing the work of building the map.
+        """
+        return self.get_workspace_child_map(
+            set(self.valid_paths) | self.scan_metadata_dir(self.name)
+        )
+
+    @property
+    def workspace_child_map(self) -> dict[UrlPath, set[UrlPath]]:
+        return self._tree_map[0]
+
+    @property
+    def workspace_files(self) -> set[UrlPath]:
+        return self._tree_map[1]
 
     @classmethod
     def from_directory(
@@ -243,24 +265,18 @@ class Workspace:
                 )
             )
 
-        # build a map of all valid workspace UrlPaths and their children from the
-        # manifest file, plus a set of all paths for just the files
         valid_paths, out_of_date_action_count = (
             cls.get_valid_filepaths_from_manifest_outputs(
                 manifest["outputs"],
                 include_out_of_date_action_outputs=include_out_of_date_action_outputs,
             )
         )
-        workspace_child_map, workspace_files = cls.get_workspace_child_map(
-            valid_paths | cls.scan_metadata_dir(name)
-        )
 
         return cls(
             name,
             manifest_text=manifest_text,
             metadata=metadata,
-            workspace_child_map=workspace_child_map,
-            workspace_files=workspace_files,
+            valid_paths=sorted(valid_paths),
             current_request=current_request,
             released_files=released_files or set(),
             manifest_hash=manifest_hash,

--- a/airlock/models.py
+++ b/airlock/models.py
@@ -186,7 +186,7 @@ class Workspace:
     """
 
     name: str
-    manifest: dict[str, Any]
+    manifest_text: str
     metadata: dict[str, Any]
     workspace_child_map: dict[UrlPath, set[UrlPath]]
     workspace_files: set[UrlPath]
@@ -194,6 +194,12 @@ class Workspace:
     released_files: set[str]
     manifest_hash: str
     out_of_date_action_count: int
+
+    @cached_property
+    def manifest(self) -> dict[str, Any]:
+        """Lazily parsed manifest dict. The workspace-index hot path doesn't
+        touch this and so avoids the JSON parse entirely."""
+        return dict(json.loads(self.manifest_text))
 
     @classmethod
     def from_directory(
@@ -212,18 +218,16 @@ class Workspace:
         if not manifest_path.exists():
             raise exceptions.ManifestFileError(f"{manifest_path} does not exist")
 
+        # Read once, then both parse and hash from the same bytes
+        data = manifest_path.read_bytes()
+        manifest_hash = hashlib.sha256(data).hexdigest()
+        manifest_text = data.decode()
         try:
-            manifest = json.loads(manifest_path.read_text())
+            manifest = json.loads(manifest_text)
         except json.JSONDecodeError as exc:
             raise exceptions.ManifestFileError(
                 f"Could not parse manifest.json file: {manifest_path}:\n{exc}"
             )
-
-        # Store the manifest hash so get_url() can include it as a query parameter
-        # and views can use it to check if the manifest has changed
-        manifest_hash = hashlib.file_digest(
-            manifest_path.open("rb"), "sha256"
-        ).hexdigest()
 
         if metadata is None:  # pragma: no cover
             metadata = {}
@@ -253,7 +257,7 @@ class Workspace:
 
         return cls(
             name,
-            manifest=manifest,
+            manifest_text=manifest_text,
             metadata=metadata,
             workspace_child_map=workspace_child_map,
             workspace_files=workspace_files,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -338,13 +338,10 @@ def update_manifest(workspace: Workspace | str, files=None, user="author"):
 
     if isinstance(workspace, Workspace):
         # Refresh the Workspace in place to match what's now on disk. Mirrors
-        # what bll.get_workspace() would produce on the next call: manifest_text
-        # is the on-disk content; the cached `manifest` property is primed with
-        # the same dict; manifest_hash matches the on-disk bytes; valid_paths
-        # is recomputed and the cached tree_map is invalidated so it's rebuilt
-        # lazily on next access.
-        workspace.manifest_text = manifest_disk_text
-        workspace.__dict__["manifest"] = manifest
+        # what bll.get_workspace() would produce on the next call: manifest_hash
+        # matches the on-disk bytes; valid_paths is recomputed and the cached
+        # tree_map is invalidated so it's rebuilt lazily on next access.
+        workspace.manifest = manifest
         workspace.manifest_hash = sha256(manifest_disk_text.encode()).hexdigest()
         valid_paths, out_of_date_count = (
             workspace.get_valid_filepaths_from_manifest_outputs(manifest["outputs"])

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -340,19 +340,18 @@ def update_manifest(workspace: Workspace | str, files=None, user="author"):
         # Refresh the Workspace in place to match what's now on disk. Mirrors
         # what bll.get_workspace() would produce on the next call: manifest_text
         # is the on-disk content; the cached `manifest` property is primed with
-        # the same dict; manifest_hash matches the on-disk bytes.
+        # the same dict; manifest_hash matches the on-disk bytes; valid_paths
+        # is recomputed and the cached tree_map is invalidated so it's rebuilt
+        # lazily on next access.
         workspace.manifest_text = manifest_disk_text
         workspace.__dict__["manifest"] = manifest
         workspace.manifest_hash = sha256(manifest_disk_text.encode()).hexdigest()
         valid_paths, out_of_date_count = (
             workspace.get_valid_filepaths_from_manifest_outputs(manifest["outputs"])
         )
-        workspace_child_map, workspace_files = workspace.get_workspace_child_map(
-            valid_paths | set(workspace.scan_metadata_dir(workspace.name))
-        )
-        workspace.workspace_child_map = workspace_child_map
-        workspace.workspace_files = workspace_files
+        workspace.valid_paths = sorted(valid_paths)
         workspace.out_of_date_action_count = out_of_date_count
+        workspace.__dict__.pop("_tree_map", None)
 
 
 def create_workspace(name: str, user=None) -> Workspace:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 import typing
 from dataclasses import dataclass, field
-from hashlib import file_digest
+from hashlib import file_digest, sha256
 from pathlib import Path
 
 from django.conf import settings
@@ -333,10 +333,17 @@ def update_manifest(workspace: Workspace | str, files=None, user="author"):
         }
 
     manifest_path.parent.mkdir(exist_ok=True, parents=True)
-    manifest_path.write_text(json.dumps(manifest, indent=2))
+    manifest_disk_text = json.dumps(manifest, indent=2)
+    manifest_path.write_text(manifest_disk_text)
 
     if isinstance(workspace, Workspace):
-        workspace.manifest = manifest
+        # Refresh the Workspace in place to match what's now on disk. Mirrors
+        # what bll.get_workspace() would produce on the next call: manifest_text
+        # is the on-disk content; the cached `manifest` property is primed with
+        # the same dict; manifest_hash matches the on-disk bytes.
+        workspace.manifest_text = manifest_disk_text
+        workspace.__dict__["manifest"] = manifest
+        workspace.manifest_hash = sha256(manifest_disk_text.encode()).hexdigest()
         valid_paths, out_of_date_count = (
             workspace.get_valid_filepaths_from_manifest_outputs(manifest["outputs"])
         )

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -248,7 +248,7 @@ def test_workspace_view_changed_manifest_htmx(airlock_client):
     factories.write_workspace_file("workspace", "some_dir/file.txt")
     # Fetch workspace with updated manifest
     workspace = factories.create_workspace("workspace")
-    assert UrlPath("some_dir/file.txt") in workspace.workspace_files
+    assert "some_dir/file.txt" in workspace.workspace_files
 
     # Store current manifest_hash
     current_manifest_hash = workspace.manifest_hash

--- a/tests/integration/views/test_workspace.py
+++ b/tests/integration/views/test_workspace.py
@@ -215,7 +215,11 @@ def test_workspace_view_with_file_htmx(airlock_client):
 def test_workspace_view_invalid_output_path_htmx(airlock_client):
     airlock_client.login(output_checker=True)
     workspace = factories.create_workspace("workspace")
-    # Valid output path
+    # Stash the original manifest hash; the request below sends this stale hash
+    # to simulate the realistic case where the manifest changed between page
+    # load and a subsequent HTMX navigation.
+    original_manifest_hash = workspace.manifest_hash
+    # Valid output path (mutates the manifest, so the hash now differs)
     factories.write_workspace_file(workspace, "some_dir/file.txt")
     # File in subdir exists, but is invalid output path (no manifest entry)
     factories.write_workspace_file(
@@ -223,7 +227,7 @@ def test_workspace_view_invalid_output_path_htmx(airlock_client):
     )
     response = airlock_client.get(
         "/workspaces/view/workspace/some_dir/some_sub_dir/file1.txt",
-        headers={"HX-Request": "true", "manifest-hash": workspace.manifest_hash},
+        headers={"HX-Request": "true", "manifest-hash": original_manifest_hash},
     )
 
     # redirects to nearest valid parent with a message to the user

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1129,9 +1129,7 @@ def test_returned_release_request_filegroups_missing_public_comment_file_updated
 )
 def test_coderepo_from_workspace_no_repo_in_manifest(bll, manifest):
     workspace = factories.create_workspace("workspace")
-    # Prime the cached_property with the test manifest dict so
-    # CodeRepo.from_workspace sees it without re-parsing.
-    workspace.__dict__["manifest"] = manifest
+    workspace.manifest = manifest
     with pytest.raises(CodeRepo.RepoNotFound):
         CodeRepo.from_workspace(workspace, "commit")
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1129,7 +1129,9 @@ def test_returned_release_request_filegroups_missing_public_comment_file_updated
 )
 def test_coderepo_from_workspace_no_repo_in_manifest(bll, manifest):
     workspace = factories.create_workspace("workspace")
-    workspace.manifest = manifest
+    # Prime the cached_property with the test manifest dict so
+    # CodeRepo.from_workspace sees it without re-parsing.
+    workspace.__dict__["manifest"] = manifest
     with pytest.raises(CodeRepo.RepoNotFound):
         CodeRepo.from_workspace(workspace, "commit")
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -74,7 +74,7 @@ def test_workspace_from_directory_no_outputs_in_manifest():
     tracer = trace.get_tracer("test")
     with tracer.start_as_current_span("test-span"):
         workspace = factories.refresh_workspace("workspace")
-    assert workspace.workspace_files == {UrlPath("metadata/manifest.json")}
+    assert workspace.workspace_files == {"metadata/manifest.json"}
     traces = get_trace()
     last_trace_event = traces[-1].events[0]
     assert last_trace_event.name == "exception"
@@ -99,15 +99,15 @@ def test_workspace_from_directory_out_of_date_action_filter():
     included = Workspace.from_directory(
         "workspace", include_out_of_date_action_outputs=True
     )
-    assert UrlPath("stale.txt") in included.workspace_files
-    assert UrlPath("current.txt") in included.workspace_files
+    assert "stale.txt" in included.workspace_files
+    assert "current.txt" in included.workspace_files
     assert included.out_of_date_action_count == 1
 
     excluded = Workspace.from_directory(
         "workspace", include_out_of_date_action_outputs=False
     )
-    assert UrlPath("stale.txt") not in excluded.workspace_files
-    assert UrlPath("current.txt") in excluded.workspace_files
+    assert "stale.txt" not in excluded.workspace_files
+    assert "current.txt" in excluded.workspace_files
     # Count comes from the manifest, not the filtered file set.
     assert excluded.out_of_date_action_count == 1
 


### PR DESCRIPTION
Some workspaces are very large (10s of 1000s of files of more) and are slow to load. We've seen 504 timeouts more frequently lately on workspace views.

Locally, a workspace with ~10K outputs and a 5MB manifest file was taking ~190ms to load (i.e. to do `bll.get_workspace()`)whether or not you actually rendered the file browser. Every file browser navigation does that again, even for htmx requests.

 It turns out to be mostly related to work we did upfront and then often didn't use. We parsed the whole manifest JSON on every load even for views (e.g. workspace index views) that only need the workspace's name and project metadata. We also built the workspace's path parent-child map (used for the tree) every time, even for views that don't need the tree.

This PR makes `Workspace.manifest` lazy: we read and store the raw text only initially. `workspace_child_map` and `workspace_files` become lazy too: built from a stored list of valid paths the first time anything actually needs the tree. 

One of the most expensive things turns out to be constructing the file path maps using UrlPaths. We now do the same thing with plain strings internally, and only convert them to `UrlPath`s in the file-browser api when we need to render them.

Performance measured on a locally generated large workspace with a 5.3MB manifest, 3000 log files in the metadata dir, and ~10,400 outputs across 24 folders, n=10:

  | Path | Main | Branch | Speedup (avg) | Speedup (min) |
  |---|---:|---:|---:|---:|
  | Index path (`bll.get_workspace`, no tree access) | avg 334.6ms, min 279.7ms | avg 45.4ms, min 32.5ms| **7.4×** | **8.6×** |
  | View path (`bll.get_workspace` + tree access) | avg 338.4ms, min 287.9ms | avg 55.2ms, min 46.5ms |**6.1×** | **6.2×** |

(Note: I also tried creating a WorkspaceMetadata db model and storing the manifest and filepaths there as a cache, only invalidating when the manifest_hash changed, but the db read actually made things very marginally worse, and all the improvements are in the cached properties and UrlPath -> str changes. The one thing it did gain is the ability to store project and workspace metadata that we currently only get from the user's api_data, which means it can be shown to output-checkers and readonly users who don't have explicit workspace access)

Probably doesn't entire sort #1204, but should make it less frequent; adding files has to do quite a lot of work reading, copying and writing to the DB anyway, but at least now it will need to spend less time loading the workspace again when it posts.