### PR TITLE
Show a loading spinner while tree scroll position is being restored

### DIFF
--- a/airlock/static/assets/file_browser/index.js
+++ b/airlock/static/assets/file_browser/index.js
@@ -1,10 +1,11 @@
 // If we have a previous scroll position to restore, disable the browser's
-// own scroll restoration to avoid conflicts with restoreTreeScrollPosition
-// and hide the tree until our restore loop finishes.
+// own scroll restoration to avoid conflicts with restoreTreeScrollPosition,
+// hide the tree until our restore loop finishes, and show a spinner in its place.
 if (sessionStorage.getItem("treeScrollTop")) {
   if ('scrollRestoration' in history) {
     history.scrollRestoration = 'manual';
-    document.head.insertAdjacentHTML("beforeend", "<style id='scroll-restore-style'>#tree-container{visibility:hidden}</style>");
+    document.head.insertAdjacentHTML("beforeend", "<style id='scroll-restore-style'>#tree{visibility:hidden}</style>");
+    document.getElementById("tree-scroll-spinner")?.classList.remove("hidden");
   }
 }
 
@@ -230,8 +231,12 @@ function restoreTreeScrollPosition(treeContainer, target, attempts = 30) {
   treeContainer.scrollTop = target;
 
   if (treeContainer.scrollTop === target || attempts <= 0) {
-    // Show the tree
+    // Hide the spinner and show the tree.
+    document.getElementById("tree-scroll-spinner")?.classList.add("hidden");
     document.getElementById("scroll-restore-style")?.remove();
+    // Removing the spinner causes the browser to adjust scrollTop, so
+    // reset it to target again
+    treeContainer.scrollTop = target;
     return;
   }
 

--- a/airlock/templates/file_browser/index.html
+++ b/airlock/templates/file_browser/index.html
@@ -17,6 +17,9 @@
   <span class="loading-indicator"></span>
   <div id="file-browser-panel" class="grid grid-cols-4 gap-x-4 flex-1">
     <div class="border-r border-t bg-white overflow-auto min-w-full hover:z-10 hover:w-fit hover:shadow-2xl" id="tree-container">
+      <span id="tree-scroll-spinner" class="hidden sticky top-4 flex justify-center py-4">
+        <img height="16" width="16" class="icon animate-spin" src="{% static 'icons/progress_activity.svg' %}" alt="">
+      </span>
       {% block tree_toolbar %}{% endblock %}
       <ul
         class="tree root tree__root"


### PR DESCRIPTION
We hide the tree until the scroll position can be restored, with no feedback to the user. Now we show a spinner while it's restoring, similar to the spinner pattern used in login.html.