### PR TITLE
Disable submit buttons after click to prevent double submissions

### DIFF
--- a/assets/src/scripts/main.js
+++ b/assets/src/scripts/main.js
@@ -1,3 +1,4 @@
 import "vite/modulepreload-polyfill";
 import "@fontsource-variable/public-sans";
 import "../styles/main.css";
+import "./prevent-double-click.js";

--- a/assets/src/scripts/prevent-double-click.js
+++ b/assets/src/scripts/prevent-double-click.js
@@ -1,0 +1,69 @@
+// Prevent repeat actions from accidental double-clicks by disabling buttons
+// once they've triggered a form submission or HTMX request.
+
+// Keep track of buttons that we've disabled; WeakSet means any that htmx swaps
+// out and which are no longer reachable will get GC'd for us
+const disabledButtons = new WeakSet();
+
+function disableButton(button) {
+  button.disabled = true;
+  button.setAttribute("aria-busy", "true");
+  disabledButtons.add(button);
+}
+
+function enableButton(button) {
+  if (!disabledButtons.has(button)) return;
+  button.disabled = false;
+  button.removeAttribute("aria-busy");
+  disabledButtons.delete(button);
+}
+
+// Note: we don't use any data-hx-* attributes in Airlock; if we did, we might
+// want to add them to this selector.
+const HTMX_FORM_SELECTOR = "[hx-post], [hx-get], [hx-put], [hx-delete], [hx-patch]";
+
+// Disable submit buttons on standard forms
+// We're using a setTimeout(0) so that we do the disabling in the next action
+// after the browser has finished processing the submit event.
+// This means that (a) the browser has already built the form data (including
+// the submit buttons's name/value attributes, and (b) we wait for any synchronous
+// preventDefault() from another handler
+document.body.addEventListener("submit", (event) => {
+  const form = event.target;
+  const isHtmx = form.matches(HTMX_FORM_SELECTOR);
+  setTimeout(() => {
+    // HTMX calls preventDefault to stop normal navigation, so for HTMX forms we
+    // still want to disable. For non-HTMX forms, defaultPrevented means another
+    // handler cancelled the submission and we should leave the button alone.
+    if (event.defaultPrevented && !isHtmx) return;
+    // event.submitter could be None if submitted programmatically, in which case, do nothing
+    if (event.submitter) disableButton(event.submitter);
+  }, 0);
+});
+
+// For buttons that trigger HTMX requests directly (no surrounding form), disable
+// on request start and re-enable when the request completes so the button is
+// usable again after in-place updates.
+document.body.addEventListener("htmx:beforeRequest", (event) => {
+  const elt = event.detail.elt;
+  // Skip buttons that belong to a form — those are already handled by the
+  // submit listener above, which fires before htmx:beforeRequest.
+  if (elt instanceof HTMLButtonElement && !elt.form) {
+    disableButton(elt);
+  }
+});
+
+document.body.addEventListener("htmx:afterRequest", (event) => {
+  const elt = event.detail.elt;
+  if (elt instanceof HTMLButtonElement) {
+    // Guard against the button having been removed from the DOM by an HTMX
+    // swap between the request starting and htmx:afterRequest firing.
+    if (elt.isConnected) enableButton(elt);
+    return;
+  }
+  if (elt instanceof HTMLFormElement) {
+    elt.querySelectorAll("button[type='submit']").forEach((button) => {
+      if (button.isConnected) enableButton(button);
+    });
+  }
+});

--- a/tests/functional/test_double_click_prevention.py
+++ b/tests/functional/test_double_click_prevention.py
@@ -1,0 +1,122 @@
+from playwright.sync_api import expect
+
+from airlock.enums import RequestStatus
+from tests import factories
+from tests.functional.conftest import login_as_user
+
+from .conftest import click_and_htmx
+
+
+def _make_pending_request(live_server, context):
+    author = login_as_user(
+        live_server,
+        context,
+        user_dict=factories.create_api_user(username="author"),
+    )
+    release_request = factories.create_request_at_status(
+        "workspace",
+        author=author,
+        status=RequestStatus.PENDING,
+        files=[
+            factories.request_file(group="group", path="file1.txt"),
+            factories.request_file(group="group", path="file2.txt"),
+        ],
+    )
+    return author, release_request
+
+
+def test_traditional_form_button_disabled_after_click(live_server, context, page):
+    """A submit button in a traditional POST form is disabled once clicked, so
+    a second click while the response is in-flight can't trigger the action again."""
+    _, release_request = _make_pending_request(live_server, context)
+
+    page.goto(live_server.url + release_request.get_url("group/file1.txt"))
+
+    button = page.locator("#withdraw-file-button")
+    expect(button).to_be_visible()
+    expect(button).to_be_enabled()
+
+    # Respond with 204 No Content so the browser stays on the current page
+    # rather than navigating to a response body.
+    page.route("**/requests/withdraw/**", lambda route: route.fulfill(status=204))
+
+    click_and_htmx(page, page.locator("#withdraw-file-button"))
+
+    expect(button).to_be_disabled()
+    expect(button).to_have_attribute("aria-busy", "true")
+
+
+def test_traditional_form_double_click_only_submits_once(live_server, context, page):
+    """Even when the user manages to click twice rapidly, only one POST is sent."""
+    _, release_request = _make_pending_request(live_server, context)
+
+    page.goto(live_server.url + release_request.get_url("group/file1.txt"))
+
+    button = page.locator("#withdraw-file-button")
+    expect(button).to_be_visible()
+
+    # record the withdraw requests seen for /requests/withdraw/** route
+    withdraw_requests = []
+
+    def handler(route):
+        withdraw_requests.append(route.request.url)
+        route.fulfill(status=204)
+
+    page.route("**/requests/withdraw/**", handler)
+
+    # Two consecutive clicks via JS. The disable is scheduled via setTimeout(0)
+    # so we sleep briefly between them to give the macrotask a chance to run.
+    page.evaluate(
+        """async () => {
+            const btn = document.querySelector('#withdraw-file-button');
+            btn.click();
+            await new Promise((r) => setTimeout(r, 50));
+            btn.click();
+        }"""
+    )
+
+    # Wait until the button is disabled (i.e. the first submission fired and the
+    # script ran), then assert only one request was recorded.
+    expect(button).to_be_disabled()
+    assert len(withdraw_requests) == 1
+
+
+def test_htmx_form_button_disabled_during_request(live_server, context, page):
+    """A submit button in an HTMX form is disabled while the request is in-flight."""
+    _, release_request = _make_pending_request(live_server, context)
+
+    page.goto(live_server.url + release_request.get_url("group/file1.txt"))
+
+    button = page.locator("#update-file-modal-button")
+    expect(button).to_be_visible()
+    expect(button).to_be_enabled()
+
+    # Hang the HTMX POST so the in-flight state is observable.
+    page.route("**/requests/multiselect/**", lambda route: None)
+
+    button.click(no_wait_after=True)
+
+    expect(button).to_be_disabled()
+    expect(button).to_have_attribute("aria-busy", "true")
+
+
+def test_htmx_form_button_re_enabled_after_request(live_server, context, page):
+    """A submit button in an HTMX form is re-enabled once the request completes."""
+    _, release_request = _make_pending_request(live_server, context)
+
+    page.goto(live_server.url + release_request.get_url("group/file1.txt"))
+
+    button = page.locator("#update-file-modal-button")
+    expect(button).to_be_visible()
+    expect(button).to_be_enabled()
+
+    # Return a minimal HTMX response so the request completes immediately.
+    page.route(
+        "**/requests/multiselect/**",
+        lambda route: route.fulfill(status=200, body="<div></div>"),
+    )
+
+    button.click(no_wait_after=True)
+
+    expect(button).to_be_enabled()
+    expect(button).not_to_have_attribute("aria-busy", "true")


### PR DESCRIPTION
Adds a script that disables buttons once they have triggered an action, so an accidental second click can't repeat it. (Repeated actions from double-clicks didn't actually do anything again, because the permissions/policies check would prevent it, but they did end up with confusing errors and alerts).

The button is re-enabled after an HTMX request completes so it can be re-clicked after things have updated.

Closes #1219 