### PR TITLE
Use persist-credentials:true for uvmirror-update workflow

### DIFF
--- a/.github/workflows/uvmirror-update.yml
+++ b/.github/workflows/uvmirror-update.yml
@@ -50,7 +50,8 @@ jobs:
         with:
           ref: ${{ env.BRANCH_NAME }}
           token: ${{ steps.generate-token.outputs.token }}
-          persist-credentials: false
+          # persist-credentials is required for the commit step
+          persist-credentials: true
 
       - uses: opensafely-core/setup-action@93841f27c28c75bf85b1a0a915e2391a06c6c8a6 # v1
         with:


### PR DESCRIPTION
We've discussed that the security risk is acceptable for this, and persist-credentials is required in order to commit the uvmirror changes.

Note that we only run the update-uvmirror job (where actions/checkout is used with persist-credentials:true) at all if the previous check-uvmirror job (which uses actions/checkout with persist-credentials:false) finds changes to the uvmirror file.