### PR TITLE
Remove `RELEASES_SLACK_CHANNEL`

### DIFF
--- a/job-server/.env.jobserver.template
+++ b/job-server/.env.jobserver.template
@@ -10,7 +10,6 @@ SOCIAL_AUTH_GITHUB_SECRET=test
 # attempt to create issues or post to slack. These variables are only required
 # for testing real slack notifications and GitHub issues with DEBUG off.
 # Note these all have prod defaults in settings.py
-RELEASES_SLACK_CHANNEL="tmp-airlock-testing"
 REGISTRATIONS_SLACK_CHANNEL="tmp-airlock-testing"
 APPLICATIONS_SLACK_CHANNEL="tmp-airlock-testing"
 COPILOT_SUPPORT_SLACK_CHANNEL="tmp-airlock-testing"


### PR DESCRIPTION
This is being removed in:

https://github.com/opensafely-core/job-server/pull/5988